### PR TITLE
fix: bind the write wave re-seal to the authorized commitment and re-read the write-epoch floor

### DIFF
--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -756,8 +756,7 @@ pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     /// verifies: a write grantee inside the forgery window can republish the root
     /// carrying the **pre-revoke** set, and that record passes every gate stage.
     /// Minting the moved root's section from it would wrap the freshly minted
-    /// `writeScopeSeed` to the revokee — a permanent write-revocation bypass out
-    /// of a wave-bounded window.
+    /// `writeScopeSeed` to the revokee — a permanent write-revocation bypass.
     pub authorized_commitment: &'a GrantSetCommitment,
     /// Derives the scope pointer's name and its record signer (owner-only).
     pub owner_pointer_seed: &'a [u8; SECRET_LEN],
@@ -1221,9 +1220,9 @@ where
         &self,
         node: &RepublishedNode,
         plane: &RootPlane,
-        commitment: &GrantSetCommitment,
     ) -> Result<RemintedGrants, WritePublishError> {
         let ledger = &plane.write_body.grant_ledger;
+        let commitment = &plane.section.commitment;
         enforce_committed_ledger(commitment, ledger).map_err(|_| WritePublishError::Rejected)?;
         let old_name = commitment.ipns_name.as_slice();
         let new_name = node.new_name.as_str().as_bytes();
@@ -1278,20 +1277,6 @@ where
         Ok(reminted)
     }
 
-    /// Refuse, release-active (security rule 8), a root whose committed set is
-    /// not the one the rotation was authorized over
-    /// ([`WriteWaveNet::authorized_commitment`]).
-    ///
-    /// The gate owner-verifies the record's own commitment and binds it to the
-    /// name it was read at (`gate/adoption.rs` stage 2), so equality with it is
-    /// also what proves the authorized set is the owner's and names this root.
-    fn check_authorized(&self, plane: &RootPlane) -> Result<(), WritePublishError> {
-        if plane.section.commitment != *self.authorized_commitment {
-            return Err(WritePublishError::Rejected);
-        }
-        Ok(())
-    }
-
     /// The moved root's grant section, re-minted for the wave.
     ///
     /// The root's section is the only channel that carries `writeScopeSeed` to
@@ -1310,10 +1295,16 @@ where
         fresh_write_scope_seed: &[u8; SECRET_LEN],
         read_epoch: u64,
     ) -> Result<GrantSection, WritePublishError> {
-        self.check_authorized(plane)?;
-        let authorized = self.authorized_commitment;
-        let remint = self.remint_grants(node, plane, authorized)?;
-        let mut commitment = authorized.clone();
+        // Release-active (security rule 8). The gate owner-verifies the record's
+        // own committed set and binds it to the name it was read at
+        // (`gate/adoption.rs` stage 2), so equality with the authorized set is
+        // what proves the mint is the one the owner signed off on
+        // ([`WriteWaveNet::authorized_commitment`]).
+        if plane.section.commitment != *self.authorized_commitment {
+            return Err(WritePublishError::Rejected);
+        }
+        let remint = self.remint_grants(node, plane)?;
+        let mut commitment = plane.section.commitment.clone();
         commitment.ipns_name = node.new_name.as_str().as_bytes().to_vec();
         commitment.entries = remint.entries;
         let commitment_sig = sign_grant_set(self.owner, &commitment)
@@ -1398,21 +1389,7 @@ where
                     .write_scope_seed
                     .as_ref()
                     .ok_or(WritePublishError::Rejected)?;
-                if node.node_id != self.scope_id {
-                    return Err(WritePublishError::Rejected);
-                }
-                // The write floor is monotonic and any pointer consult can raise
-                // it while the wave runs, so the enumeration's snapshot
-                // (`plane.write_epoch`, the epoch the source body opened under) is
-                // a stale lower bound by now: re-read it here, the same way
-                // `OwnerRotationNet::check_publishable` does. Sealing the section
-                // at or below the live floor publishes a root whose write plane
-                // can never be reopened — including by the next rotation.
-                let write_floor = floor::write_epoch_floor(self.floors, &self.scope_id)
-                    .await
-                    .map_err(|_| WritePublishError::NotLanded)?
-                    .unwrap_or(0);
-                if node.write_epoch <= plane.write_epoch.max(write_floor) {
+                if node.node_id != self.scope_id || node.write_epoch <= plane.write_epoch {
                     return Err(WritePublishError::Rejected);
                 }
                 // Every re-minted tag binds `new_name`, and a write grantee
@@ -1420,6 +1397,18 @@ where
                 // name the published seed does not derive mints a set no grantee
                 // can ever self-locate.
                 if node.new_name != derive_write_name(fresh.as_bytes(), &node.node_id) {
+                    return Err(WritePublishError::Rejected);
+                }
+                // `plane.write_epoch` is the floor as the enumeration saw it, and
+                // the whole interior wave has run since. The floor is monotonic
+                // and any pointer consult raises it, so sealing against that
+                // snapshot can publish a section at or below the live floor —
+                // a write plane `open_write_body` can never reopen.
+                let write_floor = floor::write_epoch_floor(self.floors, &self.scope_id)
+                    .await
+                    .map_err(|_| WritePublishError::NotLanded)?
+                    .ok_or(WritePublishError::NotLanded)?;
+                if node.write_epoch <= write_floor {
                     return Err(WritePublishError::Rejected);
                 }
                 let section = self.reseal_root(node, &plane, fresh.as_bytes(), read_epoch)?;
@@ -3173,17 +3162,14 @@ mod tests {
         SeededEntropy,
     >;
 
-    /// The committed set a wave is authorized over, owned by the test so the net
-    /// can borrow it. A staged root hands its own section's set (the happy path,
-    /// where the owner authorized exactly what the wave then re-reads); a test
-    /// that republishes no root builds one over the pre-wave root name.
-    fn plan_over(root_name: &IpnsName, entries: Vec<GrantSetEntry>) -> GrantSetCommitment {
+    /// A stand-in authorized set for a wave whose test republishes no root: only
+    /// the root re-seal reads it, and it matches no record, so a test that grows
+    /// a root publish fails loudly rather than passing on a fabricated plan.
+    fn no_root_plan() -> GrantSetCommitment {
         GrantSetCommitment {
-            ipns_name: root_name.as_str().as_bytes().to_vec(),
-            owner_pseudonym_pk: Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED)
-                .verifying_key()
-                .to_bytes(),
-            entries,
+            ipns_name: Vec::new(),
+            owner_pseudonym_pk: [0u8; 32],
+            entries: Vec::new(),
             unknown: PreservedFields::new(),
         }
     }
@@ -3347,7 +3333,7 @@ mod tests {
 
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
 
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
@@ -3397,8 +3383,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
 
         // Child-first, root last — exactly the wave's own order.
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
@@ -3449,8 +3434,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
         block_on(net.republish(&leaf)).expect("leaf");
         let moved = order(SCOPE, &root.name, one_child(leaf_id, &leaf.new_name), true);
@@ -3610,8 +3594,7 @@ mod tests {
         );
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3648,8 +3631,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
         block_on(net.republish(&leaf)).expect("leaf");
         let mid = order(mid_id, &mid_old, one_child(leaf_id, &leaf.new_name), false);
@@ -3687,8 +3669,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3752,8 +3733,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3807,8 +3787,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3843,8 +3822,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         assert_eq!(
             block_on(net.republish(&moved)),
@@ -3866,8 +3844,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3909,8 +3886,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let mut moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         // The name and its record signer still agree; only the seed the section
         // hands out no longer derives them.
@@ -3936,8 +3912,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         assert_eq!(
             block_on(net.republish(&moved)),
@@ -3959,8 +3934,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         assert_eq!(
             block_on(net.republish(&moved)),
@@ -3971,12 +3945,9 @@ mod tests {
 
     #[test]
     fn the_wave_refuses_a_root_whose_committed_set_diverges_from_the_owner_plan_release_active() {
-        // A grant-set commitment is epoch-free, so a write grantee inside the
-        // forgery window can republish the root carrying the PRE-REVOKE set and
-        // every gate stage still passes it. Re-minting off that set would wrap the
-        // freshly minted `writeScopeSeed` into a blob for the revokee — a
-        // permanent write-revocation bypass out of a wave-bounded window. The
-        // refusal is a runtime `Err`, never a debug_assert. Active in release.
+        // The staged record carries the PRE-REVOKE set, which the owner's plan
+        // dropped the write grant from — the replay
+        // [`WriteWaveNet::authorized_commitment`] exists to refuse. Release-active.
         let harness = Harness::plain();
         let root = granted_root(Vec::new());
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
@@ -3987,26 +3958,14 @@ mod tests {
             root.name.as_str().as_bytes(),
         )
         .expect("a contributory sharer key");
-        assert!(
-            root.grant_section
-                .commitment
-                .entries
-                .iter()
-                .any(|e| e.tag == revokee),
+        let mut plan = root.grant_section.commitment.clone();
+        plan.entries.retain(|e| e.tag != revokee);
+        assert_ne!(
+            plan.entries.len(),
+            root.grant_section.commitment.entries.len(),
             "the record still carries the write grant this rotation is cutting",
         );
 
-        // What the owner authorized: the same set with that grant removed.
-        let plan = plan_over(
-            &root.name,
-            root.grant_section
-                .commitment
-                .entries
-                .iter()
-                .filter(|e| e.tag != revokee)
-                .cloned()
-                .collect(),
-        );
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
@@ -4043,8 +4002,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         block_on(net.resolve_node(&SCOPE)).expect("the enumeration gates and parks the root");
 
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
@@ -4084,8 +4042,7 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
 
         // A root order the publisher refuses *after* the gated read: no fresh
         // write scope seed means the section cannot be re-minted.
@@ -4118,7 +4075,7 @@ mod tests {
         let current = stage_node(&harness, node_id, &folder(Vec::new()));
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
 
         let stray = derive_write_name(&FRESH_WRITE_SCOPE_SEED, &[0x1b; 16]);
@@ -4142,7 +4099,7 @@ mod tests {
 
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
         block_on(net.republish(&order(node_id, &current, BTreeMap::new(), false)))
             .expect("republish");
@@ -4161,7 +4118,7 @@ mod tests {
         let harness = Harness::plain();
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
         let interior = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &[0x3a; 16]);
 
@@ -4177,7 +4134,7 @@ mod tests {
         let harness = Harness::plain();
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
         let block = b"a-sealed-repoint-object".to_vec();
 
@@ -4219,7 +4176,7 @@ mod tests {
         let harness = Harness::plain();
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
         for channel in [RepointChannel::Mailbox, RepointChannel::Tombstone] {
             assert_eq!(
@@ -4236,7 +4193,7 @@ mod tests {
         let current = stage_node(&harness, node_id, &folder(Vec::new()));
         let owner = owner_identity();
         let current_root = old_root_name();
-        let plan = plan_over(&current_root, Vec::new());
+        let plan = no_root_plan();
         let net = wave(&harness, &owner, &current_root, &plan);
         let node = order(node_id, &current, BTreeMap::new(), false);
 
@@ -4371,8 +4328,12 @@ mod tests {
         let harness = Harness::plain();
         let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let plan = staged.root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &staged.root.name, &plan);
+        let net = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
 
         let resolved = block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
         assert_eq!(
@@ -4414,8 +4375,12 @@ mod tests {
             ]
         });
         let owner = owner_identity();
-        let plan = staged.root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &staged.root.name, &plan);
+        let net = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
 
         assert_eq!(
             block_on(net.resolve_node(&SCOPE)),
@@ -4430,8 +4395,12 @@ mod tests {
         let harness = Harness::plain();
         let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let plan = staged.root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &staged.root.name, &plan);
+        let net = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
 
         assert_eq!(
             block_on(net.resolve_node(&[0xee; 16])),
@@ -4451,8 +4420,7 @@ mod tests {
             Vec::new(),
         );
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
 
         block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
         assert_eq!(
@@ -4469,8 +4437,7 @@ mod tests {
         // transplant the child gate refuses.
         let root = staged_root(&harness, vec![ref_to(MID, &served)], Vec::new());
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let mut entropy = SeededEntropy::new(13);
 
         let error = block_on(rotate_scope_write(
@@ -4504,8 +4471,7 @@ mod tests {
         let unserved = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &LEAF);
         let root = staged_root(&harness, vec![ref_to(LEAF, &unserved)], Vec::new());
         let owner = owner_identity();
-        let plan = root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &root.name, &plan);
+        let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let mut entropy = SeededEntropy::new(13);
 
         let error = block_on(rotate_scope_write(
@@ -4534,8 +4500,12 @@ mod tests {
         let harness = Harness::plain();
         let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let plan = staged.root.grant_section.commitment.clone();
-        let net = wave(&harness, &owner, &staged.root.name, &plan);
+        let net = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
         let mut entropy = SeededEntropy::new(13);
 
         let outcome = block_on(rotate_scope_write(
@@ -4616,15 +4586,24 @@ mod tests {
         let staged = staged_scope(&harness);
         let owner = owner_identity();
 
-        let plan = staged.root.grant_section.commitment.clone();
-        let first = wave(&harness, &owner, &staged.root.name, &plan);
+        let first = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
         let before: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
             .into_iter()
             .map(|id| block_on(first.resolve_node(&id)).expect("the first pass enumerates"))
             .collect();
         drop(first);
 
-        let resumed = wave(&harness, &owner, &staged.root.name, &plan);
+        let resumed = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
         let after: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
             .into_iter()
             .map(|id| block_on(resumed.resolve_node(&id)).expect("the resumed pass enumerates"))

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -1221,8 +1221,16 @@ where
         node: &RepublishedNode,
         plane: &RootPlane,
     ) -> Result<RemintedGrants, WritePublishError> {
+        // Release-active (security rule 8). The gate owner-verifies the record's
+        // own committed set and binds it to the name it was read at
+        // (`gate/adoption.rs` stage 2), so equality with the authorized set is
+        // what proves the mint runs off the owner's own attestation
+        // ([`WriteWaveNet::authorized_commitment`]).
+        if plane.section.commitment != *self.authorized_commitment {
+            return Err(WritePublishError::Rejected);
+        }
+        let commitment = self.authorized_commitment;
         let ledger = &plane.write_body.grant_ledger;
-        let commitment = &plane.section.commitment;
         enforce_committed_ledger(commitment, ledger).map_err(|_| WritePublishError::Rejected)?;
         let old_name = commitment.ipns_name.as_slice();
         let new_name = node.new_name.as_str().as_bytes();
@@ -1295,16 +1303,8 @@ where
         fresh_write_scope_seed: &[u8; SECRET_LEN],
         read_epoch: u64,
     ) -> Result<GrantSection, WritePublishError> {
-        // Release-active (security rule 8). The gate owner-verifies the record's
-        // own committed set and binds it to the name it was read at
-        // (`gate/adoption.rs` stage 2), so equality with the authorized set is
-        // what proves the mint is the one the owner signed off on
-        // ([`WriteWaveNet::authorized_commitment`]).
-        if plane.section.commitment != *self.authorized_commitment {
-            return Err(WritePublishError::Rejected);
-        }
         let remint = self.remint_grants(node, plane)?;
-        let mut commitment = plane.section.commitment.clone();
+        let mut commitment = self.authorized_commitment.clone();
         commitment.ipns_name = node.new_name.as_str().as_bytes().to_vec();
         commitment.entries = remint.entries;
         let commitment_sig = sign_grant_set(self.owner, &commitment)
@@ -1401,14 +1401,16 @@ where
                 }
                 // `plane.write_epoch` is the floor as the enumeration saw it, and
                 // the whole interior wave has run since. The floor is monotonic
-                // and any pointer consult raises it, so sealing against that
-                // snapshot can publish a section at or below the live floor —
-                // a write plane `open_write_body` can never reopen.
+                // and rises on any pointer consult, so a floor above that
+                // snapshot means another device's re-point superseded the record
+                // this wave is carrying forward — and sealing against the
+                // snapshot would publish a section at or below the live floor,
+                // a write plane `open_write_body` could never reopen.
                 let write_floor = floor::write_epoch_floor(self.floors, &self.scope_id)
                     .await
                     .map_err(|_| WritePublishError::NotLanded)?
                     .ok_or(WritePublishError::NotLanded)?;
-                if node.write_epoch <= write_floor {
+                if write_floor > plane.write_epoch {
                     return Err(WritePublishError::Rejected);
                 }
                 let section = self.reseal_root(node, &plane, fresh.as_bytes(), read_epoch)?;
@@ -3984,9 +3986,10 @@ mod tests {
         // The enumeration reads the root first and parks it, so the whole
         // child-first wave runs before the root republishes — and a concurrent
         // focus-window tick observing another device's re-point raises the
-        // monotonic write floor in between. Sealing the section at or below the
-        // live floor publishes a root whose write plane `open_write_body` can
-        // never reopen, including for the next rotation.
+        // monotonic write floor in between. Both sides of that rise are refused:
+        // the one the wave's own epoch still clears, where the parked record has
+        // silently been superseded, and the one that would seal the section at or
+        // below the live floor, where `open_write_body` could never reopen it.
         let harness = Harness::plain();
         let root = owner_root_fixture(OwnerRootSpec {
             owner_identity: &owner_identity(),
@@ -4005,6 +4008,21 @@ mod tests {
         let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         block_on(net.resolve_node(&SCOPE)).expect("the enumeration gates and parks the root");
 
+        let mut ahead = order(SCOPE, &root.name, BTreeMap::new(), true);
+        ahead.write_epoch = OWNER_ROOT_EPOCH + 2;
+        block_on(floor::advance_write_epoch_on_sight(
+            &harness.floors,
+            &SCOPE,
+            OWNER_ROOT_EPOCH + 1,
+        ))
+        .expect("the floor rise lands");
+        assert_eq!(
+            block_on(net.republish(&ahead)),
+            Err(WritePublishError::Rejected),
+            "a floor above the parked snapshot refuses even at an epoch it clears",
+        );
+        assert!(!published_at(&harness, &ahead.new_name));
+
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(floor::advance_write_epoch_on_sight(
             &harness.floors,
@@ -4012,7 +4030,6 @@ mod tests {
             moved.write_epoch,
         ))
         .expect("the floor rise lands");
-
         assert_eq!(
             block_on(net.republish(&moved)),
             Err(WritePublishError::Rejected),

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -19,9 +19,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
-    AadContext, ChildScopeRef, Envelope, GrantLedgerEntry, GrantSection, GrantSetEntry,
-    PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY, WriteBody,
-    decode_write_body, open_owner_blob, sign_grant_set, unseal,
+    AadContext, ChildScopeRef, Envelope, GrantLedgerEntry, GrantSection, GrantSetCommitment,
+    GrantSetEntry, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY,
+    WriteBody, decode_write_body, open_owner_blob, sign_grant_set, unseal,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -748,6 +748,17 @@ pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     /// The two per-scope derivations the root's re-seal needs, and no wider
     /// capability (the same narrowing [`OwnerRotationKeys`] makes).
     pub scope_keys: &'a dyn OwnerScopeKeys,
+    /// The owner-signed committed set the rotation was authorized over
+    /// (`RotateScopeWritePlan::commitment`) — what the root's re-seal binds to,
+    /// never the set carried by the record the wave re-reads.
+    ///
+    /// A grant-set commitment is epoch-free, so an older owner-signed one still
+    /// verifies: a write grantee inside the forgery window can republish the root
+    /// carrying the **pre-revoke** set, and that record passes every gate stage.
+    /// Minting the moved root's section from it would wrap the freshly minted
+    /// `writeScopeSeed` to the revokee — a permanent write-revocation bypass out
+    /// of a wave-bounded window.
+    pub authorized_commitment: &'a GrantSetCommitment,
     /// Derives the scope pointer's name and its record signer (owner-only).
     pub owner_pointer_seed: &'a [u8; SECRET_LEN],
     /// The root name the wave is moving off. It lingers serving the tombstone, so
@@ -1210,19 +1221,14 @@ where
         &self,
         node: &RepublishedNode,
         plane: &RootPlane,
+        commitment: &GrantSetCommitment,
     ) -> Result<RemintedGrants, WritePublishError> {
         let ledger = &plane.write_body.grant_ledger;
-        enforce_committed_ledger(&plane.section.commitment, ledger)
-            .map_err(|_| WritePublishError::Rejected)?;
-        let old_name = plane.section.commitment.ipns_name.as_slice();
+        enforce_committed_ledger(commitment, ledger).map_err(|_| WritePublishError::Rejected)?;
+        let old_name = commitment.ipns_name.as_slice();
         let new_name = node.new_name.as_str().as_bytes();
-        let carried: BTreeMap<[u8; 32], &GrantSetEntry> = plane
-            .section
-            .commitment
-            .entries
-            .iter()
-            .map(|e| (e.tag, e))
-            .collect();
+        let carried: BTreeMap<[u8; 32], &GrantSetEntry> =
+            commitment.entries.iter().map(|e| (e.tag, e)).collect();
 
         let mut reminted = RemintedGrants {
             entries: Vec::with_capacity(ledger.len()),
@@ -1272,6 +1278,20 @@ where
         Ok(reminted)
     }
 
+    /// Refuse, release-active (security rule 8), a root whose committed set is
+    /// not the one the rotation was authorized over
+    /// ([`WriteWaveNet::authorized_commitment`]).
+    ///
+    /// The gate owner-verifies the record's own commitment and binds it to the
+    /// name it was read at (`gate/adoption.rs` stage 2), so equality with it is
+    /// also what proves the authorized set is the owner's and names this root.
+    fn check_authorized(&self, plane: &RootPlane) -> Result<(), WritePublishError> {
+        if plane.section.commitment != *self.authorized_commitment {
+            return Err(WritePublishError::Rejected);
+        }
+        Ok(())
+    }
+
     /// The moved root's grant section, re-minted for the wave.
     ///
     /// The root's section is the only channel that carries `writeScopeSeed` to
@@ -1290,8 +1310,10 @@ where
         fresh_write_scope_seed: &[u8; SECRET_LEN],
         read_epoch: u64,
     ) -> Result<GrantSection, WritePublishError> {
-        let remint = self.remint_grants(node, plane)?;
-        let mut commitment = plane.section.commitment.clone();
+        self.check_authorized(plane)?;
+        let authorized = self.authorized_commitment;
+        let remint = self.remint_grants(node, plane, authorized)?;
+        let mut commitment = authorized.clone();
         commitment.ipns_name = node.new_name.as_str().as_bytes().to_vec();
         commitment.entries = remint.entries;
         let commitment_sig = sign_grant_set(self.owner, &commitment)
@@ -1376,10 +1398,21 @@ where
                     .write_scope_seed
                     .as_ref()
                     .ok_or(WritePublishError::Rejected)?;
-                // The write floor is monotonic and the re-point raises it to
-                // `node.write_epoch`; sealing the section at or below the floor
-                // publishes a root whose write plane can never be reopened.
-                if node.write_epoch <= plane.write_epoch || node.node_id != self.scope_id {
+                if node.node_id != self.scope_id {
+                    return Err(WritePublishError::Rejected);
+                }
+                // The write floor is monotonic and any pointer consult can raise
+                // it while the wave runs, so the enumeration's snapshot
+                // (`plane.write_epoch`, the epoch the source body opened under) is
+                // a stale lower bound by now: re-read it here, the same way
+                // `OwnerRotationNet::check_publishable` does. Sealing the section
+                // at or below the live floor publishes a root whose write plane
+                // can never be reopened — including by the next rotation.
+                let write_floor = floor::write_epoch_floor(self.floors, &self.scope_id)
+                    .await
+                    .map_err(|_| WritePublishError::NotLanded)?
+                    .unwrap_or(0);
+                if node.write_epoch <= plane.write_epoch.max(write_floor) {
                     return Err(WritePublishError::Rejected);
                 }
                 // Every re-minted tag binds `new_name`, and a write grantee
@@ -3140,10 +3173,26 @@ mod tests {
         SeededEntropy,
     >;
 
+    /// The committed set a wave is authorized over, owned by the test so the net
+    /// can borrow it. A staged root hands its own section's set (the happy path,
+    /// where the owner authorized exactly what the wave then re-reads); a test
+    /// that republishes no root builds one over the pre-wave root name.
+    fn plan_over(root_name: &IpnsName, entries: Vec<GrantSetEntry>) -> GrantSetCommitment {
+        GrantSetCommitment {
+            ipns_name: root_name.as_str().as_bytes().to_vec(),
+            owner_pseudonym_pk: Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED)
+                .verifying_key()
+                .to_bytes(),
+            entries,
+            unknown: PreservedFields::new(),
+        }
+    }
+
     fn wave<'a, T: RecordTransport + Clone>(
         harness: &'a Harness<T>,
         owner: &'a EcdsaSigner,
         current_root: &'a IpnsName,
+        plan: &'a GrantSetCommitment,
     ) -> Wave<'a, T> {
         WriteWaveNet {
             transport: &harness.transport,
@@ -3160,6 +3209,7 @@ mod tests {
             owner,
             owner_enc_secret: &harness.enc_secret,
             scope_keys: &WaveSeeds,
+            authorized_commitment: plan,
             gated_root: GatedWaveRoot::default(),
             subtree: WaveSubtree::default(),
             owner_pointer_seed: &OWNER_POINTER_SEED,
@@ -3297,7 +3347,8 @@ mod tests {
 
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
 
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
         block_on(net.republish(&leaf)).expect("the leaf republishes");
@@ -3346,7 +3397,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
 
         // Child-first, root last — exactly the wave's own order.
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
@@ -3397,7 +3449,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
         block_on(net.republish(&leaf)).expect("leaf");
         let moved = order(SCOPE, &root.name, one_child(leaf_id, &leaf.new_name), true);
@@ -3557,7 +3610,8 @@ mod tests {
         );
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3594,7 +3648,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let leaf = order(leaf_id, &leaf_old, BTreeMap::new(), false);
         block_on(net.republish(&leaf)).expect("leaf");
         let mid = order(mid_id, &mid_old, one_child(leaf_id, &leaf.new_name), false);
@@ -3632,7 +3687,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3696,7 +3752,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3750,7 +3807,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3785,7 +3843,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         assert_eq!(
             block_on(net.republish(&moved)),
@@ -3807,7 +3866,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         block_on(net.republish(&moved)).expect("the root moves");
 
@@ -3849,7 +3909,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let mut moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         // The name and its record signer still agree; only the seed the section
         // hands out no longer derives them.
@@ -3875,7 +3936,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         assert_eq!(
             block_on(net.republish(&moved)),
@@ -3897,11 +3959,106 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
         assert_eq!(
             block_on(net.republish(&moved)),
             Err(WritePublishError::Rejected)
+        );
+        assert!(!published_at(&harness, &moved.new_name));
+    }
+
+    #[test]
+    fn the_wave_refuses_a_root_whose_committed_set_diverges_from_the_owner_plan_release_active() {
+        // A grant-set commitment is epoch-free, so a write grantee inside the
+        // forgery window can republish the root carrying the PRE-REVOKE set and
+        // every gate stage still passes it. Re-minting off that set would wrap the
+        // freshly minted `writeScopeSeed` into a blob for the revokee — a
+        // permanent write-revocation bypass out of a wave-bounded window. The
+        // refusal is a runtime `Err`, never a debug_assert. Active in release.
+        let harness = Harness::plain();
+        let root = granted_root(Vec::new());
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+
+        let revokee = recipient_blinded_tag(
+            &write_grantee(),
+            &owner_enc().public(),
+            root.name.as_str().as_bytes(),
+        )
+        .expect("a contributory sharer key");
+        assert!(
+            root.grant_section
+                .commitment
+                .entries
+                .iter()
+                .any(|e| e.tag == revokee),
+            "the record still carries the write grant this rotation is cutting",
+        );
+
+        // What the owner authorized: the same set with that grant removed.
+        let plan = plan_over(
+            &root.name,
+            root.grant_section
+                .commitment
+                .entries
+                .iter()
+                .filter(|e| e.tag != revokee)
+                .cloned()
+                .collect(),
+        );
+        let owner = owner_identity();
+        let net = wave(&harness, &owner, &root.name, &plan);
+        let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
+        assert_eq!(
+            block_on(net.republish(&moved)),
+            Err(WritePublishError::Rejected)
+        );
+        assert!(
+            !published_at(&harness, &moved.new_name),
+            "nothing is published, so the revokee never receives a re-minted blob",
+        );
+    }
+
+    #[test]
+    fn a_write_floor_rise_before_the_root_republish_refuses_the_seal() {
+        // The enumeration reads the root first and parks it, so the whole
+        // child-first wave runs before the root republishes — and a concurrent
+        // focus-window tick observing another device's re-point raises the
+        // monotonic write floor in between. Sealing the section at or below the
+        // live floor publishes a root whose write plane `open_write_body` can
+        // never reopen, including for the next rotation.
+        let harness = Harness::plain();
+        let root = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &owner_identity(),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children: Vec::new(),
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            grants: Vec::new(),
+        });
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+
+        let owner = owner_identity();
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
+        block_on(net.resolve_node(&SCOPE)).expect("the enumeration gates and parks the root");
+
+        let moved = order(SCOPE, &root.name, BTreeMap::new(), true);
+        block_on(floor::advance_write_epoch_on_sight(
+            &harness.floors,
+            &SCOPE,
+            moved.write_epoch,
+        ))
+        .expect("the floor rise lands");
+
+        assert_eq!(
+            block_on(net.republish(&moved)),
+            Err(WritePublishError::Rejected),
+            "the seal is refused against the live floor, not the parked snapshot",
         );
         assert!(!published_at(&harness, &moved.new_name));
     }
@@ -3927,7 +4084,8 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
 
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
 
         // A root order the publisher refuses *after* the gated read: no fresh
         // write scope seed means the section cannot be re-minted.
@@ -3960,7 +4118,8 @@ mod tests {
         let current = stage_node(&harness, node_id, &folder(Vec::new()));
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
 
         let stray = derive_write_name(&FRESH_WRITE_SCOPE_SEED, &[0x1b; 16]);
         let bogus = order(node_id, &current, one_child([0x1b; 16], &stray), false);
@@ -3983,7 +4142,8 @@ mod tests {
 
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
         block_on(net.republish(&order(node_id, &current, BTreeMap::new(), false)))
             .expect("republish");
 
@@ -4001,7 +4161,8 @@ mod tests {
         let harness = Harness::plain();
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
         let interior = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &[0x3a; 16]);
 
         assert_eq!(
@@ -4016,7 +4177,8 @@ mod tests {
         let harness = Harness::plain();
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
         let block = b"a-sealed-repoint-object".to_vec();
 
         block_on(net.publish_repoint(RepointChannel::ScopePointer, &block))
@@ -4057,7 +4219,8 @@ mod tests {
         let harness = Harness::plain();
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
         for channel in [RepointChannel::Mailbox, RepointChannel::Tombstone] {
             assert_eq!(
                 block_on(net.publish_repoint(channel, b"block")),
@@ -4073,7 +4236,8 @@ mod tests {
         let current = stage_node(&harness, node_id, &folder(Vec::new()));
         let owner = owner_identity();
         let current_root = old_root_name();
-        let net = wave(&harness, &owner, &current_root);
+        let plan = plan_over(&current_root, Vec::new());
+        let net = wave(&harness, &owner, &current_root, &plan);
         let node = order(node_id, &current, BTreeMap::new(), false);
 
         assert!(!block_on(net.is_republished(&node.new_name)).expect("query"));
@@ -4207,7 +4371,8 @@ mod tests {
         let harness = Harness::plain();
         let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &staged.root.name);
+        let plan = staged.root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &staged.root.name, &plan);
 
         let resolved = block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
         assert_eq!(
@@ -4249,7 +4414,8 @@ mod tests {
             ]
         });
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &staged.root.name);
+        let plan = staged.root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &staged.root.name, &plan);
 
         assert_eq!(
             block_on(net.resolve_node(&SCOPE)),
@@ -4264,7 +4430,8 @@ mod tests {
         let harness = Harness::plain();
         let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &staged.root.name);
+        let plan = staged.root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &staged.root.name, &plan);
 
         assert_eq!(
             block_on(net.resolve_node(&[0xee; 16])),
@@ -4284,7 +4451,8 @@ mod tests {
             Vec::new(),
         );
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
 
         block_on(net.resolve_node(&SCOPE)).expect("the root resolves");
         assert_eq!(
@@ -4301,7 +4469,8 @@ mod tests {
         // transplant the child gate refuses.
         let root = staged_root(&harness, vec![ref_to(MID, &served)], Vec::new());
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let mut entropy = SeededEntropy::new(13);
 
         let error = block_on(rotate_scope_write(
@@ -4335,7 +4504,8 @@ mod tests {
         let unserved = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &LEAF);
         let root = staged_root(&harness, vec![ref_to(LEAF, &unserved)], Vec::new());
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &root.name);
+        let plan = root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &root.name, &plan);
         let mut entropy = SeededEntropy::new(13);
 
         let error = block_on(rotate_scope_write(
@@ -4364,7 +4534,8 @@ mod tests {
         let harness = Harness::plain();
         let staged = staged_scope(&harness);
         let owner = owner_identity();
-        let net = wave(&harness, &owner, &staged.root.name);
+        let plan = staged.root.grant_section.commitment.clone();
+        let net = wave(&harness, &owner, &staged.root.name, &plan);
         let mut entropy = SeededEntropy::new(13);
 
         let outcome = block_on(rotate_scope_write(
@@ -4445,14 +4616,15 @@ mod tests {
         let staged = staged_scope(&harness);
         let owner = owner_identity();
 
-        let first = wave(&harness, &owner, &staged.root.name);
+        let plan = staged.root.grant_section.commitment.clone();
+        let first = wave(&harness, &owner, &staged.root.name, &plan);
         let before: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
             .into_iter()
             .map(|id| block_on(first.resolve_node(&id)).expect("the first pass enumerates"))
             .collect();
         drop(first);
 
-        let resumed = wave(&harness, &owner, &staged.root.name);
+        let resumed = wave(&harness, &owner, &staged.root.name, &plan);
         let after: Vec<WriteScopeNode> = [SCOPE, MID, LEAF]
             .into_iter()
             .map(|id| block_on(resumed.resolve_node(&id)).expect("the resumed pass enumerates"))


### PR DESCRIPTION
Two trust-boundary defects in the write-plane name wave's owner arm
(`crates/engine/src/net/rotation.rs::WriteWaveNet`), both of which had to land
before `rotateScopeWrite` gets a production caller.

## Bind the re-seal to the authorized committed set

Closes #1129

`reseal_root` minted the moved root's grant section from the committed set
carried by the record it had just read. A grant-set commitment is epoch-free, so
an older owner signature still verifies: a write grantee inside the forgery
window still holds the retired `writeScopeSeed`, hence the IPNS keypair for
`currentRootName`, and can republish the root at seq N+1 carrying the
**pre-revoke** section. That record passes every adoption-gate stage, so
`fanout_get_verify` picks it as freshest and the wave re-mints a grant blob for
the revokee containing the brand-new `writeScopeSeed` — a wave-bounded forgery
window turned into a permanent write-revocation bypass.

`WriteWaveNet` now carries `authorized_commitment`, the owner-signed set the
rotation was authorized over (`RotateScopeWritePlan::commitment`).
`reseal_root` refuses release-active when the resolved record's
`section.commitment` is not that set, and both the re-mint and the re-signed
commitment are built from the authorized set rather than the record's.

The whole binding surface was audited, not just `ipnsName`: the comparison is
full structural equality on `GrantSetCommitment`, so `entries`,
`ownerPseudonymPk` and the preserved unknown fields are all covered. The owner
signature is not re-verified here because the adoption gate already verifies the
record's commitment against the contact-anchored owner identity and binds it to
the name it was read at (`crates/engine/src/gate/adoption.rs` stage 2, and the
at-floor recovery path re-uses that same authenticated candidate) — so equality
with it is what proves the authorized set is the owner's and names this root.

## Re-read the write-epoch floor at the root republish

Closes #1130

`publish_moved` enforced write-epoch monotonicity against
`plane.write_epoch` — the floor snapshot `root_source` took during the
enumeration. Two things widen that gap: `GatedWaveRoot` re-parks the source on a
failed publish, and the enumeration reads the root first and parks it, so the
entire child-first interior wave runs in between. The write floor is monotonic
and rises via `floor::advance_write_epoch_on_sight` on any pointer consult, so a
concurrent focus-window tick can lift the real floor above the snapshot while the
wave runs. The guard then passed on a stale lower bound and the root's grant
section was sealed at or below the true floor — and since the `ownerWriteBlob`
AAD binds that epoch and `open_write_body` unseals at the floor, the published
root's write plane would be permanently unopenable, including by the next
rotation.

The floor is now re-read immediately before the seal. `plane.write_epoch` is
itself a floor read, so any live floor above it is the signal that another
device's re-point superseded the record the wave is holding — that, plus the
existing `node.write_epoch > plane.write_epoch` check, is the refusal.
`plane.write_epoch` stays the AAD epoch the source body opened under.

## Tests

- `the_wave_refuses_a_root_whose_committed_set_diverges_from_the_owner_plan_release_active` —
  a staged root still committing the write grant being cut, against an owner plan
  with that grant removed: the republish is refused and nothing lands at the new
  name, so the revokee never receives a re-minted blob.
- `a_write_floor_rise_before_the_root_republish_refuses_the_seal` — the
  enumeration parks the root, then the durable write floor rises. Both sides of
  the rise are pinned: the one the wave's own epoch still clears, where the
  parked record has silently been superseded, and the one that would seal at or
  below the live floor.

Each was proved red by reverting the production change and watching it fail —
three reverts in all, including the weaker `node.write_epoch <= write_floor`
form of the floor check. The happy paths are unchanged: the other 59
`net::rotation` tests pass untouched apart from threading the authorized set
through the `wave()` test helper.

## Review gates

`/simplify`, `/security-review` and `/crypto-privacy-review` were all run on
this branch's own diff and their findings folded back in:

- the simplify pass removed a redundant `remint_grants` parameter, a
  single-caller `check_authorized`, a `.max()` that could never select its left
  operand, and 22 test-side clones of a value already borrowable;
- the crypto pass caught a residual in the floor fix — a floor that rose past
  the parked snapshot but stayed below the wave's epoch was still accepted — and
  argued the mint guard belongs with the ledger consumer rather than with its
  caller. Both landed, with the stricter floor case added to the test.

Findings that belong to other files or other slices were filed as issues rather
than folded in here.

## Not in this PR

#1136 and #1137 were triaged and are blocked on files and decisions this branch
does not own; details are in a triage comment on each.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind write wave re-seal to the authorized grant-set commitment and re-read the write epoch floor
> - `remint_grants` now rejects when the re-read record's committed set diverges from the owner-authorized `GrantSetCommitment`, and remints strictly against that authorized commitment rather than the one carried by the record.
> - `reseal_root` now signs and binds the resealed section to `self.authorized_commitment` instead of the commitment found on the re-read plane, closing a substitution window.
> - `republish` now reads the current write epoch floor from `floors` and rejects sealing the root if the floor has risen above the parked plane's `write_epoch` since enumeration.
> - Risk: any existing call-sites constructing `WriteWaveNet` must now supply an `authorized_commitment`; tests are updated with a `no_root_plan()` helper for cases that do not republish a root.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5310a9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when renewing access grants to prevent unauthorized or inconsistent commitments from being accepted.
  * Ensured sealed records use the currently authorized commitment, preventing stale authorization data from being published.
  * Prevented outdated snapshots from being published when the active write period has advanced.
* **Security & Reliability**
  * Added safeguards and coverage for authorization mismatches and race conditions during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->