### PR TITLE
fix: subtract the retained versions before a prune retires a doomed root

### DIFF
--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -36,7 +36,8 @@ pub use read::{
 };
 pub use retention::{
     ContentVersion, ExpandError, Expansion, PrunePlan, QuotaExceeded, RetentionPolicy,
-    expand_retire_targets, plan_prune, pre_flight_quota_check,
+    RetireTarget, RootPlacement, expand_retire_targets, plan_prune, pre_flight_quota_check,
+    version_cids,
 };
 pub use write::{ContentWriter, FinishedContent};
 

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -7,6 +7,7 @@
 //! pure: it selects retire targets, and the net plane runs the retire.
 
 use core::num::NonZeroU64;
+use std::collections::BTreeSet;
 
 use cipherbox_core::content::{decode_content_cid_str, encode_content_cid_str, verify_cid};
 use cipherbox_core::error::CodecError;
@@ -163,13 +164,98 @@ pub enum ExpandError {
     ForeignManifest,
 }
 
+/// Where a version's root rides in the CID set that names it.
+///
+/// The register and retire paths need opposite orders because the expansion key
+/// differs: registration recovers its leaves from staging, so the root carries
+/// nothing; retirement recovers them from the fetched root block, so the root
+/// must outlive everything it expands to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootPlacement {
+    /// The root first, then every leaf in file order — registration.
+    First,
+    /// Every leaf in file order, then the root — retirement.
+    Last,
+}
+
+/// Every CID one version pins, spelled as the registry names them.
+///
+/// The one derivation both the register and the retire path go through: every
+/// block is its own accountable pin row (blueprint/api.md "Pin/name registry"),
+/// so a retirement naming fewer CIDs than the registration claimed spends
+/// account quota forever, and one naming more unpins live blocks.
+#[must_use]
+pub fn version_cids<'a>(
+    root_cid: &[u8],
+    leaf_cids: impl IntoIterator<Item = &'a [u8]>,
+    root: RootPlacement,
+) -> Vec<String> {
+    let root_cid = encode_content_cid_str(root_cid);
+    let leaves = leaf_cids.into_iter().map(encode_content_cid_str);
+    match root {
+        RootPlacement::First => core::iter::once(root_cid).chain(leaves).collect(),
+        RootPlacement::Last => leaves.chain(core::iter::once(root_cid)).collect(),
+    }
+}
+
+/// One block a retire must name, and what its own pin row charges.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetireTarget {
+    /// The block's content CID (multibase string).
+    pub cid: String,
+    /// The pinned bytes this block's row accounts for.
+    pub pinned_bytes: u64,
+}
+
 /// One doomed version's whole retire set and what retiring it frees.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Expansion {
     /// Every leaf in file order, then the root **last**.
-    pub targets: Vec<String>,
-    /// The pinned bytes the manifest accounts for.
+    pub targets: Vec<RetireTarget>,
+    /// The pinned bytes the targets account for.
     pub pinned_bytes: u64,
+}
+
+impl Expansion {
+    /// The targets as the registry names them, in retire order.
+    #[must_use]
+    pub fn cids(&self) -> Vec<String> {
+        self.targets
+            .iter()
+            .map(|target| target.cid.clone())
+            .collect()
+    }
+
+    /// Drop every target a retained version also names, and re-total what the
+    /// remainder frees.
+    ///
+    /// A pin row is keyed `(account, cid)` and physical unpin fires at global
+    /// refcount zero (blueprint/api.md "Pin/name registry"), so retiring a CID a
+    /// retained version also names unpins live content. Which versions are
+    /// retained is a whole-plan property the prune op decides, never one a
+    /// single root's expansion can see. A subtracted target frees nothing, so
+    /// the total is re-summed rather than kept in the manifest's closed form.
+    #[must_use]
+    pub fn minus_retained(&self, retained: &BTreeSet<String>) -> Self {
+        let targets: Vec<RetireTarget> = self
+            .targets
+            .iter()
+            .filter(|target| !retained.contains(&target.cid))
+            .cloned()
+            .collect();
+        Self {
+            pinned_bytes: sum_pinned(&targets),
+            targets,
+        }
+    }
+}
+
+/// What a target set accounts for, saturating so a hand-framed manifest can
+/// never wrap the figure to a small one.
+fn sum_pinned(targets: &[RetireTarget]) -> u64 {
+    targets.iter().fold(0u64, |total, target| {
+        total.saturating_add(target.pinned_bytes)
+    })
 }
 
 impl From<DagError> for ExpandError {
@@ -216,23 +302,38 @@ pub fn expand_retire_targets(
     }
     verify_cid(&expected, root_block).map_err(ExpandError::TrustViolation)?;
     let manifest = decode_root(root_block)?;
-
-    let accounted = manifest
-        .size
-        .saturating_add((manifest.leaf_cids.len() as u64).saturating_mul(SEALED_LEAF_OVERHEAD))
-        .saturating_add(root_block.len() as u64);
-    if manifest.chunk_size != profile.chunk_size() as u64 || accounted != pinned_bytes {
+    if manifest.chunk_size != profile.chunk_size() as u64 {
         return Err(ExpandError::ForeignManifest);
     }
 
-    let mut targets = Vec::with_capacity(manifest.leaf_cids.len() + 1);
-    targets.extend(
+    // Every leaf but the tail carries a whole chunk; the tail carries what is
+    // left. Per-target rather than the manifest's closed form, because a
+    // subtracted target must be able to drop its own bytes out of the total.
+    let leaf_bytes = |index: usize| {
         manifest
-            .leaf_cids
-            .iter()
-            .map(|cid| encode_content_cid_str(cid)),
-    );
-    targets.push(content_cid.to_owned());
+            .size
+            .saturating_sub((index as u64).saturating_mul(manifest.chunk_size))
+            .min(manifest.chunk_size)
+            .saturating_add(SEALED_LEAF_OVERHEAD)
+    };
+    let targets: Vec<RetireTarget> = version_cids(
+        &expected,
+        manifest.leaf_cids.iter().map(|cid| &cid[..]),
+        RootPlacement::Last,
+    )
+    .into_iter()
+    .zip(
+        (0..manifest.leaf_cids.len())
+            .map(leaf_bytes)
+            .chain([root_block.len() as u64]),
+    )
+    .map(|(cid, pinned_bytes)| RetireTarget { cid, pinned_bytes })
+    .collect();
+
+    let accounted = sum_pinned(&targets);
+    if accounted != pinned_bytes {
+        return Err(ExpandError::ForeignManifest);
+    }
     Ok(Expansion {
         targets,
         pinned_bytes: accounted,
@@ -378,18 +479,106 @@ mod tests {
             "a multi-chunk version is the normal case"
         );
 
-        let expected: Vec<String> = leaf_cids
-            .into_iter()
-            .chain([doomed.content_cid.clone()])
-            .collect();
+        let expansion = expand(&doomed, &root_block).expect("expands");
         assert_eq!(
-            expand(&doomed, &root_block).expect("expands"),
-            Expansion {
-                targets: expected,
-                pinned_bytes: doomed.pinned_bytes,
-            },
+            expansion.cids(),
+            leaf_cids
+                .into_iter()
+                .chain([doomed.content_cid.clone()])
+                .collect::<Vec<_>>(),
             "every leaf in file order, then the expansion key last"
         );
+        assert_eq!(expansion.pinned_bytes, doomed.pinned_bytes);
+    }
+
+    /// The register and the retire path must name the same blocks: naming fewer
+    /// on retire spends account quota forever, naming more unpins live blocks.
+    /// Only their order differs, and it differs because the caller says so.
+    #[test]
+    fn the_retire_expansion_names_exactly_what_registration_pinned() {
+        let plaintext: Vec<u8> = (0..100u8).collect();
+        let (doomed, root_block, _) = doomed_version(&plaintext);
+        let root = decode_content_cid_str(&doomed.content_cid).expect("a canonical root address");
+        let leaves = decode_root(&root_block)
+            .expect("a root manifest")
+            .leaf_cid_vecs();
+
+        let registered = version_cids(
+            &root,
+            leaves.iter().map(Vec::as_slice),
+            RootPlacement::First,
+        );
+        let retired = expand(&doomed, &root_block).expect("expands").cids();
+
+        assert_ne!(registered, retired, "the two orders are not the same order");
+        assert_eq!(
+            BTreeSet::from_iter(registered.iter().cloned()),
+            BTreeSet::from_iter(retired.iter().cloned()),
+            "a retire batch names exactly what a register batch claimed"
+        );
+        assert_eq!(
+            registered.len(),
+            retired.len(),
+            "and names each of them once"
+        );
+    }
+
+    /// A pin row is keyed `(account, cid)`, so a doomed root naming a CID a
+    /// retained version also names would unpin live content.
+    #[test]
+    fn a_target_a_retained_version_also_names_is_never_retired() {
+        let plaintext: Vec<u8> = (0..100u8).collect();
+        let (doomed, root_block, leaf_cids) = doomed_version(&plaintext);
+        let expansion = expand(&doomed, &root_block).expect("expands");
+
+        let retained = BTreeSet::from([leaf_cids[0].clone()]);
+        let reduced = expansion.minus_retained(&retained);
+
+        assert!(
+            !reduced.cids().contains(&leaf_cids[0]),
+            "the retained leaf is not a retire target"
+        );
+        assert_eq!(
+            reduced.cids(),
+            leaf_cids[1..]
+                .iter()
+                .cloned()
+                .chain([doomed.content_cid.clone()])
+                .collect::<Vec<_>>(),
+            "everything else keeps its retire order"
+        );
+    }
+
+    /// The figure a prune quotes must be what the retire frees, so a subtracted
+    /// target takes its own bytes out of the total rather than leaving the
+    /// manifest's closed form standing.
+    #[test]
+    fn the_reclaim_figure_counts_only_the_targets_a_retire_still_names() {
+        for size in [0usize, 1, 15, 16, 17, 40, 100] {
+            let (doomed, root_block, leaf_cids) = doomed_version(&vec![3u8; size]);
+            let expansion = expand(&doomed, &root_block).expect("expands");
+
+            let all_leaves = BTreeSet::from_iter(leaf_cids.iter().cloned());
+            let root_only = expansion.minus_retained(&all_leaves);
+            assert_eq!(
+                root_only.pinned_bytes,
+                root_block.len() as u64,
+                "size {size}: an all-aliased expansion frees its root block alone"
+            );
+
+            let nothing = expansion.minus_retained(&BTreeSet::new());
+            assert_eq!(
+                nothing, expansion,
+                "size {size}: subtracting nothing changes nothing"
+            );
+
+            let whole = BTreeSet::from_iter(expansion.cids());
+            assert_eq!(
+                expansion.minus_retained(&whole).pinned_bytes,
+                0,
+                "size {size}: an expansion that frees nothing quotes nothing"
+            );
+        }
     }
 
     /// The expansion under the framing the fixture used.
@@ -430,7 +619,7 @@ mod tests {
             doomed.pinned_bytes,
         )
         .expect("expands")
-        .targets;
+        .cids();
         assert_eq!(targets.len(), leaves + 1);
         assert!(
             targets.len() > REGISTRY_BATCH_MAX,

--- a/crates/engine/src/content/retention.rs
+++ b/crates/engine/src/content/retention.rs
@@ -164,12 +164,9 @@ pub enum ExpandError {
     ForeignManifest,
 }
 
-/// Where a version's root rides in the CID set that names it.
-///
-/// The register and retire paths need opposite orders because the expansion key
-/// differs: registration recovers its leaves from staging, so the root carries
-/// nothing; retirement recovers them from the fetched root block, so the root
-/// must outlive everything it expands to.
+/// Where a version's root rides in the CID set that names it. The caller says
+/// which, because only the caller knows whether the root is its expansion key
+/// (see [`expand_retire_targets`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootPlacement {
     /// The root first, then every leaf in file order — registration.
@@ -184,6 +181,9 @@ pub enum RootPlacement {
 /// block is its own accountable pin row (blueprint/api.md "Pin/name registry"),
 /// so a retirement naming fewer CIDs than the registration claimed spends
 /// account quota forever, and one naming more unpins live blocks.
+///
+/// # Panics
+/// If any CID is not the frozen content-plane CIDv1 framing.
 #[must_use]
 pub fn version_cids<'a>(
     root_cid: &[u8],
@@ -226,27 +226,40 @@ impl Expansion {
             .collect()
     }
 
-    /// Drop every target a retained version also names, and re-total what the
-    /// remainder frees.
+    /// Split at the retained boundary: what a retire may still name, and the
+    /// targets a retained version holds hostage (deduplicated — a manifest may
+    /// repeat a link).
     ///
     /// A pin row is keyed `(account, cid)` and physical unpin fires at global
     /// refcount zero (blueprint/api.md "Pin/name registry"), so retiring a CID a
     /// retained version also names unpins live content. Which versions are
     /// retained is a whole-plan property the prune op decides, never one a
-    /// single root's expansion can see. A subtracted target frees nothing, so
-    /// the total is re-summed rather than kept in the manifest's closed form.
+    /// single root's expansion can see. A held target frees nothing, so the
+    /// total is re-summed rather than kept in the manifest's closed form.
     #[must_use]
-    pub fn minus_retained(&self, retained: &BTreeSet<String>) -> Self {
-        let targets: Vec<RetireTarget> = self
+    pub fn split_retained(&self, retained: &BTreeSet<String>) -> (Self, Vec<String>) {
+        let (held, retirable): (Vec<RetireTarget>, Vec<RetireTarget>) = self
             .targets
             .iter()
-            .filter(|target| !retained.contains(&target.cid))
             .cloned()
-            .collect();
-        Self {
-            pinned_bytes: sum_pinned(&targets),
-            targets,
-        }
+            .partition(|target| retained.contains(&target.cid));
+        (
+            Self {
+                pinned_bytes: sum_pinned(&retirable),
+                targets: retirable,
+            },
+            held.into_iter()
+                .map(|target| target.cid)
+                .collect::<BTreeSet<String>>()
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    /// What a retire may still name once every retained target is out of it.
+    #[must_use]
+    pub fn minus_retained(&self, retained: &BTreeSet<String>) -> Self {
+        self.split_retained(retained).0
     }
 }
 
@@ -277,11 +290,13 @@ impl From<DagError> for ExpandError {
 /// where a root-first order would leave its leaves unnameable and charged.
 ///
 /// The manifest is held to `profile`'s framing and to `pinned_bytes`, the total
-/// the plan quoted. Anyone holding a scope's write seed can author a version
-/// record, so without both bounds a hand-framed root — correctly addressed, and
-/// internally consistent under a `chunkSize` of its own choosing — could name up
-/// to [`MAX_RESOLVED_RECORD_BYTES`]-worth of CIDs the owner's own token would
-/// then delete.
+/// the plan quoted, which bounds the link count to what that framing implies —
+/// without them a root framed under a `chunkSize` of its own choosing could name
+/// up to [`MAX_RESOLVED_RECORD_BYTES`]-worth of CIDs. Neither bound establishes
+/// *provenance*: anyone holding the scope's write seed authors both the root and
+/// the record `size` the plan quotes from, so the links can still be CIDs of
+/// that author's choosing. Keeping those off the retire is
+/// [`Expansion::split_retained`]'s job, at the plan that knows what it keeps.
 pub fn expand_retire_targets(
     content_cid: &str,
     root_block: &[u8],

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -50,10 +50,10 @@ pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
     ContentWriter, DAG_ROOT_CODEC, DagError, ExpandError, Expansion, FinishedContent, Gateway,
     GatewayConfig, GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded,
-    ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RetireTarget, RootManifest, RootPlacement,
-    SealError, SealedChunk, SealedContent, assemble, decode_root, expand_retire_targets,
-    frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block,
-    seal_one_chunk, test_connection, validate_byo_config, version_cids,
+    ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RetireTarget, RootManifest, SealError,
+    SealedChunk, SealedContent, assemble, decode_root, expand_retire_targets, frame_and_seal,
+    leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block, seal_one_chunk,
+    test_connection, validate_byo_config,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -50,10 +50,10 @@ pub use content::{
     ByoIpfsConfig, ByoKind, ContentDag, ContentKey, ContentPlane, ContentProfile, ContentVersion,
     ContentWriter, DAG_ROOT_CODEC, DagError, ExpandError, Expansion, FinishedContent, Gateway,
     GatewayConfig, GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded,
-    ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RootManifest, SealError, SealedChunk,
-    SealedContent, assemble, decode_root, expand_retire_targets, frame_and_seal,
-    leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block, seal_one_chunk,
-    test_connection, validate_byo_config,
+    ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RetireTarget, RootManifest, RootPlacement,
+    SealError, SealedChunk, SealedContent, assemble, decode_root, expand_retire_targets,
+    frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block,
+    seal_one_chunk, test_connection, validate_byo_config, version_cids,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -10,9 +10,10 @@
 //! ordered it ([`drain_owed_retires`]).
 
 use core::cell::RefCell;
+use std::collections::BTreeSet;
 
 use cipherbox_core::content::{
-    decode_content_cid_str, encode_content_cid_str, is_wellformed_content_cid,
+    CONTENT_CID_LEN, decode_content_cid_str, encode_content_cid_str, is_wellformed_content_cid,
 };
 
 use super::REGISTRY_BATCH_MAX;
@@ -130,8 +131,10 @@ where
 /// [`orphan_staging_keys`]: crate::sync::orphan_staging_keys
 pub const RETIRE_LEDGER_PREFIX: &[u8] = b"cbx/rl/";
 
-/// The owed bytes as one ledger entry stores them.
-const OWED_BYTES_LEN: usize = 8;
+/// The fixed head of one stored entry: the owed figure then the manifest total,
+/// both big-endian `u64`. Whatever follows is the retained-target list, one
+/// binary content CID each.
+const ENTRY_HEAD_LEN: usize = 16;
 
 /// The [`RetireLedger`] every host gets for free, over the durable staging store
 /// it already implements.
@@ -172,13 +175,12 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
     async fn owe(&self, owner_tag: &[u8], entries: &[OwedRetire]) -> SeamResult<()> {
         for entry in entries {
             let key = Self::key(owner_tag, &entry.target)?;
+            let stored = encode_entry(entry)?;
             // A readable entry keeps its stored figure, so a replayed prune
             // cannot double what the vault reports as pending; an unreadable one
             // is repaired rather than left to sit undrainable forever.
-            if owed_bytes(self.0.staged_bytes(&key).await?).is_none() {
-                self.0
-                    .put_staged_bytes(&key, &entry.owed_bytes.to_be_bytes())
-                    .await?;
+            if decode_entry(&entry.target, self.0.staged_bytes(&key).await?).is_none() {
+                self.0.put_staged_bytes(&key, &stored).await?;
             }
         }
         Ok(())
@@ -194,13 +196,11 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
             else {
                 continue;
             };
-            let Some(owed_bytes) = owed_bytes(self.0.staged_bytes(&key).await?) else {
+            let target = encode_content_cid_str(cid);
+            let Some(entry) = decode_entry(&target, self.0.staged_bytes(&key).await?) else {
                 continue;
             };
-            entries.push(OwedRetire {
-                target: encode_content_cid_str(cid),
-                owed_bytes,
-            });
+            entries.push(entry);
         }
         // Store enumeration order is host-dependent, and a pass can stop early;
         // sorted, it at least stops at the same place on every host.
@@ -218,12 +218,40 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
     }
 }
 
-/// One entry's stored figure, or `None` for bytes this build did not write.
-fn owed_bytes(stored: Option<Vec<u8>>) -> Option<u64> {
+/// One entry as the staging store holds it.
+fn encode_entry(entry: &OwedRetire) -> SeamResult<Vec<u8>> {
+    let mut stored = Vec::with_capacity(ENTRY_HEAD_LEN + entry.retained.len() * CONTENT_CID_LEN);
+    stored.extend_from_slice(&entry.owed_bytes.to_be_bytes());
+    stored.extend_from_slice(&entry.manifest_bytes.to_be_bytes());
+    for cid in &entry.retained {
+        stored.extend_from_slice(
+            &decode_content_cid_str(cid).map_err(|_| {
+                SeamError::new("retire-ledger retained target is not a content CID")
+            })?,
+        );
+    }
+    Ok(stored)
+}
+
+/// One entry read back, or `None` for bytes this build did not write. A partial
+/// or over-long trailer reads as unwritten rather than as a shorter retained
+/// list, which would retire a target the prune excluded.
+fn decode_entry(target: &str, stored: Option<Vec<u8>>) -> Option<OwedRetire> {
     let stored = stored?;
-    <[u8; OWED_BYTES_LEN]>::try_from(&stored[..])
-        .ok()
-        .map(u64::from_be_bytes)
+    if stored.len() < ENTRY_HEAD_LEN || (stored.len() - ENTRY_HEAD_LEN) % CONTENT_CID_LEN != 0 {
+        return None;
+    }
+    let (head, rest) = stored.split_at(ENTRY_HEAD_LEN);
+    let retained = rest
+        .chunks_exact(CONTENT_CID_LEN)
+        .map(|cid| is_wellformed_content_cid(cid).then(|| encode_content_cid_str(cid)))
+        .collect::<Option<Vec<String>>>()?;
+    Some(OwedRetire {
+        target: target.to_owned(),
+        owed_bytes: u64::from_be_bytes(<[u8; 8]>::try_from(&head[..8]).ok()?),
+        manifest_bytes: u64::from_be_bytes(<[u8; 8]>::try_from(&head[8..]).ok()?),
+        retained,
+    })
 }
 
 /// Work the ledger once and report the pinned bytes still owed afterwards — the
@@ -290,7 +318,8 @@ enum RetireOutcome {
     RegistryDown,
 }
 
-/// Retire one owed version's whole block set.
+/// Retire one owed version's block set, less every target the prune's retained
+/// versions also name ([`OwedRetire::retained`]).
 ///
 /// The entry settles **between** the leaf batches and the root's own final
 /// batch. The root is the expansion key, so an entry still owed once its root is
@@ -320,13 +349,23 @@ where
         return RetireOutcome::Deferred;
     };
     let Ok(expansion) =
-        expand_retire_targets(&entry.target, &root_block, profile, entry.owed_bytes)
+        expand_retire_targets(&entry.target, &root_block, profile, entry.manifest_bytes)
     else {
         return RetireOutcome::Deferred;
     };
-    let Some((root, leaves)) = expansion.targets.split_last() else {
+    let retirable = expansion.minus_retained(&BTreeSet::from_iter(entry.retained.iter().cloned()));
+    // The stored figure is what the prune promised this entry frees; a store
+    // whose retained list no longer produces it is not one to retire from.
+    if retirable.pinned_bytes != entry.owed_bytes {
+        return RetireOutcome::Deferred;
+    }
+    let targets = retirable.cids();
+    let Some((root, leaves)) = targets.split_last() else {
         return RetireOutcome::Deferred;
     };
+    if root != &entry.target {
+        return RetireOutcome::Deferred;
+    }
     if retire(api, leaves).await.is_err() {
         return RetireOutcome::RegistryDown;
     }
@@ -442,10 +481,7 @@ mod tests {
     fn owed_version(plaintext: &[u8]) -> (OwedRetire, Vec<u8>, Vec<String>) {
         let (version, root_block, leaf_cids) = doomed_version(plaintext);
         (
-            OwedRetire {
-                target: version.content_cid,
-                owed_bytes: version.pinned_bytes,
-            },
+            OwedRetire::whole(version.content_cid, version.pinned_bytes),
             root_block,
             leaf_cids,
         )
@@ -688,6 +724,77 @@ mod tests {
         );
         assert!(owed.is_empty());
         assert_eq!(remaining, 0);
+    }
+
+    /// Which versions a prune retained is a whole-plan property only the prune
+    /// saw, so it rides the entry. A target it names must never reach the
+    /// registry, and the vault must owe only what the rest frees.
+    #[test]
+    fn a_retained_target_is_never_named_by_the_retire_that_carries_it() {
+        let (whole, root_block, leaf_cids) = owed_version(&[9u8; 100]);
+        let expansion = expand_retire_targets(
+            &whole.target,
+            &root_block,
+            &ContentProfile::CI,
+            whole.manifest_bytes,
+        )
+        .expect("expands");
+        let hostage = leaf_cids[0].clone();
+        let entry = OwedRetire {
+            target: whole.target.clone(),
+            owed_bytes: expansion
+                .minus_retained(&BTreeSet::from([hostage.clone()]))
+                .pinned_bytes,
+            manifest_bytes: whole.manifest_bytes,
+            retained: vec![hostage.clone()],
+        };
+        assert!(
+            entry.owed_bytes < entry.manifest_bytes,
+            "an aliased expansion frees less than its manifest accounts for"
+        );
+        let store = InMemoryStagingStore::default();
+        owe(&store, OWNER, &entry);
+
+        let http = ledger_http(&entry, Some(root_block), Some(1));
+        let (remaining, owed) = drain(&store, OWNER, &http);
+
+        assert_eq!(
+            retired_targets(&http),
+            leaf_cids[1..]
+                .iter()
+                .cloned()
+                .chain([entry.target.clone()])
+                .collect::<Vec<_>>(),
+            "the retained target is skipped; everything else keeps its order"
+        );
+        assert!(owed.is_empty(), "the entry still settles");
+        assert_eq!(remaining, 0);
+    }
+
+    /// The retained list is the only record of what an entry must not retire, so
+    /// a trailer this build did not write reads as no entry at all rather than
+    /// as a shorter list.
+    #[test]
+    fn a_stored_entry_this_build_did_not_write_reads_as_nothing() {
+        let (whole, ..) = owed_version(&[1u8; 40]);
+        let entry = OwedRetire {
+            retained: vec![whole.target.clone()],
+            ..whole
+        };
+        let stored = encode_entry(&entry).expect("encodes");
+        assert_eq!(
+            decode_entry(&entry.target, Some(stored.clone())),
+            Some(entry.clone()),
+            "a round trip is the whole entry"
+        );
+        for bytes in [
+            Vec::new(),
+            vec![0u8; ENTRY_HEAD_LEN - 1],
+            [&stored[..], &[7u8; CONTENT_CID_LEN - 1]].concat(),
+            [&stored[..], &[7u8; CONTENT_CID_LEN]].concat(),
+        ] {
+            assert_eq!(decode_entry(&entry.target, Some(bytes)), None);
+        }
     }
 
     #[test]

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -174,19 +174,31 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
     async fn owe(&self, owner_tag: &[u8], entries: &[OwedRetire]) -> SeamResult<()> {
         for entry in entries {
             let key = Self::key(owner_tag, &entry.target)?;
-            let stored = encode_entry(entry)?;
-            // A held entry keeps its stored figure, so a replayed prune cannot
-            // double what the vault reports as pending; an unreadable one is
-            // repaired rather than left to sit undrainable forever. One target
-            // can ride two nodes' histories, though, so an entry that protects
-            // less than this one is replaced whole — figure and retained set
-            // together, since the two must stay consistent.
-            let held = decode_entry(self.0.staged_bytes(&key).await?);
-            if held.is_none_or(|(.., retained)| {
-                !entry.retained.iter().all(|cid| retained.contains(cid))
-            }) {
-                self.0.put_staged_bytes(&key, &stored).await?;
-            }
+            // An unreadable entry is repaired rather than left to sit
+            // undrainable forever.
+            let stored = match decode_entry(self.0.staged_bytes(&key).await?) {
+                None => encode_entry(entry.owed_bytes, entry.manifest_bytes, &entry.retained)?,
+                // A held entry whose protection already covers the incoming one
+                // stands, so a replayed prune cannot move what the vault reports
+                // as pending.
+                Some((.., retained)) if entry.retained.iter().all(|cid| retained.contains(cid)) => {
+                    continue;
+                }
+                Some((owed_bytes, manifest_bytes, retained)) => {
+                    let mut union: BTreeSet<String> = retained.into_iter().collect();
+                    union.extend(entry.retained.iter().cloned());
+                    encode_entry(
+                        // A union protects at least what either side did, so the
+                        // smaller figure bounds what the merged entry frees.
+                        owed_bytes.min(entry.owed_bytes),
+                        // The manifest total is the root block's own property,
+                        // not the prune's, so the held figure stands.
+                        manifest_bytes,
+                        &union.into_iter().collect::<Vec<_>>(),
+                    )?
+                }
+            };
+            self.0.put_staged_bytes(&key, &stored).await?;
         }
         Ok(())
     }
@@ -229,12 +241,13 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
     }
 }
 
-/// One entry as the staging store holds it.
-fn encode_entry(entry: &OwedRetire) -> SeamResult<Vec<u8>> {
-    let mut stored = Vec::with_capacity(ENTRY_HEAD_LEN + entry.retained.len() * CONTENT_CID_LEN);
-    stored.extend_from_slice(&entry.owed_bytes.to_be_bytes());
-    stored.extend_from_slice(&entry.manifest_bytes.to_be_bytes());
-    for cid in &entry.retained {
+/// One entry as the staging store holds it. The target itself is the key, so it
+/// is not written into the value.
+fn encode_entry(owed_bytes: u64, manifest_bytes: u64, retained: &[String]) -> SeamResult<Vec<u8>> {
+    let mut stored = Vec::with_capacity(ENTRY_HEAD_LEN + retained.len() * CONTENT_CID_LEN);
+    stored.extend_from_slice(&owed_bytes.to_be_bytes());
+    stored.extend_from_slice(&manifest_bytes.to_be_bytes());
+    for cid in retained {
         stored.extend_from_slice(
             &decode_content_cid_str(cid).map_err(|_| {
                 SeamError::new("retire-ledger retained target is not a content CID")
@@ -365,10 +378,18 @@ where
     else {
         return RetireOutcome::Deferred;
     };
+    let named = BTreeSet::from_iter(expansion.cids());
+    // Every retained target a prune journals comes out of this same
+    // content-verified expansion, so one that is not in it is a bent store, not
+    // a wider protection — and it would silently protect nothing at all.
+    if !entry.retained.iter().all(|cid| named.contains(cid)) {
+        return RetireOutcome::Deferred;
+    }
     let retirable = expansion.minus_retained(&BTreeSet::from_iter(entry.retained.iter().cloned()));
-    // The stored figure is what the prune promised this entry frees; a store
-    // whose retained list no longer produces it is not one to retire from.
-    if retirable.pinned_bytes != entry.owed_bytes {
+    // The ceiling on what this entry may free ([`OwedRetire::owed_bytes`]): a
+    // store whose retained list would free *more* than the prune promised is not
+    // one to retire from.
+    if retirable.pinned_bytes > entry.owed_bytes {
         return RetireOutcome::Deferred;
     }
     let targets = retirable.cids();
@@ -793,7 +814,8 @@ mod tests {
             retained: vec![whole.target.clone()],
             ..whole
         };
-        let stored = encode_entry(&entry).expect("encodes");
+        let stored =
+            encode_entry(entry.owed_bytes, entry.manifest_bytes, &entry.retained).expect("encodes");
         assert_eq!(
             decode_entry(Some(stored.clone())),
             Some((entry.owed_bytes, entry.manifest_bytes, entry.retained)),
@@ -813,7 +835,7 @@ mod tests {
     /// protects less than the incoming one must not stand: the second prune's
     /// retained set is the only record that its own survivors alias these bytes.
     #[test]
-    fn an_entry_that_protects_less_than_the_incoming_one_is_replaced() {
+    fn an_entry_that_protects_less_than_the_incoming_one_widens() {
         let (whole, root_block, leaf_cids) = owed_version(&[2u8; 100]);
         let expansion = expand_retire_targets(
             &whole.target,
@@ -836,7 +858,7 @@ mod tests {
         assert_eq!(
             block_on(StagingRetireLedger::new(&store).owed(OWNER)).expect("owed"),
             vec![protecting.clone()],
-            "the wider protection replaces the narrower entry whole"
+            "the wider protection widens the entry it merges into"
         );
 
         owe(&store, OWNER, &whole);
@@ -845,6 +867,132 @@ mod tests {
             vec![protecting],
             "and a replay that protects nothing does not narrow it again"
         );
+    }
+
+    /// Two prunes of one root can protect **non-comparable** sets, and the
+    /// merged entry must still drain.
+    #[test]
+    fn two_prunes_protecting_disjoint_targets_merge_and_the_merged_entry_drains() {
+        let (whole, root_block, leaf_cids) = owed_version(&[2u8; 100]);
+        let expansion = expand_retire_targets(
+            &whole.target,
+            &root_block,
+            &ContentProfile::CI,
+            whole.manifest_bytes,
+        )
+        .expect("expands");
+        assert!(
+            leaf_cids.len() > 2,
+            "two hostages and something left to free"
+        );
+        let protecting = |hostage: &String| OwedRetire {
+            owed_bytes: expansion
+                .minus_retained(&BTreeSet::from([hostage.clone()]))
+                .pinned_bytes,
+            retained: vec![hostage.clone()],
+            ..whole.clone()
+        };
+        let store = InMemoryStagingStore::default();
+        owe(&store, OWNER, &protecting(&leaf_cids[0]));
+        owe(&store, OWNER, &protecting(&leaf_cids[1]));
+
+        let held = block_on(StagingRetireLedger::new(&store).owed(OWNER)).expect("owed");
+        assert_eq!(
+            held.iter()
+                .map(|entry| BTreeSet::from_iter(entry.retained.iter().cloned()))
+                .collect::<Vec<_>>(),
+            vec![BTreeSet::from([leaf_cids[0].clone(), leaf_cids[1].clone()])],
+            "neither prune's protection is dropped"
+        );
+
+        let http = ledger_http(&whole, Some(root_block), Some(1));
+        let (remaining, owed) = drain(&store, OWNER, &http);
+        assert_eq!(
+            retired_targets(&http),
+            leaf_cids[2..]
+                .iter()
+                .cloned()
+                .chain([whole.target])
+                .collect::<Vec<_>>(),
+            "both hostages are skipped, and the merged entry still drains"
+        );
+        assert!(owed.is_empty(), "a widened entry is not a stuck one");
+        assert_eq!(remaining, 0);
+    }
+
+    /// A merged entry's figure is a ceiling rather than the exact total, and the
+    /// slack is worth one protected target. A store that bent a retained CID
+    /// would spend that slack and retire the target it displaced, so membership
+    /// of the entry's own content-verified expansion is what catches it.
+    #[test]
+    fn a_retained_target_the_expansion_does_not_name_retires_nothing() {
+        let (whole, root_block, leaf_cids) = owed_version(&[8u8; 100]);
+        let expansion = expand_retire_targets(
+            &whole.target,
+            &root_block,
+            &ContentProfile::CI,
+            whole.manifest_bytes,
+        )
+        .expect("expands");
+        let without = |hostage: &String| {
+            expansion
+                .minus_retained(&BTreeSet::from([hostage.clone()]))
+                .pinned_bytes
+        };
+        assert_eq!(
+            without(&leaf_cids[0]),
+            without(&leaf_cids[1]),
+            "two equal-weight hostages, so the bent set reproduces the ceiling exactly"
+        );
+        let stranger = owed_version(&[9u8; 40]).2[0].clone();
+        assert!(!expansion.cids().contains(&stranger));
+
+        // What a merge of two prunes protecting {leaf 0} and {leaf 1} stores,
+        // with the first CID bent to a stranger: the byte ceiling alone cannot
+        // tell the difference, so leaf 0 would go to the registry unprotected.
+        let bent = OwedRetire {
+            owed_bytes: without(&leaf_cids[0]),
+            retained: vec![stranger, leaf_cids[1].clone()],
+            ..whole
+        };
+        let store = InMemoryStagingStore::default();
+        block_on(store.put_staged_bytes(
+            &StagingRetireLedger::<InMemoryStagingStore>::key(OWNER, &bent.target).expect("key"),
+            &encode_entry(bent.owed_bytes, bent.manifest_bytes, &bent.retained).expect("encodes"),
+        ))
+        .expect("the store takes it");
+
+        let http = ledger_http(&bent, Some(root_block), Some(1));
+        let (remaining, owed) = drain(&store, OWNER, &http);
+        assert!(
+            retired_targets(&http).is_empty(),
+            "a retained target off the expansion retires nothing at all"
+        );
+        assert_eq!(owed, vec![bent.clone()], "and stays owed");
+        assert_eq!(remaining, bent.owed_bytes);
+    }
+
+    /// The stored figure is the ceiling on what an entry may free, so a store
+    /// that lost an entry's retained targets — leaving an expansion that frees
+    /// more than the prune ever promised — is not one to retire from.
+    #[test]
+    fn an_entry_that_would_free_more_than_it_promised_retires_nothing() {
+        let (whole, root_block, _) = owed_version(&[3u8; 100]);
+        let understated = OwedRetire {
+            owed_bytes: whole.owed_bytes - 1,
+            ..whole
+        };
+        let store = InMemoryStagingStore::default();
+        owe(&store, OWNER, &understated);
+
+        let http = ledger_http(&understated, Some(root_block), Some(1));
+        let (remaining, owed) = drain(&store, OWNER, &http);
+        assert!(
+            retired_targets(&http).is_empty(),
+            "an expansion the stored figure does not cover retires nothing"
+        );
+        assert_eq!(owed, vec![understated.clone()], "and stays owed");
+        assert_eq!(remaining, understated.owed_bytes);
     }
 
     /// The ledger is not authenticated, so a store that lost or bent an entry

--- a/crates/engine/src/net/retire.rs
+++ b/crates/engine/src/net/retire.rs
@@ -132,9 +132,8 @@ where
 pub const RETIRE_LEDGER_PREFIX: &[u8] = b"cbx/rl/";
 
 /// The fixed head of one stored entry: the owed figure then the manifest total,
-/// both big-endian `u64`. Whatever follows is the retained-target list, one
-/// binary content CID each.
-const ENTRY_HEAD_LEN: usize = 16;
+/// both big-endian `u64`, followed by the retained-target list as binary CIDs.
+const ENTRY_HEAD_LEN: usize = 2 * size_of::<u64>();
 
 /// The [`RetireLedger`] every host gets for free, over the durable staging store
 /// it already implements.
@@ -176,10 +175,16 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
         for entry in entries {
             let key = Self::key(owner_tag, &entry.target)?;
             let stored = encode_entry(entry)?;
-            // A readable entry keeps its stored figure, so a replayed prune
-            // cannot double what the vault reports as pending; an unreadable one
-            // is repaired rather than left to sit undrainable forever.
-            if decode_entry(&entry.target, self.0.staged_bytes(&key).await?).is_none() {
+            // A held entry keeps its stored figure, so a replayed prune cannot
+            // double what the vault reports as pending; an unreadable one is
+            // repaired rather than left to sit undrainable forever. One target
+            // can ride two nodes' histories, though, so an entry that protects
+            // less than this one is replaced whole — figure and retained set
+            // together, since the two must stay consistent.
+            let held = decode_entry(self.0.staged_bytes(&key).await?);
+            if held.is_none_or(|(.., retained)| {
+                !entry.retained.iter().all(|cid| retained.contains(cid))
+            }) {
                 self.0.put_staged_bytes(&key, &stored).await?;
             }
         }
@@ -196,11 +201,17 @@ impl<St: StagingStore> RetireLedger for StagingRetireLedger<'_, St> {
             else {
                 continue;
             };
-            let target = encode_content_cid_str(cid);
-            let Some(entry) = decode_entry(&target, self.0.staged_bytes(&key).await?) else {
+            let Some((owed_bytes, manifest_bytes, retained)) =
+                decode_entry(self.0.staged_bytes(&key).await?)
+            else {
                 continue;
             };
-            entries.push(entry);
+            entries.push(OwedRetire {
+                target: encode_content_cid_str(cid),
+                owed_bytes,
+                manifest_bytes,
+                retained,
+            });
         }
         // Store enumeration order is host-dependent, and a pass can stop early;
         // sorted, it at least stops at the same place on every host.
@@ -233,25 +244,26 @@ fn encode_entry(entry: &OwedRetire) -> SeamResult<Vec<u8>> {
     Ok(stored)
 }
 
-/// One entry read back, or `None` for bytes this build did not write. A partial
-/// or over-long trailer reads as unwritten rather than as a shorter retained
-/// list, which would retire a target the prune excluded.
-fn decode_entry(target: &str, stored: Option<Vec<u8>>) -> Option<OwedRetire> {
+/// One entry's owed figure, manifest total, and retained targets — or `None` for
+/// bytes this build did not write. A partial or over-long trailer reads as
+/// unwritten rather than as a shorter retained list, which would retire a target
+/// the prune excluded. The target itself comes from the key, never the value.
+fn decode_entry(stored: Option<Vec<u8>>) -> Option<(u64, u64, Vec<String>)> {
     let stored = stored?;
-    if stored.len() < ENTRY_HEAD_LEN || (stored.len() - ENTRY_HEAD_LEN) % CONTENT_CID_LEN != 0 {
+    if (stored.len().checked_sub(ENTRY_HEAD_LEN)?) % CONTENT_CID_LEN != 0 {
         return None;
     }
-    let (head, rest) = stored.split_at(ENTRY_HEAD_LEN);
+    let (owed, rest) = stored.split_first_chunk::<{ size_of::<u64>() }>()?;
+    let (manifest, rest) = rest.split_first_chunk::<{ size_of::<u64>() }>()?;
     let retained = rest
         .chunks_exact(CONTENT_CID_LEN)
         .map(|cid| is_wellformed_content_cid(cid).then(|| encode_content_cid_str(cid)))
         .collect::<Option<Vec<String>>>()?;
-    Some(OwedRetire {
-        target: target.to_owned(),
-        owed_bytes: u64::from_be_bytes(<[u8; 8]>::try_from(&head[..8]).ok()?),
-        manifest_bytes: u64::from_be_bytes(<[u8; 8]>::try_from(&head[8..]).ok()?),
+    Some((
+        u64::from_be_bytes(*owed),
+        u64::from_be_bytes(*manifest),
         retained,
-    })
+    ))
 }
 
 /// Work the ledger once and report the pinned bytes still owed afterwards — the
@@ -783,8 +795,8 @@ mod tests {
         };
         let stored = encode_entry(&entry).expect("encodes");
         assert_eq!(
-            decode_entry(&entry.target, Some(stored.clone())),
-            Some(entry.clone()),
+            decode_entry(Some(stored.clone())),
+            Some((entry.owed_bytes, entry.manifest_bytes, entry.retained)),
             "a round trip is the whole entry"
         );
         for bytes in [
@@ -793,8 +805,81 @@ mod tests {
             [&stored[..], &[7u8; CONTENT_CID_LEN - 1]].concat(),
             [&stored[..], &[7u8; CONTENT_CID_LEN]].concat(),
         ] {
-            assert_eq!(decode_entry(&entry.target, Some(bytes)), None);
+            assert_eq!(decode_entry(Some(bytes)), None);
         }
+    }
+
+    /// One root `contentCid` can ride two nodes' histories, so a held entry that
+    /// protects less than the incoming one must not stand: the second prune's
+    /// retained set is the only record that its own survivors alias these bytes.
+    #[test]
+    fn an_entry_that_protects_less_than_the_incoming_one_is_replaced() {
+        let (whole, root_block, leaf_cids) = owed_version(&[2u8; 100]);
+        let expansion = expand_retire_targets(
+            &whole.target,
+            &root_block,
+            &ContentProfile::CI,
+            whole.manifest_bytes,
+        )
+        .expect("expands");
+        let hostage = leaf_cids[0].clone();
+        let protecting = OwedRetire {
+            owed_bytes: expansion
+                .minus_retained(&BTreeSet::from([hostage.clone()]))
+                .pinned_bytes,
+            retained: vec![hostage.clone()],
+            ..whole.clone()
+        };
+        let store = InMemoryStagingStore::default();
+        owe(&store, OWNER, &whole);
+        owe(&store, OWNER, &protecting);
+        assert_eq!(
+            block_on(StagingRetireLedger::new(&store).owed(OWNER)).expect("owed"),
+            vec![protecting.clone()],
+            "the wider protection replaces the narrower entry whole"
+        );
+
+        owe(&store, OWNER, &whole);
+        assert_eq!(
+            block_on(StagingRetireLedger::new(&store).owed(OWNER)).expect("owed"),
+            vec![protecting],
+            "and a replay that protects nothing does not narrow it again"
+        );
+    }
+
+    /// The ledger is not authenticated, so a store that lost or bent an entry
+    /// must never let a leaf ride the final batch in the root's place.
+    #[test]
+    fn an_entry_whose_retained_set_names_its_own_root_retires_nothing() {
+        let (whole, root_block, _) = owed_version(&[4u8; 100]);
+        let expansion = expand_retire_targets(
+            &whole.target,
+            &root_block,
+            &ContentProfile::CI,
+            whole.manifest_bytes,
+        )
+        .expect("expands");
+        let entry = OwedRetire {
+            // Consistent with the bent retained set, so the byte gate passes and
+            // the missing expansion key is the only thing left to catch it.
+            owed_bytes: expansion
+                .minus_retained(&BTreeSet::from([whole.target.clone()]))
+                .pinned_bytes,
+            retained: vec![whole.target.clone()],
+            ..whole
+        };
+        let store = InMemoryStagingStore::default();
+        owe(&store, OWNER, &entry);
+
+        let http = ledger_http(&entry, Some(root_block), Some(1));
+        let (remaining, owed) = drain(&store, OWNER, &http);
+
+        assert!(
+            retired_targets(&http).is_empty(),
+            "an entry that cannot name its own expansion key retires nothing"
+        );
+        assert_eq!(owed, vec![entry.clone()], "and stays owed");
+        assert_eq!(remaining, entry.owed_bytes);
     }
 
     #[test]

--- a/crates/engine/src/seams/retire_ledger.rs
+++ b/crates/engine/src/seams/retire_ledger.rs
@@ -17,12 +17,17 @@ pub struct OwedRetire {
     /// The pinned bytes this entry stands for — the vault's pending-reclaim
     /// figure is their sum. [`Self::retained`] is already subtracted, so it is
     /// what the retire frees, not what the manifest accounts for.
+    ///
+    /// An **upper bound**, not an equality: a merged retained set only ever
+    /// widens, so the drain recomputes the figure off the root block and holds
+    /// the stored one as the ceiling.
     pub owed_bytes: u64,
     /// The pinned total the doomed manifest must account for — the bound the
     /// expansion holds a hand-framed root to.
     pub manifest_bytes: u64,
-    /// Targets of this root's expansion that a version the prune **retained**
-    /// also names, so the retire must skip them
+    /// Targets of this root's expansion that another entry of the prune already
+    /// accounts for — a version it **retained**, or a doomed one charged ahead
+    /// of this — so the retire must skip them
     /// ([`Expansion::split_retained`](crate::content::Expansion::split_retained)).
     ///
     /// Normally empty — honestly-authored versions seal identical plaintext
@@ -62,8 +67,10 @@ impl OwedRetire {
 ///   already holds keeps the stored entry rather than adding a second one, so a
 ///   replayed prune cannot double the pending figure — unless the incoming entry
 ///   names a [`retained`](OwedRetire::retained) target the held one does not, in
-///   which case it replaces it whole, so protection only ever widens. Order is
-///   not part of the contract.
+///   which case the two retained sets **merge**, so protection only ever widens
+///   and never moves; the merged
+///   [`owed_bytes`](OwedRetire::owed_bytes) is the lower of the two. Order — of
+///   the entries, and of one entry's retained set — is not part of the contract.
 /// - **Never-discard**: nothing but `settle` removes an entry. There is no
 ///   attempt budget, no expiry, and no sweep — every failure mode is either
 ///   self-clearing or ours, and the byte figure is the only record of what was
@@ -72,8 +79,8 @@ impl OwedRetire {
 ///
 /// `owner_tag` is opaque engine-chosen bytes; the store never interprets it.
 pub trait RetireLedger {
-    /// Journals `entries` under `owner_tag`, keeping the stored `owed_bytes` of
-    /// any target already held.
+    /// Journals `entries` under `owner_tag`, merging any target already held
+    /// rather than adding a second entry for it.
     async fn owe(&self, owner_tag: &[u8], entries: &[OwedRetire]) -> SeamResult<()>;
 
     /// Every entry owed under `owner_tag`, in unspecified order.

--- a/crates/engine/src/seams/retire_ledger.rs
+++ b/crates/engine/src/seams/retire_ledger.rs
@@ -22,19 +22,17 @@ pub struct OwedRetire {
     /// expansion holds a hand-framed root to.
     pub manifest_bytes: u64,
     /// Targets of this root's expansion that a version the prune **retained**
-    /// also names, so the retire must skip them.
+    /// also names, so the retire must skip them
+    /// ([`Expansion::split_retained`](crate::content::Expansion::split_retained)).
     ///
-    /// Which versions are retained is a whole-plan property only the prune op
-    /// sees; a single root's expansion cannot derive it. Normally empty —
-    /// honestly-authored versions seal identical plaintext under a fresh
-    /// per-version key and a fresh per-chunk nonce, so their leaf sets are
-    /// disjoint by construction.
+    /// Normally empty — honestly-authored versions seal identical plaintext
+    /// under a fresh per-version key and a fresh per-chunk nonce, so their leaf
+    /// sets are disjoint by construction.
     pub retained: Vec<String>,
 }
 
 impl OwedRetire {
-    /// The debt of a doomed version whose expansion aliases nothing a retained
-    /// version names — every prune's normal case.
+    /// A debt whose expansion aliases nothing a retained version names.
     #[must_use]
     pub fn whole(target: String, pinned_bytes: u64) -> Self {
         Self {
@@ -61,9 +59,11 @@ impl OwedRetire {
 ///   account's paid debt from another's unpaid one
 ///   ([`RetireResult`](crate::api::RetireResult)).
 /// - **Keyed by target**: [`owe`](RetireLedger::owe)ing a target the store
-///   already holds keeps the stored `owed_bytes` rather than adding a second
-///   entry, so a replayed prune cannot double the pending figure. Order is not
-///   part of the contract.
+///   already holds keeps the stored entry rather than adding a second one, so a
+///   replayed prune cannot double the pending figure — unless the incoming entry
+///   names a [`retained`](OwedRetire::retained) target the held one does not, in
+///   which case it replaces it whole, so protection only ever widens. Order is
+///   not part of the contract.
 /// - **Never-discard**: nothing but `settle` removes an entry. There is no
 ///   attempt budget, no expiry, and no sweep — every failure mode is either
 ///   self-clearing or ours, and the byte figure is the only record of what was

--- a/crates/engine/src/seams/retire_ledger.rs
+++ b/crates/engine/src/seams/retire_ledger.rs
@@ -15,8 +15,35 @@ pub struct OwedRetire {
     /// The doomed version's root `contentCid` (multibase string).
     pub target: String,
     /// The pinned bytes this entry stands for — the vault's pending-reclaim
-    /// figure is their sum.
+    /// figure is their sum. [`Self::retained`] is already subtracted, so it is
+    /// what the retire frees, not what the manifest accounts for.
     pub owed_bytes: u64,
+    /// The pinned total the doomed manifest must account for — the bound the
+    /// expansion holds a hand-framed root to.
+    pub manifest_bytes: u64,
+    /// Targets of this root's expansion that a version the prune **retained**
+    /// also names, so the retire must skip them.
+    ///
+    /// Which versions are retained is a whole-plan property only the prune op
+    /// sees; a single root's expansion cannot derive it. Normally empty —
+    /// honestly-authored versions seal identical plaintext under a fresh
+    /// per-version key and a fresh per-chunk nonce, so their leaf sets are
+    /// disjoint by construction.
+    pub retained: Vec<String>,
+}
+
+impl OwedRetire {
+    /// The debt of a doomed version whose expansion aliases nothing a retained
+    /// version names — every prune's normal case.
+    #[must_use]
+    pub fn whole(target: String, pinned_bytes: u64) -> Self {
+        Self {
+            target,
+            owed_bytes: pinned_bytes,
+            manifest_bytes: pinned_bytes,
+            retained: Vec::new(),
+        }
+    }
 }
 
 /// Durable per-owner set of retirements a published prune still owes the

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -25,7 +25,9 @@ use core::cell::{Cell, RefCell};
 use core::num::NonZeroU64;
 use std::collections::{BTreeMap, BTreeSet};
 
-use cipherbox_core::content::{encode_content_cid_str, is_wellformed_content_cid, verify_cid};
+use cipherbox_core::content::{
+    decode_content_cid_str, encode_content_cid_str, is_wellformed_content_cid, verify_cid,
+};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
@@ -38,8 +40,9 @@ use zeroize::Zeroizing;
 
 use crate::api::{ApiClient, ApiError, QUOTA_EXCEEDED, REGISTRY_BATCH_REFUSED, UPLOAD_TOO_LARGE};
 use crate::content::{
-    ContentProfile, ContentVersion, Gateway, ProviderError, SealedContent, place_block, plan_prune,
-    pre_flight_quota_check,
+    ContentPlane, ContentProfile, ContentVersion, Expansion, Gateway, ProviderError, RootPlacement,
+    SealedContent, expand_retire_targets, place_block, plan_prune, pre_flight_quota_check,
+    read_block, version_cids,
 };
 use crate::entropy::Entropy;
 use crate::facade::{BlockProgress, Event, NodeId, OpPhase};
@@ -1694,6 +1697,10 @@ where
         {
             return Err(Halt::Permanent(DeadLetterReason::PayloadRefused));
         }
+        // Ahead of the publish: a debt this pass cannot compute must leave the
+        // history it was read from standing, not a shortened one it never
+        // journaled.
+        let owed = self.prune_debt(&plan.retire_targets, survivors).await?;
         versions.truncate(survivors.len());
         let content_cids = survivors
             .iter()
@@ -1723,7 +1730,7 @@ where
             )
             .await
             .map_err(Halt::from)?;
-        self.owe_retires(scope, &plan.retire_targets).await?;
+        self.owe_retires(scope, &owed).await?;
         self.project_published_file(
             target,
             head_size,
@@ -1750,21 +1757,76 @@ where
             .collect()
     }
 
+    /// What each doomed version still owes the registry once every target a
+    /// retained version also names is taken out of it.
+    ///
+    /// A pin row is keyed `(account, cid)` and physical unpin fires at global
+    /// refcount zero (blueprint/api.md "Pin/name registry"), so retiring a CID a
+    /// retained version also names unpins the live file. A doomed root's link
+    /// list is not this device's word for what that version holds: in a shared
+    /// scope a write-grantee authors versions of its own, and their blocks
+    /// register under the grantee's account until this one syncs — so a root
+    /// that content-addresses correctly can still name leaves the owner is
+    /// living on. Only the prune sees both sides of that, which is why the
+    /// subtraction happens here rather than inside a single root's expansion.
+    async fn prune_debt(
+        &self,
+        doomed: &[ContentVersion],
+        retained: &[ContentVersion],
+    ) -> Result<Vec<OwedRetire>, Halt> {
+        let mut protected = BTreeSet::new();
+        for version in retained {
+            protected.extend(self.expand_version(version).await?.cids());
+        }
+        let mut owed = Vec::with_capacity(doomed.len());
+        for version in doomed {
+            let expansion = self.expand_version(version).await?;
+            owed.push(OwedRetire {
+                target: version.content_cid.clone(),
+                owed_bytes: expansion.minus_retained(&protected).pinned_bytes,
+                manifest_bytes: expansion.pinned_bytes,
+                retained: expansion
+                    .targets
+                    .into_iter()
+                    .filter(|target| protected.contains(&target.cid))
+                    .map(|target| target.cid)
+                    .collect(),
+            });
+        }
+        Ok(owed)
+    }
+
+    /// One published version's whole CID set, off its own fetched root block.
+    async fn expand_version(&self, version: &ContentVersion) -> Result<Expansion, Halt> {
+        let expected = decode_content_cid_str(&version.content_cid)
+            .map_err(|_| Halt::Permanent(DeadLetterReason::PayloadRefused))?;
+        let root_block = read_block(
+            self.gateway,
+            self.http,
+            &version.content_cid,
+            &expected,
+            ContentPlane::Root,
+        )
+        .await
+        // A root no source served is this pass's problem, not the version's.
+        .map_err(|_| Halt::Unclassified)?;
+        expand_retire_targets(
+            &version.content_cid,
+            &root_block,
+            self.content_profile,
+            version.pinned_bytes,
+        )
+        .map_err(|_| Halt::Permanent(DeadLetterReason::PayloadRefused))
+    }
+
     /// Journal the dropped roots as owed, under this identity's ledger scope.
     async fn owe_retires(
         &self,
         scope: &DrainScope<'_>,
-        doomed: &[ContentVersion],
+        entries: &[OwedRetire],
     ) -> Result<(), Halt> {
-        let entries: Vec<OwedRetire> = doomed
-            .iter()
-            .map(|version| OwedRetire {
-                target: version.content_cid.clone(),
-                owed_bytes: version.pinned_bytes,
-            })
-            .collect();
         StagingRetireLedger::new(self.staging)
-            .owe(&owner_tag(scope.enc_secret), &entries)
+            .owe(&owner_tag(scope.enc_secret), entries)
             .await
             .map_err(seam)
     }
@@ -1928,7 +1990,11 @@ where
         .await?;
         emit(OpPhase::UploadCompleted, total);
 
-        let content_cids = registry_cids(&staged.root_cid, content.leaf_cids());
+        let content_cids = version_cids(
+            &staged.root_cid,
+            content.leaf_cids().iter().map(Vec::as_slice),
+            RootPlacement::First,
+        );
         Ok(UploadedVersion {
             version: content.version(*key, applied.op.authored_at.0),
             content_cids,
@@ -2437,9 +2503,14 @@ where
                 .to_owned()
         });
         let content = match op.content_root_cid() {
-            Some(root_cid) => {
-                registry_cids(root_cid, &version_leaf_cids(self.staging, root_cid).await)
-            }
+            Some(root_cid) => version_cids(
+                root_cid,
+                version_leaf_cids(self.staging, root_cid)
+                    .await
+                    .iter()
+                    .map(Vec::as_slice),
+                RootPlacement::First,
+            ),
             None => Vec::new(),
         };
         name.into_iter().chain(content).collect()
@@ -2843,21 +2914,6 @@ fn checked_content_cid(cid: &[u8]) -> Result<&[u8], Halt> {
     is_wellformed_content_cid(cid)
         .then_some(cid)
         .ok_or(Halt::Permanent(DeadLetterReason::PayloadRefused))
-}
-
-/// One version as the registry names it: the root first, then every leaf in
-/// file order, read from the blocks this device staged.
-///
-/// Every block is its own accountable pin row (blueprint/api.md "Pin/name
-/// registry"), so a retirement naming fewer CIDs than the registration claimed
-/// spends account quota forever. The prune drain names the same set from the
-/// fetched root block instead ([`expand_retire_targets`]), because by then
-/// staging has released the leaves.
-fn registry_cids(root_cid: &[u8], leaf_cids: &[Vec<u8>]) -> Vec<String> {
-    core::iter::once(root_cid)
-        .chain(leaf_cids.iter().map(Vec::as_slice))
-        .map(encode_content_cid_str)
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -846,7 +846,7 @@ where
             None,
         )
         .await
-        .map_err(|_| Halt::Unclassified)?;
+        .map_err(|_| Halt::UploadAttempt)?;
         // The cache can be older than the floors — a restored data dir is
         // exactly that. The whole pass anchors here: this record's epoch
         // becomes the epoch every record it publishes is sealed at, so a
@@ -863,7 +863,7 @@ where
             floor::Strictness::AtFloor,
         )
         .await
-        .map_err(|_| Halt::Unclassified)?;
+        .map_err(|_| Halt::UploadAttempt)?;
         // Encode/decode fail-closed symmetry: this build authors exactly
         // `ENVELOPE_V`, so republishing a newer client's root would silently
         // downgrade `v` — the exact rollback the read-body AAD defends against.
@@ -871,7 +871,7 @@ where
             return Err(Halt::Unclassified);
         }
         let read_key = self.node_read_key(scope, &scope.root.0);
-        let body = open_read_body(&envelope, &read_key).map_err(|_| Halt::Unclassified)?;
+        let body = open_read_body(&envelope, &read_key).map_err(|_| Halt::UploadAttempt)?;
         let ReadBody::Folder {
             created_at,
             modified_at,
@@ -964,7 +964,7 @@ where
         let (adopted, envelope) = adopter
             .open_carried_at_floor(&name, &record_bytes)
             .await
-            .map_err(|_| Halt::Unclassified)?;
+            .map_err(|_| Halt::UploadAttempt)?;
         // The same two rollback guards the root load makes: this build authors
         // exactly `ENVELOPE_V`, and re-sealing a node at another epoch than the
         // scope's would cross the AAD epoch binding.
@@ -1730,7 +1730,10 @@ where
             )
             .await
             .map_err(Halt::from)?;
-        self.owe_retires(scope, &owed).await?;
+        StagingRetireLedger::new(self.staging)
+            .owe(&owner_tag(scope.enc_secret), &owed)
+            .await
+            .map_err(seam)?;
         self.project_published_file(
             target,
             head_size,
@@ -1758,17 +1761,14 @@ where
     }
 
     /// What each doomed version still owes the registry once every target a
-    /// retained version also names is taken out of it.
+    /// retained version also names is taken out of it
+    /// ([`Expansion::split_retained`]).
     ///
-    /// A pin row is keyed `(account, cid)` and physical unpin fires at global
-    /// refcount zero (blueprint/api.md "Pin/name registry"), so retiring a CID a
-    /// retained version also names unpins the live file. A doomed root's link
-    /// list is not this device's word for what that version holds: in a shared
-    /// scope a write-grantee authors versions of its own, and their blocks
-    /// register under the grantee's account until this one syncs — so a root
-    /// that content-addresses correctly can still name leaves the owner is
-    /// living on. Only the prune sees both sides of that, which is why the
-    /// subtraction happens here rather than inside a single root's expansion.
+    /// A doomed root's link list is not this device's word for what that version
+    /// holds: in a shared scope a write-grantee authors versions of its own, and
+    /// their blocks register under the grantee's account until this one syncs —
+    /// so a root that content-addresses correctly can still name leaves the
+    /// owner is living on. Only the prune sees both sides of that.
     async fn prune_debt(
         &self,
         doomed: &[ContentVersion],
@@ -1781,16 +1781,12 @@ where
         let mut owed = Vec::with_capacity(doomed.len());
         for version in doomed {
             let expansion = self.expand_version(version).await?;
+            let (retirable, held) = expansion.split_retained(&protected);
             owed.push(OwedRetire {
                 target: version.content_cid.clone(),
-                owed_bytes: expansion.minus_retained(&protected).pinned_bytes,
+                owed_bytes: retirable.pinned_bytes,
                 manifest_bytes: expansion.pinned_bytes,
-                retained: expansion
-                    .targets
-                    .into_iter()
-                    .filter(|target| protected.contains(&target.cid))
-                    .map(|target| target.cid)
-                    .collect(),
+                retained: held,
             });
         }
         Ok(owed)
@@ -1808,8 +1804,10 @@ where
             ContentPlane::Root,
         )
         .await
-        // A root no source served is this pass's problem, not the version's.
-        .map_err(|_| Halt::Unclassified)?;
+        // Charged, unlike a plain outage: a version whose root no source will
+        // serve is authorable by anyone holding the scope's write seed, and an
+        // uncharged retry would let one hold the whole queue behind its head.
+        .map_err(|_| Halt::UploadAttempt)?;
         expand_retire_targets(
             &version.content_cid,
             &root_block,
@@ -1817,18 +1815,6 @@ where
             version.pinned_bytes,
         )
         .map_err(|_| Halt::Permanent(DeadLetterReason::PayloadRefused))
-    }
-
-    /// Journal the dropped roots as owed, under this identity's ledger scope.
-    async fn owe_retires(
-        &self,
-        scope: &DrainScope<'_>,
-        entries: &[OwedRetire],
-    ) -> Result<(), Halt> {
-        StagingRetireLedger::new(self.staging)
-            .owe(&owner_tag(scope.enc_secret), entries)
-            .await
-            .map_err(seam)
     }
 
     // -----------------------------------------------------------------------
@@ -1888,7 +1874,7 @@ where
         // Resolved before any byte moves: a session that cannot authenticate the
         // member's placement choice holds its content ops rather than picking a
         // destination for them.
-        let placement = self.placement.as_ref().map_err(|_| Halt::Unclassified)?;
+        let placement = self.placement.as_ref().map_err(|_| Halt::UploadAttempt)?;
         // What the mark may claim, narrowed as the mirror misses blocks the mark
         // covers ([`Destinations::mirror_missed`]).
         let mut reached = placement.destinations();
@@ -2340,7 +2326,7 @@ where
             epoch,
         };
         let preflighted = preflight(&binding, &self.node_read_key(scope, node_id), head)
-            .map_err(|_| Halt::Unclassified)?;
+            .map_err(|_| Halt::UploadAttempt)?;
         // The name and the seed the signer comes from have independent sources
         // for the scope root — the vault pointer's `currentRoot` and the
         // owner-write-blob. Publishing under a name this signer cannot sign for
@@ -2462,7 +2448,7 @@ where
     async fn abandon(&self, scope: &DrainScope<'_>, op_id: OpId, op: &Op) -> Result<(), Halt> {
         retire(self.api, &self.registered_by(scope, op).await)
             .await
-            .map_err(|_| Halt::Unclassified)?;
+            .map_err(|_| Halt::UploadAttempt)?;
         self.dequeue_op(op_id).await
     }
 
@@ -2629,7 +2615,7 @@ where
         self.entropy
             .borrow_mut()
             .fill(&mut nonce)
-            .map_err(|_| Halt::Unclassified)?;
+            .map_err(|_| Halt::UploadAttempt)?;
         Ok(nonce)
     }
 }

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -1760,8 +1760,8 @@ where
             .collect()
     }
 
-    /// What each doomed version still owes the registry once every target a
-    /// retained version also names is taken out of it
+    /// What each doomed version still owes the registry once every target
+    /// another version of the same plan already accounts for is taken out of it
     /// ([`Expansion::split_retained`]).
     ///
     /// A doomed root's link list is not this device's word for what that version
@@ -1769,6 +1769,11 @@ where
     /// their blocks register under the grantee's account until this one syncs —
     /// so a root that content-addresses correctly can still name leaves the
     /// owner is living on. Only the prune sees both sides of that.
+    ///
+    /// The same argument lets two *doomed* roots name one leaf. A pin row is
+    /// keyed `(account, cid)`, so that leaf is one row and belongs to exactly one
+    /// entry: charging it twice would over-report pending reclaim and hand the
+    /// registry the same CID under two debts.
     async fn prune_debt(
         &self,
         doomed: &[ContentVersion],
@@ -1779,9 +1784,16 @@ where
             protected.extend(self.expand_version(version).await?.cids());
         }
         let mut owed = Vec::with_capacity(doomed.len());
+        let mut charged: BTreeSet<&str> = BTreeSet::new();
         for version in doomed {
+            // A history may name one root twice, and the ledger is keyed by
+            // target: the second naming owes nothing the first does not carry.
+            if !charged.insert(version.content_cid.as_str()) {
+                continue;
+            }
             let expansion = self.expand_version(version).await?;
             let (retirable, held) = expansion.split_retained(&protected);
+            protected.extend(retirable.cids());
             owed.push(OwedRetire {
                 target: version.content_cid.clone(),
                 owed_bytes: retirable.pinned_bytes,

--- a/crates/engine/src/testkit/conformance/retire_ledger.rs
+++ b/crates/engine/src/testkit/conformance/retire_ledger.rs
@@ -14,10 +14,7 @@ fn root(seed: u8) -> String {
 }
 
 fn owed(target: &str, owed_bytes: u64) -> OwedRetire {
-    OwedRetire {
-        target: target.into(),
-        owed_bytes,
-    }
+    OwedRetire::whole(target.into(), owed_bytes)
 }
 
 /// The entries as a map, so a kit assertion never depends on an order the
@@ -141,4 +138,28 @@ where
     reopened.owe(alice, &[]).await.unwrap();
     reopened.settle(alice, &[]).await.unwrap();
     assert_eq!(held(&reopened, alice).await.len(), 2);
+
+    // The retained set is the only record of what this entry must not retire,
+    // so it is as durable as the figure beside it.
+    let aliased = OwedRetire {
+        target: root(3),
+        owed_bytes: 11,
+        manifest_bytes: 90,
+        retained: vec![root(4), root(5)],
+    };
+    reopened
+        .owe(alice, core::slice::from_ref(&aliased))
+        .await
+        .unwrap();
+    let after_reopen = open().await;
+    assert_eq!(
+        after_reopen
+            .owed(alice)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.target == aliased.target),
+        Some(aliased),
+        "an entry must survive reopen whole, retained set included"
+    );
 }

--- a/crates/engine/src/testkit/conformance/retire_ledger.rs
+++ b/crates/engine/src/testkit/conformance/retire_ledger.rs
@@ -139,27 +139,40 @@ where
     reopened.settle(alice, &[]).await.unwrap();
     assert_eq!(held(&reopened, alice).await.len(), 2);
 
-    // The retained set is the only record of what this entry must not retire,
-    // so it is as durable as the figure beside it.
+    // The retained set is the only record of what an entry must not retire, so
+    // it is as durable as the figure beside it, and an entry that protects less
+    // never displaces one that protects more.
     let aliased = OwedRetire {
         target: root(3),
         owed_bytes: 11,
         manifest_bytes: 90,
         retained: vec![root(4), root(5)],
     };
-    reopened
-        .owe(alice, core::slice::from_ref(&aliased))
-        .await
-        .unwrap();
-    let after_reopen = open().await;
-    assert_eq!(
-        after_reopen
+    let held_of = async |ledger: &L, target: &str| {
+        ledger
             .owed(alice)
             .await
             .unwrap()
             .into_iter()
-            .find(|entry| entry.target == aliased.target),
+            .find(|entry| entry.target == target)
+    };
+    reopened
+        .owe(alice, &[owed(&aliased.target, 90), aliased.clone()])
+        .await
+        .unwrap();
+    assert_eq!(
+        held_of(&reopened, &aliased.target).await,
+        Some(aliased.clone()),
+        "a wider retained set replaces the entry it widens"
+    );
+    reopened
+        .owe(alice, &[owed(&aliased.target, 90)])
+        .await
+        .unwrap();
+    let after_reopen = open().await;
+    assert_eq!(
+        held_of(&after_reopen, &aliased.target).await,
         Some(aliased),
-        "an entry must survive reopen whole, retained set included"
+        "protection only ever widens, and survives reopen whole"
     );
 }

--- a/crates/engine/src/testkit/conformance/retire_ledger.rs
+++ b/crates/engine/src/testkit/conformance/retire_ledger.rs
@@ -1,7 +1,7 @@
 //! Conformance kit: [`RetireLedger`] owner scoping, set semantics, and
 //! durability.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use cipherbox_core::content::{compute_cid, encode_content_cid_str};
 
@@ -140,14 +140,14 @@ where
     assert_eq!(held(&reopened, alice).await.len(), 2);
 
     // The retained set is the only record of what an entry must not retire, so
-    // it is as durable as the figure beside it, and an entry that protects less
-    // never displaces one that protects more.
+    // it is as durable as the figure beside it, and protection only ever widens.
     let aliased = OwedRetire {
         target: root(3),
         owed_bytes: 11,
         manifest_bytes: 90,
         retained: vec![root(4), root(5)],
     };
+    // Retained order is not part of the contract, so the kit compares sets.
     let held_of = async |ledger: &L, target: &str| {
         ledger
             .owed(alice)
@@ -155,24 +155,63 @@ where
             .unwrap()
             .into_iter()
             .find(|entry| entry.target == target)
+            .map(|entry| {
+                (
+                    entry.owed_bytes,
+                    entry.manifest_bytes,
+                    BTreeSet::from_iter(entry.retained),
+                )
+            })
+    };
+    let merged = |owed_bytes, retained: &[String]| {
+        Some((
+            owed_bytes,
+            aliased.manifest_bytes,
+            BTreeSet::from_iter(retained.iter().cloned()),
+        ))
     };
     reopened
-        .owe(alice, &[owed(&aliased.target, 90), aliased.clone()])
+        .owe(
+            alice,
+            &[
+                owed(&aliased.target, aliased.manifest_bytes),
+                aliased.clone(),
+            ],
+        )
         .await
         .unwrap();
     assert_eq!(
         held_of(&reopened, &aliased.target).await,
-        Some(aliased.clone()),
-        "a wider retained set replaces the entry it widens"
+        merged(aliased.owed_bytes, &[root(4), root(5)]),
+        "a wider retained set widens the entry it merges into"
     );
     reopened
-        .owe(alice, &[owed(&aliased.target, 90)])
+        .owe(alice, &[owed(&aliased.target, aliased.manifest_bytes)])
+        .await
+        .unwrap();
+    assert_eq!(
+        held_of(&reopened, &aliased.target).await,
+        merged(aliased.owed_bytes, &[root(4), root(5)]),
+        "and a replay that protects nothing does not narrow it again"
+    );
+
+    // Two prunes of one target can protect non-comparable sets, and each is the
+    // only record that *its* survivors alias those bytes.
+    reopened
+        .owe(
+            alice,
+            &[OwedRetire {
+                owed_bytes: aliased.owed_bytes + 19,
+                retained: vec![root(6)],
+                ..aliased.clone()
+            }],
+        )
         .await
         .unwrap();
     let after_reopen = open().await;
     assert_eq!(
         held_of(&after_reopen, &aliased.target).await,
-        Some(aliased),
-        "protection only ever widens, and survives reopen whole"
+        merged(aliased.owed_bytes, &[root(4), root(5), root(6)]),
+        "a disjoint retained set merges rather than displacing, and survives reopen"
     );
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -7297,3 +7297,64 @@ fn a_doomed_root_naming_a_retained_versions_leaf_never_retires_that_leaf() {
         "the debt clears on the registry's own answer"
     );
 }
+
+/// A version whose root block no source will serve is authorable by anyone
+/// holding the scope's write seed, and the prune has to fetch it to know what
+/// the retire may name. An uncharged retry would let one such version hold the
+/// FIFO head — and every op queued behind it — forever.
+#[test]
+fn a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let body: Vec<u8> = (0..60u8).collect();
+    let file = file_with_history(&world, &mut engine, &mut tasks, &[body]);
+    let head = published_versions(&world.record_store, &blocks, file).remove(0);
+    let unserved = compute_cid(DAG_ROOT_CODEC, b"a root block no source ever stored");
+    plant_record(
+        &world.record_store,
+        &blocks,
+        file,
+        Planted {
+            node_id: file.0,
+            scope_id: SCOPE,
+            read_key: read_key_of(file),
+            body: &ReadBody::File {
+                created_at: 0,
+                modified_at: 0,
+                versions: vec![
+                    head,
+                    CoreVersion::new(
+                        unserved,
+                        [0u8; 32],
+                        ContentProfile::CI.chunk_size() as u64,
+                        0,
+                    ),
+                ],
+                unknown: PreservedFields::new(),
+            },
+        },
+    );
+    let retired_before = retire_targets(&alice).len();
+
+    stage_prune(&alice, &world, file, 1);
+    let (dead_letters, passes) = tick_until_dead_lettered(&world, &engine, &mut tasks);
+
+    assert!(passes > 1, "the budget is spent over several passes");
+    assert_eq!(
+        dead_letters
+            .iter()
+            .map(|letter| letter.reason)
+            .collect::<Vec<_>>(),
+        vec![DeadLetterReason::AttemptsExhausted]
+    );
+    assert_eq!(
+        retire_targets(&alice).len(),
+        retired_before,
+        "a prune that never expanded retires nothing"
+    );
+    assert_eq!(engine.pending_reclaim_bytes(), 0, "and journals no debt");
+}

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -25,9 +25,10 @@ use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
 use cipherbox_engine::api::REGISTRY_BATCH_REFUSED;
+use cipherbox_engine::content::chunk::SEALED_LEAF_OVERHEAD;
 use cipherbox_engine::content::{
     ByoIpfsConfig, ByoKind, DAG_ROOT_CODEC, GatewaySource, PinMode, RetentionPolicy, SealedChunk,
-    decode_root,
+    assemble, decode_root,
 };
 use cipherbox_engine::facade::PendingClass;
 use cipherbox_engine::net::OrphanHeads;
@@ -7196,4 +7197,103 @@ fn a_prune_whose_doomed_version_shares_a_surviving_cid_is_refused() {
         "and no retire names the CID a survivor still holds"
     );
     assert_eq!(engine.pending_reclaim_bytes(), 0);
+}
+
+/// A doomed root's link list is not this device's word for what that version
+/// holds: in a shared scope a write-grantee authors versions of its own, and
+/// their blocks register under the grantee's account until the owner syncs
+/// (blueprint/api.md "Pin/name registry"). A root that content-addresses
+/// correctly and whose link count matches the `size` it declares can therefore
+/// name the owner's own live leaves, which the registry's `(account, cid)` pin
+/// row would unpin under the owner's own token.
+#[test]
+fn a_doomed_root_naming_a_retained_versions_leaf_never_retires_that_leaf() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let body: Vec<u8> = (0..60u8).collect();
+    let file = file_with_history(&world, &mut engine, &mut tasks, &[body.clone()]);
+    let head = published_versions(&world.record_store, &blocks, file).remove(0);
+    let live_leaves = decode_root(
+        &blocks
+            .get(&encode_content_cid_str(&head.content_cid))
+            .expect("the head root block"),
+    )
+    .expect("a root manifest")
+    .leaf_cid_vecs();
+    assert!(
+        live_leaves.len() > 1,
+        "a multi-chunk head is the normal case"
+    );
+
+    // The planted root links the owner's first live leaf plus one block only the
+    // planted version names. Nothing about the block is malformed: it addresses
+    // to its own CID and declares a `size` its link count matches.
+    let chunk = ContentProfile::CI.chunk_size() as u64;
+    let hostage = live_leaves[0].clone();
+    let grantee_leaf = compute_cid(CONTENT_CID_CODEC, b"a block only the planted root names");
+    let planted = assemble(
+        &[hostage.clone(), grantee_leaf.clone()],
+        2 * chunk,
+        &ContentProfile::CI,
+    )
+    .expect("assembles");
+    let planted_root = blocks.put(planted.root_block.clone());
+    plant_record(
+        &world.record_store,
+        &blocks,
+        file,
+        Planted {
+            node_id: file.0,
+            scope_id: SCOPE,
+            read_key: read_key_of(file),
+            body: &ReadBody::File {
+                created_at: 0,
+                modified_at: 0,
+                versions: vec![
+                    head.clone(),
+                    CoreVersion::new(planted.content_cid.clone(), [0u8; 32], 2 * chunk, 0),
+                ],
+                unknown: PreservedFields::new(),
+            },
+        },
+    );
+
+    // With the registry down the debt stands unpaid, so the vault reports the
+    // figure the prune quoted itself.
+    blocks.refuse_retire(true);
+    stage_prune(&alice, &world, file, 1);
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(
+        engine.pending_reclaim_bytes(),
+        chunk + SEALED_LEAF_OVERHEAD + planted.root_block.len() as u64,
+        "the quote counts the planted block and the root, never the hostage leaf"
+    );
+
+    blocks.refuse_retire(false);
+    tick(&world, &engine, &mut tasks);
+
+    let retired = retire_targets(&alice);
+    assert!(
+        !retired.contains(&encode_content_cid_str(&hostage)),
+        "the leaf the retained head lives on is never retired"
+    );
+    assert!(
+        retired.contains(&encode_content_cid_str(&grantee_leaf)),
+        "the blocks the planted version really added still retire"
+    );
+    assert!(retired.contains(&planted_root), "and so does its own root");
+    assert_eq!(
+        block_on(engine.read_content(file)).expect("the head still reads"),
+        body,
+        "the retained version's bytes are still retrievable"
+    );
+    assert_eq!(
+        engine.pending_reclaim_bytes(),
+        0,
+        "the debt clears on the registry's own answer"
+    );
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -6979,6 +6979,32 @@ fn file_with_history(
     node
 }
 
+/// Republish `file`'s record over a version list this engine would not author —
+/// what a co-grantee holding the scope's write seed can put on the wire.
+fn plant_versions(world: &FakeWorld, blocks: &Blocks, file: NodeId, versions: Vec<CoreVersion>) {
+    plant_record(
+        &world.record_store,
+        blocks,
+        file,
+        Planted {
+            node_id: file.0,
+            scope_id: SCOPE,
+            read_key: read_key_of(file),
+            body: &ReadBody::File {
+                created_at: 0,
+                modified_at: 0,
+                versions,
+                unknown: PreservedFields::new(),
+            },
+        },
+    );
+}
+
+/// One such version, naming `content_cid` for `plaintext_bytes` of plaintext.
+fn planted_version(content_cid: &[u8], plaintext_bytes: u64) -> CoreVersion {
+    CoreVersion::new(content_cid.to_vec(), [0u8; 32], plaintext_bytes, 0)
+}
+
 /// Queue a prune of `file` against its currently published sequence.
 fn stage_prune(device: &FakeDevice, world: &FakeWorld, file: NodeId, keep_latest: u64) {
     let (sequence, _) = published(&world.record_store, file);
@@ -7242,24 +7268,14 @@ fn a_doomed_root_naming_a_retained_versions_leaf_never_retires_that_leaf() {
     )
     .expect("assembles");
     let planted_root = blocks.put(planted.root_block.clone());
-    plant_record(
-        &world.record_store,
+    plant_versions(
+        &world,
         &blocks,
         file,
-        Planted {
-            node_id: file.0,
-            scope_id: SCOPE,
-            read_key: read_key_of(file),
-            body: &ReadBody::File {
-                created_at: 0,
-                modified_at: 0,
-                versions: vec![
-                    head.clone(),
-                    CoreVersion::new(planted.content_cid.clone(), [0u8; 32], 2 * chunk, 0),
-                ],
-                unknown: PreservedFields::new(),
-            },
-        },
+        vec![
+            head.clone(),
+            planted_version(&planted.content_cid, 2 * chunk),
+        ],
     );
 
     // With the registry down the debt stands unpaid, so the vault reports the
@@ -7296,6 +7312,127 @@ fn a_doomed_root_naming_a_retained_versions_leaf_never_retires_that_leaf() {
         0,
         "the debt clears on the registry's own answer"
     );
+}
+
+/// The same adversarial authoring lets two *doomed* roots name one leaf. A pin
+/// row is keyed `(account, cid)`, so that leaf is a single row: charging it to
+/// both debts would over-quote the reclaim and hand the registry one CID under
+/// two entries.
+#[test]
+fn a_leaf_two_doomed_roots_share_is_charged_to_exactly_one_of_them() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let file = file_with_history(&world, &mut engine, &mut tasks, &[(0..60u8).collect()]);
+    let head = published_versions(&world.record_store, &blocks, file).remove(0);
+
+    // Two planted versions over one shared block, each with a block of its own.
+    let chunk = ContentProfile::CI.chunk_size() as u64;
+    let shared = compute_cid(CONTENT_CID_CODEC, b"a block both planted roots name");
+    let plant = |only_mine: &[u8]| {
+        let dag = assemble(
+            &[shared.clone(), compute_cid(CONTENT_CID_CODEC, only_mine)],
+            2 * chunk,
+            &ContentProfile::CI,
+        )
+        .expect("assembles");
+        blocks.put(dag.root_block.clone());
+        dag
+    };
+    let (older, newer) = (plant(b"only the older"), plant(b"only the newer"));
+    plant_versions(
+        &world,
+        &blocks,
+        file,
+        vec![
+            head,
+            planted_version(&newer.content_cid, 2 * chunk),
+            planted_version(&older.content_cid, 2 * chunk),
+        ],
+    );
+
+    blocks.refuse_retire(true);
+    stage_prune(&alice, &world, file, 1);
+    tick(&world, &engine, &mut tasks);
+    let leaf = chunk + SEALED_LEAF_OVERHEAD;
+    assert_eq!(
+        engine.pending_reclaim_bytes(),
+        3 * leaf + (older.root_block.len() + newer.root_block.len()) as u64,
+        "the shared block is quoted once, not once per doomed root"
+    );
+
+    blocks.refuse_retire(false);
+    tick(&world, &engine, &mut tasks);
+
+    let retired = retire_targets(&alice);
+    let shared_cid = encode_content_cid_str(&shared);
+    assert_eq!(
+        retired.iter().filter(|cid| **cid == shared_cid).count(),
+        1,
+        "one pin row is named by one retire"
+    );
+    for dag in [&older, &newer] {
+        assert!(
+            retired.contains(&encode_content_cid_str(&dag.content_cid)),
+            "both doomed roots still retire"
+        );
+    }
+    assert_eq!(engine.pending_reclaim_bytes(), 0);
+}
+
+/// Nothing on the wire forbids one `contentCid` appearing twice in a version
+/// list. The repeat is the same pin rows, so it owes nothing the first naming
+/// does not already carry — and charging it again would leave an entry
+/// protecting its own expansion key, which could never drain.
+#[test]
+fn a_root_a_history_names_twice_owes_one_debt_that_still_drains() {
+    let world = FakeWorld::new();
+    let blocks = Blocks::default();
+    seed_account(&world, &blocks);
+    let alice = world.device(b"alice");
+    let (mut engine, _events, mut tasks) = boot(&world, &blocks, &alice, 42);
+
+    let file = file_with_history(&world, &mut engine, &mut tasks, &[(0..60u8).collect()]);
+    let head = published_versions(&world.record_store, &blocks, file).remove(0);
+
+    let chunk = ContentProfile::CI.chunk_size() as u64;
+    let leaves: Vec<Vec<u8>> = [b"twice-a".as_slice(), b"twice-b".as_slice()]
+        .iter()
+        .map(|seed| compute_cid(CONTENT_CID_CODEC, seed))
+        .collect();
+    let planted = assemble(&leaves, 2 * chunk, &ContentProfile::CI).expect("assembles");
+    blocks.put(planted.root_block.clone());
+    let repeated = planted_version(&planted.content_cid, 2 * chunk);
+    plant_versions(
+        &world,
+        &blocks,
+        file,
+        vec![head, repeated.clone(), repeated],
+    );
+
+    blocks.refuse_retire(true);
+    stage_prune(&alice, &world, file, 1);
+    tick(&world, &engine, &mut tasks);
+    assert_eq!(
+        engine.pending_reclaim_bytes(),
+        2 * (chunk + SEALED_LEAF_OVERHEAD) + planted.root_block.len() as u64,
+        "the repeat quotes nothing of its own"
+    );
+
+    blocks.refuse_retire(false);
+    tick(&world, &engine, &mut tasks);
+
+    let retired = retire_targets(&alice);
+    for cid in leaves.iter().chain([&planted.content_cid]) {
+        assert!(
+            retired.contains(&encode_content_cid_str(cid)),
+            "the one debt still names its whole expansion"
+        );
+    }
+    assert_eq!(engine.pending_reclaim_bytes(), 0, "and clears");
 }
 
 /// A version whose root block no source will serve is authorable by anyone


### PR DESCRIPTION
## Why

A registry pin row is keyed `(account, cid)` and physical unpin fires at global refcount zero
(`blueprint/api.md` "Pin/name registry"). `expand_retire_targets` expands **one** doomed root and has
no view of the versions the prune retains, so it cannot subtract a leaf a retained version also
names. The guard already in `publish_prune` compares only root `contentCid`s — the aliasing is at
leaf level.

Honestly-authored versions cannot collide: `ContentKey::generate` mints a fresh per-version key and
`seal_one_chunk` draws a fresh nonce per chunk, so identical plaintext seals to different CIDs. The
reachable path crosses a privilege boundary. A write-grantee in a shared scope authors versions that
register under the grantee's account until the owner syncs, so it can publish a root whose `links`
name the owner's live leaves. That root content-addresses correctly and satisfies `decode_root`'s
`links.len() == ceil(size/chunkSize)` check for a `size` of its own choosing. The pinned-bytes bound
does not close it either: the grantee controls the `Version.size` the plan derives the quoted total
from, so it controls both sides of that equality. The owner's routine prune then retires the owner's
own live leaves under the owner's own token.

## What changed

**Subtraction at the prune op, not inside the expansion.** `Drain::prune_debt` expands every doomed
and every retained version off its own fetched root block — **ahead of the publish**, so a debt this
pass cannot compute leaves the history it read standing — and subtracts the union of the retained
expansions from each doomed target set. `OwedRetire` now carries the aliased targets plus the
manifest total the expansion is held to, so `retire_owed` skips them and the vault's pending-reclaim
figure is what the retire actually frees. The reclaim figure is re-summed over the surviving targets
rather than kept in the manifest's closed form, which is why `Expansion` now carries a per-target
byte figure: a subtracted leaf frees nothing.

`retire_owed` gained two fail-closed checks: the recomputed reduced total must equal the stored
figure, and the last target must still be the entry's own root (the expansion key).

**One CID-set derivation.** `registry_cids` (root-first, leaves from staging) and the retire
expansion (leaves-then-root, leaves from the fetched root block) were independent with nothing
holding the sets equal. Both now go through `version_cids`, with the ordering an explicit
`RootPlacement` argument **of the call** rather than a property of which function the caller reached.
`registry_cids` is gone; its two call sites name the placement themselves.

## Tests

- `a_doomed_root_naming_a_retained_versions_leaf_never_retires_that_leaf` (`tests/write_plane.rs`) —
  drives the adversarial shape end to end: a planted root that addresses correctly and whose link
  count matches its declared `size`, linking the owner's live first leaf plus one block of its own.
  Asserts the hostage leaf never reaches the registry, the planted version's own blocks still do, the
  retained version still reads back, and — with the registry down — that the quoted reclaim counts
  only the bytes it frees.
- `the_retire_expansion_names_exactly_what_registration_pinned` — the two derivations differ in order
  and agree as sets.
- `a_target_a_retained_version_also_names_is_never_retired`,
  `the_reclaim_figure_counts_only_the_targets_a_retire_still_names` — the pure subtraction.
- `a_retained_target_is_never_named_by_the_retire_that_carries_it`,
  `a_stored_entry_this_build_did_not_write_reads_as_nothing` — the ledger drain and its encoding.
- The `RetireLedger` conformance kit now pins the retained set as durable.

Every one was proven red with the production change reverted.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on this diff. Two live defects
came back and are fixed in the second commit:

- **An unfetchable root wedged the whole op queue.** `expand_version` mapped a `read_block` failure to
  `Halt::Unclassified`, which charges nothing. A version whose root no source will serve is authorable
  by anyone holding the scope's write seed, so one such version held the FIFO head — and every op
  behind it — forever. Charged as an upload attempt now, so the budget dead-letters it;
  `a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters` fires the 50-pass guard
  without the fix.
- **`RetireLedger::owe` could lose a retained set.** It skipped any target the store already held. One
  root `contentCid` can ride two nodes' histories, so a prune whose survivors alias those bytes could
  find a `retained: []` entry already journaled by an unrelated prune — re-introducing the class this
  PR fixes. An entry that protects less than the incoming one is now replaced whole, so protection
  only ever widens, and the conformance kit pins it.

The quality pass folded in too: `split_retained` states the retained predicate once and deduplicates
the held set (a manifest may repeat a link), `decode_entry` takes the target from the key instead of
echoing an argument, the pass-through `owe_retires`/`registry_cids` wrappers are inlined, the pin-row
rationale is stated once at its home, and `version_cids`/`RootPlacement` are off the crate-root
re-export.

`expand_retire_targets`' doc claimed its framing and pinned-bytes bounds kept a hand-framed root from
naming CIDs of its own choosing. They do not — the same author supplies the record `size` the plan
quotes from — so it now states what they actually bound and points at the subtraction.

## Residual, filed as #1176

The protected set is the pruned file's own surviving versions. A grantee can read another file's root
block off the gateway (they are keyless plaintext) and author a version whose `links` are *that*
file's live leaves; the same unpin follows, one indirection away. The set is also a snapshot taken at
prune time and consumed whenever the ledger drains. Closing both wants an account-wide live-CID view
the engine does not have, or a registry that reference-counts per referencing record — out of scope
for what #1124 asks. #1176 carries all of it, blocked by #1124.

## Notes for review

- A prune now fetches one root block per version in the file's history before publishing, and the
  doomed roots are fetched again at drain time. A manifest that cannot account for the total the plan
  quoted refuses the op permanently, the same verdict the shipped root-alias guard already gives, so a
  grantee can deny *reclaim* by planting an unexpandable version — fail-closed toward a leak, never
  loss. Tracked in #1176.
- `owe_retires`' publish-then-journal ordering is untouched.

Closes #1124
Closes #1125


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Subtract retained version targets before a prune journals retire debt
> - Before publishing a pruned record, `Drain::apply_prune` now calls a new `prune_debt()` method to compute retire debts; if debt cannot be computed, the prune is halted.
> - `prune_debt()` expands surviving versions to build a protected CID set, then for each doomed version subtracts retained targets and deduplicates shared roots across doomed versions to avoid double-charging shared leaves.
> - `Expansion` gains per-target byte accounting and a `minus_retained()` method; `expand_retire_targets` now returns per-target byte totals and rejects manifests whose per-target sum doesn't match the quoted total.
> - `drain_owed_retires` enforces that retirable bytes don't exceed `owed_bytes`, validates retained CIDs are a subset of the expansion, and defers instead of proceeding when constraints are violated.
> - Risk: prune publish attempts that previously succeeded when debt computation failed will now be deferred until debt can be computed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea1a5db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved content retirement to preserve shared content referenced by retained versions.
  - Ensured retirement processes content in the correct order and accurately accounts for reclaimable storage.
  - Improved handling of incomplete or invalid retirement records and retry scenarios.
  - Prevented failed pruning attempts from incorrectly creating reclaimable storage debt.

- **Reliability**
  - Improved tracking of retained content across restarts and repeated retirement operations.
  - More upload and retirement failures are now classified and charged consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->