### PR TITLE
feat: decide the Core Kit storage scope and gate its key set

### DIFF
--- a/apps/web/src/auth/coreKit.test.ts
+++ b/apps/web/src/auth/coreKit.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createCoreKitSession } from './coreKit';
 
+const STORE_KEY = 'corekit_store';
+
 // The SDK reaches for the Web3Auth network on construction; the seam is what
 // lets the persistence options it is handed be read back.
-const built = vi.hoisted(() => ({ options: [] as Record<string, unknown>[] }));
-vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@web3auth/mpc-core-kit')>()),
-  Web3AuthMPCCoreKit: class {
-    constructor(options: Record<string, unknown>) {
-      built.options.push(options);
-    }
-  },
-}));
+const built = vi.hoisted(() => ({ options: undefined as Record<string, unknown> | undefined }));
+vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@web3auth/mpc-core-kit')>();
+  return {
+    ...actual,
+    Web3AuthMPCCoreKit: class {
+      readonly _storageKey = STORE_KEY;
+      readonly status = actual.COREKIT_STATUS.LOGGED_IN;
+      constructor(options: Record<string, unknown>) {
+        built.options = options;
+      }
+      logout(): Promise<void> {
+        return Promise.resolve();
+      }
+    },
+  };
+});
 
 const ENV = {
   VITE_WEB3AUTH_CLIENT_ID: 'client-id',
@@ -22,15 +32,24 @@ describe('the Core Kit store', () => {
   it('persists origin-wide, so a tab that did not log in can still be promoted to leader', () => {
     createCoreKitSession(ENV);
 
-    expect(built.options.at(-1)?.storage).toBe(window.localStorage);
+    expect(built.options?.storage).toBe(window.localStorage);
   });
 
   it('caps how long a persisted session stays restorable, below the SDK default', () => {
     createCoreKitSession(ENV);
 
-    const sessionTime = built.options.at(-1)?.sessionTime;
-    expect(typeof sessionTime).toBe('number');
-    expect(sessionTime as number).toBeLessThan(86_400);
-    expect(sessionTime as number).toBeGreaterThan(0);
+    // The SDK restores its own 86400s default on a falsy value, so an upper
+    // bound alone would pass on `0`.
+    expect(built.options?.sessionTime).toBeGreaterThan(0);
+    expect(built.options?.sessionTime).toBeLessThan(86_400);
+  });
+
+  it('is cleared on logout, which the SDK leaves standing', async () => {
+    const session = createCoreKitSession(ENV);
+    window.localStorage.setItem(STORE_KEY, '{"sessionId":"a-session-id"}');
+
+    await session.logout();
+
+    expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/auth/coreKit.test.ts
+++ b/apps/web/src/auth/coreKit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCoreKitSession } from './coreKit';
+
+// The SDK reaches for the Web3Auth network on construction; the seam is what
+// lets the persistence options it is handed be read back.
+const built = vi.hoisted(() => ({ options: [] as Record<string, unknown>[] }));
+vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@web3auth/mpc-core-kit')>()),
+  Web3AuthMPCCoreKit: class {
+    constructor(options: Record<string, unknown>) {
+      built.options.push(options);
+    }
+  },
+}));
+
+const ENV = {
+  VITE_WEB3AUTH_CLIENT_ID: 'client-id',
+  VITE_WEB3AUTH_VERIFIER: 'verifier',
+} satisfies Partial<ImportMetaEnv>;
+
+describe('the Core Kit store', () => {
+  it('persists origin-wide, so a tab that did not log in can still be promoted to leader', () => {
+    createCoreKitSession(ENV);
+
+    expect(built.options.at(-1)?.storage).toBe(window.localStorage);
+  });
+
+  it('caps how long a persisted session stays restorable, below the SDK default', () => {
+    createCoreKitSession(ENV);
+
+    const sessionTime = built.options.at(-1)?.sessionTime;
+    expect(typeof sessionTime).toBe('number');
+    expect(sessionTime as number).toBeLessThan(86_400);
+    expect(sessionTime as number).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/auth/coreKit.test.ts
+++ b/apps/web/src/auth/coreKit.test.ts
@@ -1,23 +1,40 @@
-import { describe, expect, it, vi } from 'vitest';
+import { COREKIT_STATUS } from '@web3auth/mpc-core-kit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCoreKitSession } from './coreKit';
 
 const STORE_KEY = 'corekit_store';
 
 // The SDK reaches for the Web3Auth network on construction; the seam is what
-// lets the persistence options it is handed be read back.
-const built = vi.hoisted(() => ({ options: undefined as Record<string, unknown> | undefined }));
+// lets the persistence options it is handed be read back, and what drives the
+// login and logout outcomes a device can actually land in.
+const sdk = vi.hoisted(() => ({
+  options: undefined as Record<string, unknown> | undefined,
+  status: 'LOGGED_IN',
+  statusAfterLogin: 'LOGGED_IN',
+  logoutError: undefined as Error | undefined,
+  logoutCalls: 0,
+}));
 vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@web3auth/mpc-core-kit')>();
   return {
     ...actual,
     Web3AuthMPCCoreKit: class {
       readonly _storageKey = STORE_KEY;
-      readonly status = actual.COREKIT_STATUS.LOGGED_IN;
       constructor(options: Record<string, unknown>) {
-        built.options = options;
+        sdk.options = options;
+      }
+      get status(): string {
+        return sdk.status;
+      }
+      async loginWithOAuth(): Promise<void> {
+        sdk.status = sdk.statusAfterLogin;
+      }
+      commitChanges(): Promise<void> {
+        return Promise.resolve();
       }
       logout(): Promise<void> {
-        return Promise.resolve();
+        sdk.logoutCalls += 1;
+        return sdk.logoutError ? Promise.reject(sdk.logoutError) : Promise.resolve();
       }
     },
   };
@@ -28,20 +45,28 @@ const ENV = {
   VITE_WEB3AUTH_VERIFIER: 'verifier',
 } satisfies Partial<ImportMetaEnv>;
 
+const REFUSED = new Error('the session server is unreachable');
+
 describe('the Core Kit store', () => {
+  beforeEach(() => {
+    sdk.options = undefined;
+    sdk.status = COREKIT_STATUS.LOGGED_IN;
+    sdk.statusAfterLogin = COREKIT_STATUS.LOGGED_IN;
+    sdk.logoutError = undefined;
+    sdk.logoutCalls = 0;
+    window.localStorage.clear();
+  });
+
   it('persists origin-wide, so a tab that did not log in can still be promoted to leader', () => {
     createCoreKitSession(ENV);
 
-    expect(built.options?.storage).toBe(window.localStorage);
+    expect(sdk.options?.storage).toBe(window.localStorage);
   });
 
-  it('caps how long a persisted session stays restorable, below the SDK default', () => {
+  it('caps how long a persisted session stays restorable at eight hours', () => {
     createCoreKitSession(ENV);
 
-    // The SDK restores its own 86400s default on a falsy value, so an upper
-    // bound alone would pass on `0`.
-    expect(built.options?.sessionTime).toBeGreaterThan(0);
-    expect(built.options?.sessionTime).toBeLessThan(86_400);
+    expect(sdk.options?.sessionTime).toBe(28_800);
   });
 
   it('is cleared on logout, which the SDK leaves standing', async () => {
@@ -50,6 +75,40 @@ describe('the Core Kit store', () => {
 
     await session.logout();
 
+    expect(sdk.logoutCalls).toBe(1);
+    expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
+  });
+
+  it('is cleared when the SDK refuses to log out, and the refusal still surfaces', async () => {
+    const session = createCoreKitSession(ENV);
+    sdk.logoutError = REFUSED;
+    window.localStorage.setItem(STORE_KEY, '{"sessionId":"a-session-id"}');
+
+    await expect(session.logout()).rejects.toThrow(REFUSED);
+
+    expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
+  });
+
+  it('is cleared on a sign-out the SDK has no session to end', async () => {
+    const session = createCoreKitSession(ENV);
+    sdk.status = COREKIT_STATUS.NOT_INITIALIZED;
+    window.localStorage.setItem(STORE_KEY, '{"sessionId":"a-session-id"}');
+
+    await session.logout();
+
+    expect(sdk.logoutCalls).toBe(0);
+    expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
+  });
+
+  it('is cleared when a login stops short of a session and the rollback is refused', async () => {
+    const session = createCoreKitSession(ENV);
+    sdk.statusAfterLogin = COREKIT_STATUS.REQUIRED_SHARE;
+    sdk.logoutError = REFUSED;
+    window.localStorage.setItem(STORE_KEY, '{"sessionId":"a-session-id"}');
+
+    await expect(session.login('google')).rejects.toThrow(/needs approval or a recovery phrase/);
+
+    expect(sdk.logoutCalls).toBe(1);
     expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/auth/coreKit.ts
+++ b/apps/web/src/auth/coreKit.ts
@@ -34,6 +34,7 @@ export interface CoreKitSession extends LoginSecretExporter {
 class Web3AuthSession implements CoreKitSession {
   constructor(
     private readonly coreKit: Web3AuthMPCCoreKit,
+    private readonly store: Storage,
     private readonly verifier: string,
     private readonly clientId: string
   ) {}
@@ -74,7 +75,14 @@ class Web3AuthSession implements CoreKitSession {
   }
 
   async logout(): Promise<void> {
-    if (this.isLoggedIn()) await this.coreKit.logout();
+    try {
+      if (this.isLoggedIn()) await this.coreKit.logout();
+    } finally {
+      // The SDK's own logout blanks its session id in place and leaves the rest
+      // of its store standing — a device factor share among it, once MFA is
+      // reachable. A refused logout must not leave that behind either.
+      this.store.removeItem(this.coreKit._storageKey);
+    }
   }
 
   _UNSAFE_exportTssKey(): Promise<string> {
@@ -83,31 +91,33 @@ class Web3AuthSession implements CoreKitSession {
 }
 
 /**
- * How long a persisted Core Kit session stays restorable, well under the SDK's
- * 86400s default. The store below holds a session id that reconstitutes a
- * logged-in Core Kit, so this is the ceiling on how long a reader of the origin's
- * storage holds a path to the login secret — the storage scope cannot be that
- * ceiling, because the session has to be restorable in a tab that did not log in.
+ * Bounds two things at once, which is what sets the value: the Web3Auth-held
+ * session record the stored id redeems, and `session_token_exp_second` on the
+ * signatures a login secret re-export needs. So it has to outlast a working
+ * session — a tab past it cannot be promoted to leader — while still not
+ * surviving a night on a shared machine, which the SDK's 86400s default does.
  */
-const SESSION_SECONDS = 2 * 60 * 60;
+const SESSION_SECONDS = 8 * 60 * 60;
 
 /** Builds this tab's Core Kit session from the build-time environment. */
 export function createCoreKitSession(env: Partial<ImportMetaEnv>): CoreKitSession {
   const { clientId, verifier } = loginEnv(env);
+  // Origin-wide by decision, not by default: a tab promoted to leader re-exports
+  // the login secret from its own restored Core Kit session
+  // (`EngineClient.promote`), so a per-tab store would strand every tab that did
+  // not itself log in. What sits in it is a secp256k1 scalar that both addresses
+  // and decrypts a Web3Auth-held record holding the shares an export needs, so
+  // it is bearer key material and `SESSION_SECONDS` is its only other bound.
+  const store = window.localStorage;
 
   const coreKit = new Web3AuthMPCCoreKit({
     web3AuthClientId: clientId,
     web3AuthNetwork:
       environment(env) === 'production' ? WEB3AUTH_NETWORK.MAINNET : WEB3AUTH_NETWORK.DEVNET,
-    // Origin-wide by decision, not by default. A tab promoted to leader on
-    // failover re-exports the login secret from its own restored Core Kit
-    // session (`EngineClient.promote` in `packages/client`, which has no other
-    // source), so per-tab `sessionStorage` would leave every tab that did not
-    // itself log in unable to stand the engine up.
-    storage: window.localStorage,
+    storage: store,
     sessionTime: SESSION_SECONDS,
     manualSync: true,
     tssLib,
   });
-  return new Web3AuthSession(coreKit, verifier, clientId);
+  return new Web3AuthSession(coreKit, store, verifier, clientId);
 }

--- a/apps/web/src/auth/coreKit.ts
+++ b/apps/web/src/auth/coreKit.ts
@@ -61,6 +61,7 @@ class Web3AuthSession implements CoreKitSession {
       // device approval are not built yet, so fail rather than half-log-in, and
       // end the partial session rather than leave it resident on the device.
       await this.coreKit.logout().catch(() => undefined);
+      this.clearStore();
       throw new Error('this device needs approval or a recovery phrase before it can sign in');
     }
     await this.coreKit.commitChanges();
@@ -78,11 +79,17 @@ class Web3AuthSession implements CoreKitSession {
     try {
       if (this.isLoggedIn()) await this.coreKit.logout();
     } finally {
-      // The SDK's own logout blanks its session id in place and leaves the rest
-      // of its store standing — a device factor share among it, once MFA is
-      // reachable. A refused logout must not leave that behind either.
-      this.store.removeItem(this.coreKit._storageKey);
+      this.clearStore();
     }
+  }
+
+  /**
+   * The SDK's own logout blanks its session id in place and leaves the rest of
+   * its store standing — a device factor share among it, once MFA is reachable.
+   * So every path that ends a session, refused or partial, clears it here.
+   */
+  private clearStore(): void {
+    this.store.removeItem(this.coreKit._storageKey);
   }
 
   _UNSAFE_exportTssKey(): Promise<string> {

--- a/apps/web/src/auth/coreKit.ts
+++ b/apps/web/src/auth/coreKit.ts
@@ -82,6 +82,15 @@ class Web3AuthSession implements CoreKitSession {
   }
 }
 
+/**
+ * How long a persisted Core Kit session stays restorable, well under the SDK's
+ * 86400s default. The store below holds a session id that reconstitutes a
+ * logged-in Core Kit, so this is the ceiling on how long a reader of the origin's
+ * storage holds a path to the login secret — the storage scope cannot be that
+ * ceiling, because the session has to be restorable in a tab that did not log in.
+ */
+const SESSION_SECONDS = 2 * 60 * 60;
+
 /** Builds this tab's Core Kit session from the build-time environment. */
 export function createCoreKitSession(env: Partial<ImportMetaEnv>): CoreKitSession {
   const { clientId, verifier } = loginEnv(env);
@@ -90,11 +99,13 @@ export function createCoreKitSession(env: Partial<ImportMetaEnv>): CoreKitSessio
     web3AuthClientId: clientId,
     web3AuthNetwork:
       environment(env) === 'production' ? WEB3AUTH_NETWORK.MAINNET : WEB3AUTH_NETWORK.DEVNET,
-    // Core Kit persists its own device-factor share and session id here. The
-    // login secret is not among them — it only ever leaves this realm as the
-    // transferred buffer — but this store is a bearer path back to a logged-in
-    // Core Kit.
+    // Origin-wide by decision, not by default. A tab promoted to leader on
+    // failover re-exports the login secret from its own restored Core Kit
+    // session (`EngineClient.promote` in `packages/client`, which has no other
+    // source), so per-tab `sessionStorage` would leave every tab that did not
+    // itself log in unable to stand the engine up.
     storage: window.localStorage,
+    sessionTime: SESSION_SECONDS,
     manualSync: true,
     tssLib,
   });

--- a/tests/web-e2e/tests/smoke.spec.ts
+++ b/tests/web-e2e/tests/smoke.spec.ts
@@ -67,10 +67,10 @@ test('signing out returns the tab to the front door', async ({ page }) => {
 
 /**
  * The whole accepted key set: Core Kit's own store, which is the only one this
- * app hands out (`apps/web/src/auth/coreKit.ts`), and the log level a torus
- * dependency's logger writes on import.
+ * app hands out (`apps/web/src/auth/coreKit.ts`), and the log level `loglevel`
+ * writes on import, one key per named logger the torus dependencies build.
  */
-const ALLOWED_STORAGE_KEY = /^(loglevel|corekit_store$)/;
+const ALLOWED_STORAGE_KEY = /^(?:loglevel(?::[\w.-]+)?|corekit_store)$/;
 
 /**
  * This build carries no Web3Auth credentials, so Core Kit never constructs and

--- a/tests/web-e2e/tests/smoke.spec.ts
+++ b/tests/web-e2e/tests/smoke.spec.ts
@@ -64,3 +64,40 @@ test('signing out returns the tab to the front door', async ({ page }) => {
   await expect(new LoginPage(page).googleButton).toBeVisible();
   await expect(files.browser).toHaveCount(0);
 });
+
+/**
+ * Everything the origin is allowed to leave in Web Storage. Core Kit is the only
+ * thing this app gives a store to (`apps/web/src/auth/coreKit.ts`), and that store
+ * is a bearer path back to a logged-in session — so anything appearing beside it
+ * fails here rather than passing review.
+ *
+ * `loglevel` caches a log level per named logger at import time; it holds no
+ * session state.
+ */
+const ALLOWED_STORAGE_KEY = /^loglevel:/;
+
+/**
+ * Deliberately scoped to what the app itself persists: this build carries no
+ * Web3Auth credentials, so `createCoreKitSession` throws and Core Kit never
+ * constructs — the suite signs in through the introspection hook instead, and has
+ * no interactive session whose key set it could observe. What it gates is that the
+ * login flow, the cold start and a reload add nothing of their own beside it.
+ */
+test('a signed-in tab leaves nothing outside the storage allow-list', async ({ page }) => {
+  const vault = new VaultPage(page);
+
+  await vault.open();
+  await vault.coldStart();
+  await vault.settled();
+  // Nothing in the tab survives a reload in memory, so what answers afterwards is
+  // exactly what the flow persisted.
+  await vault.open();
+
+  const stored = await page.evaluate(() => ({
+    local: Object.keys(localStorage),
+    session: Object.keys(sessionStorage),
+  }));
+
+  expect(stored.local.filter((key) => !ALLOWED_STORAGE_KEY.test(key))).toEqual([]);
+  expect(stored.session).toEqual([]);
+});

--- a/tests/web-e2e/tests/smoke.spec.ts
+++ b/tests/web-e2e/tests/smoke.spec.ts
@@ -66,32 +66,23 @@ test('signing out returns the tab to the front door', async ({ page }) => {
 });
 
 /**
- * Everything the origin is allowed to leave in Web Storage. Core Kit is the only
- * thing this app gives a store to (`apps/web/src/auth/coreKit.ts`), and that store
- * is a bearer path back to a logged-in session — so anything appearing beside it
- * fails here rather than passing review.
- *
- * `loglevel` caches a log level per named logger at import time; it holds no
- * session state.
+ * The whole accepted key set: Core Kit's own store, which is the only one this
+ * app hands out (`apps/web/src/auth/coreKit.ts`), and the log level a torus
+ * dependency's logger writes on import.
  */
-const ALLOWED_STORAGE_KEY = /^loglevel:/;
+const ALLOWED_STORAGE_KEY = /^(loglevel|corekit_store$)/;
 
 /**
- * Deliberately scoped to what the app itself persists: this build carries no
- * Web3Auth credentials, so `createCoreKitSession` throws and Core Kit never
- * constructs — the suite signs in through the introspection hook instead, and has
- * no interactive session whose key set it could observe. What it gates is that the
- * login flow, the cold start and a reload add nothing of their own beside it.
+ * This build carries no Web3Auth credentials, so Core Kit never constructs and
+ * the suite signs in through the introspection hook — what this gates is that
+ * the login flow and cold start persist nothing of their own beside that set.
  */
-test('a signed-in tab leaves nothing outside the storage allow-list', async ({ page }) => {
+test('the login flow leaves nothing outside the storage allow-list', async ({ page }) => {
   const vault = new VaultPage(page);
 
   await vault.open();
   await vault.coldStart();
   await vault.settled();
-  // Nothing in the tab survives a reload in memory, so what answers afterwards is
-  // exactly what the flow persisted.
-  await vault.open();
 
   const stored = await page.evaluate(() => ({
     local: Object.keys(localStorage),


### PR DESCRIPTION
## The decision

Keep the Web3Auth Core Kit store **origin-wide** (`window.localStorage`), and bound the
window with an explicit `sessionTime` instead of the storage scope.

The issue's default was `sessionStorage`, on the reading that the one-leader tab model makes
cross-tab session restore moot. It does not. A follower tab that is promoted to leader
re-exports the login secret from **its own** restored Core Kit session, and that is the only
source there is:

- `packages/client/src/engineClient.ts` `promote()` → `provideFailoverSecret()` →
  `SecretSource.provideSecret()`, which throws outright without a source.
- `apps/web/src/engine/loginHandoff.ts` `LoginSecretSource.provideSecret` calls
  `_UNSAFE_exportTssKey()` on this tab's Core Kit; nothing else can answer, and the secret
  never crosses the BroadcastChannel.
- `apps/web/src/auth/CoreKitProvider.tsx` builds a session and calls `restore()` per tab, and
  `apps/web/src/auth/useAuth.ts` arms the secret source only after that tab's own handoff.

Under `sessionStorage`, any tab the user did not personally log in through (a bookmark, a
second window) restores nothing, renders signed out, and — worse — cannot stand the engine up
when the leader dies, so the promotion aborts and the origin loses its engine.

## The cost accepted

The store stays readable by any same-origin script for as long as it exists. The value in it
is a secp256k1 scalar that both addresses and decrypts a Web3Auth-held record carrying the
shares an export needs — bearer key material, not an opaque handle. `SESSION_SECONDS` is
therefore its only other bound, and it is now set deliberately.

`sessionTime` turned out to bound two things, which is what set the value: the held session
record's TTL, and `session_token_exp_second` on the signatures a re-export needs. Two hours
would have capped the *working session* at two hours — a mid-session failover promotion would
have failed, silently, over a UI still rendering signed in. Eight hours outlasts a working
day while still not surviving a night on a shared machine, which the SDK's 86400s default
does.

The remaining exposure — an offline-replayable capability in script-readable storage — wants a
sealed store under a non-extractable IndexedDB key. That is filed separately.

## Also in this diff

Core Kit's `logout()` blanks its session id **in place** and leaves the rest of its store
standing, including a device factor share once MFA is reachable. `Web3AuthSession.logout()`
now clears the store itself, on the refused path too.

## Gates

- Unit (`apps/web/src/auth/coreKit.test.ts`): the store is origin-wide, the session ceiling is
  truthy and under the SDK default — truthiness matters, because the SDK restores 86400s on a
  falsy value — and logout clears the store.
- web-e2e (`tests/web-e2e/tests/smoke.spec.ts`): a full login and cold start leave nothing in
  Web Storage outside the named allow-list. Deliberately scoped: the suite signs in through
  the introspection hook and this build carries no Web3Auth credentials, so Core Kit never
  constructs — what it gates is that nothing else in the app starts persisting. Proven red by
  adding one `localStorage.setItem` to the bundle.

The unit test is the gate on the storage decision itself; the e2e is the gate on anything new
appearing beside it.

Closes #913


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate Core Kit storage scope and clear store on session-ending paths
> - Sets `sessionTime` to 28,800 seconds (8 hours) on `Web3AuthMPCCoreKit` construction via a new `SESSION_SECONDS` constant.
> - Binds the SDK to `window.localStorage` for origin-wide storage scope.
> - Adds a `clearStore()` helper to `Web3AuthSession` that removes the SDK's persisted entry (keyed by `coreKit._storageKey`) from the provided `Storage` instance.
> - Store clearing now runs on all session-ending paths: logout (via `try/finally`), and failed/partial logins that don't reach `LOGGED_IN`.
> - Adds unit tests in [coreKit.test.ts](https://github.com/FSM1/cipher-box/pull/1174/files#diff-39bcb0066319d0b1d0d216d50e91fd818a967f7f26c00a2b45a9a1759ea9633f) and an e2e smoke test asserting only `corekit_store` and `loglevel` keys remain in storage after login.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39c5515.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved session persistence and restoration across browser restarts.
  * Sessions now remain active for up to eight hours before requiring renewal.
  * Logout reliably clears saved sign-in data, even if a sign-out request encounters an error.
  * Startup behavior now limits browser storage to approved authentication data and avoids unnecessary session storage entries.

* **Tests**
  * Added coverage for session persistence, restoration timing, logout cleanup, and storage behavior during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->