### PR TITLE
fix: self-heal a corrupt Core Kit store instead of wedging the app

### DIFF
--- a/apps/web/src/auth/CoreKitProvider.test.tsx
+++ b/apps/web/src/auth/CoreKitProvider.test.tsx
@@ -6,23 +6,35 @@ import { createCoreKitSession } from './coreKit';
 import { CoreKitProvider, useCoreKit } from './CoreKitProvider';
 
 const STORE_KEY = 'corekit_store';
-/** A truncated write, which is what an evicted or half-flushed store looks like. */
-const CORRUPT_STORE = '{"sessionId":"a-sessio';
+/** Every store shape the SDK's read throws on, since it parses and then indexes. */
+const UNREADABLE_STORES: [string, string][] = [
+  // What an evicted or half-flushed store looks like: the parse itself throws.
+  ['a truncated write', '{"sessionId":"a-sessio'],
+  // Parses cleanly, then the index step throws because `null` has no keys.
+  ['a null literal', 'null'],
+];
 const SIGNED_OUT_STORE = '{"deviceFactor":"a-device-factor"}';
 const LOGGED_IN_STORE = '{"sessionId":"a-fresh-session-id"}';
 /** The SDK's own feature check is a bare `fetch`, so a restore fails offline. */
 const OFFLINE = new Error('Failed to fetch');
 
-// The SDK reads its store through a bare `JSON.parse` on both the restore and
-// the login path, so one unreadable blob defeats every later login too. The
-// fake reproduces that read, and the network leg that follows it in `init`.
+// The SDK reads its store as `JSON.parse(raw || '{}')[key]` (`AsyncStorage.get`,
+// which `init` calls for `sessionId`) on both the restore and the login path, so
+// one unreadable blob defeats every later login too. The fake reproduces that
+// read — parse *and* index — and the network leg that follows it in `init`.
 const sdk = vi.hoisted(() => ({
   status: 'NOT_INITIALIZED',
   initFailure: undefined as Error | undefined,
 }));
 vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@web3auth/mpc-core-kit')>();
-  const readStore = (): unknown => JSON.parse(window.localStorage.getItem(STORE_KEY) ?? '{}');
+  const readStore = (): unknown => {
+    const parsed = JSON.parse(window.localStorage.getItem(STORE_KEY) || '{}') as Record<
+      string,
+      unknown
+    >;
+    return parsed.sessionId;
+  };
   return {
     ...actual,
     Web3AuthMPCCoreKit: class {
@@ -67,29 +79,35 @@ describe('CoreKitProvider', () => {
     window.localStorage.clear();
   });
 
-  it('discards a store the restore could not read, and does not pass it off as a signed-out tab', async () => {
-    window.localStorage.setItem(STORE_KEY, CORRUPT_STORE);
-    const { result } = mount();
+  it.each(UNREADABLE_STORES)(
+    'discards %s the restore could not read, and does not pass it off as a signed-out tab',
+    async (_shape, store) => {
+      window.localStorage.setItem(STORE_KEY, store);
+      const { result } = mount();
 
-    await waitFor(() => expect(result.current.status).toBe('ready'));
+      await waitFor(() => expect(result.current.status).toBe('ready'));
 
-    expect(result.current.error).toMatch(/could not be restored/);
-    expect(result.current.session?.isLoggedIn()).toBe(false);
-    expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
-  });
+      expect(result.current.error).toMatch(/could not be restored/);
+      expect(result.current.session?.isLoggedIn()).toBe(false);
+      expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
+    }
+  );
 
-  it('leaves a login after a failed restore able to establish a session', async () => {
-    window.localStorage.setItem(STORE_KEY, CORRUPT_STORE);
-    const { result } = mount();
-    await waitFor(() => expect(result.current.status).toBe('ready'));
+  it.each(UNREADABLE_STORES)(
+    'leaves a login after a restore that failed on %s able to establish a session',
+    async (_shape, store) => {
+      window.localStorage.setItem(STORE_KEY, store);
+      const { result } = mount();
+      await waitFor(() => expect(result.current.status).toBe('ready'));
 
-    await act(async () => {
-      await result.current.session?.login('google');
-    });
+      await act(async () => {
+        await result.current.session?.login('google');
+      });
 
-    expect(result.current.session?.isLoggedIn()).toBe(true);
-    expect(window.localStorage.getItem(STORE_KEY)).toBe(LOGGED_IN_STORE);
-  });
+      expect(result.current.session?.isLoggedIn()).toBe(true);
+      expect(window.localStorage.getItem(STORE_KEY)).toBe(LOGGED_IN_STORE);
+    }
+  );
 
   it('keeps a readable store when the restore failed for some other reason', async () => {
     window.localStorage.setItem(STORE_KEY, SIGNED_OUT_STORE);

--- a/apps/web/src/auth/CoreKitProvider.test.tsx
+++ b/apps/web/src/auth/CoreKitProvider.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { COREKIT_STATUS } from '@web3auth/mpc-core-kit';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCoreKitSession } from './coreKit';
+import { CoreKitProvider, useCoreKit } from './CoreKitProvider';
+
+const STORE_KEY = 'corekit_store';
+/** A truncated write, which is what an evicted or half-flushed store looks like. */
+const CORRUPT_STORE = '{"sessionId":"a-sessio';
+const SIGNED_OUT_STORE = '{"deviceFactor":"a-device-factor"}';
+const LOGGED_IN_STORE = '{"sessionId":"a-fresh-session-id"}';
+/** The SDK's own feature check is a bare `fetch`, so a restore fails offline. */
+const OFFLINE = new Error('Failed to fetch');
+
+// The SDK reads its store through a bare `JSON.parse` on both the restore and
+// the login path, so one unreadable blob defeats every later login too. The
+// fake reproduces that read, and the network leg that follows it in `init`.
+const sdk = vi.hoisted(() => ({
+  status: 'NOT_INITIALIZED',
+  initFailure: undefined as Error | undefined,
+}));
+vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@web3auth/mpc-core-kit')>();
+  const readStore = (): unknown => JSON.parse(window.localStorage.getItem(STORE_KEY) ?? '{}');
+  return {
+    ...actual,
+    Web3AuthMPCCoreKit: class {
+      readonly _storageKey = STORE_KEY;
+      get status(): string {
+        return sdk.status;
+      }
+      async init(): Promise<void> {
+        readStore();
+        if (sdk.initFailure) throw sdk.initFailure;
+      }
+      async loginWithOAuth(): Promise<void> {
+        readStore();
+        window.localStorage.setItem(STORE_KEY, LOGGED_IN_STORE);
+        sdk.status = actual.COREKIT_STATUS.LOGGED_IN;
+      }
+      commitChanges(): Promise<void> {
+        return Promise.resolve();
+      }
+    },
+  };
+});
+
+const ENV = {
+  VITE_WEB3AUTH_CLIENT_ID: 'client-id',
+  VITE_WEB3AUTH_VERIFIER: 'verifier',
+} satisfies Partial<ImportMetaEnv>;
+
+/** The provider over a real Core Kit session, so the store it owns is the real one. */
+function mount() {
+  return renderHook(() => useCoreKit(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <CoreKitProvider createSession={() => createCoreKitSession(ENV)}>{children}</CoreKitProvider>
+    ),
+  });
+}
+
+describe('CoreKitProvider', () => {
+  beforeEach(() => {
+    sdk.status = COREKIT_STATUS.NOT_INITIALIZED;
+    sdk.initFailure = undefined;
+    window.localStorage.clear();
+  });
+
+  it('discards a store the restore could not read, and does not pass it off as a signed-out tab', async () => {
+    window.localStorage.setItem(STORE_KEY, CORRUPT_STORE);
+    const { result } = mount();
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(result.current.error).toMatch(/could not be restored/);
+    expect(result.current.session?.isLoggedIn()).toBe(false);
+    expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
+  });
+
+  it('leaves a login after a failed restore able to establish a session', async () => {
+    window.localStorage.setItem(STORE_KEY, CORRUPT_STORE);
+    const { result } = mount();
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await result.current.session?.login('google');
+    });
+
+    expect(result.current.session?.isLoggedIn()).toBe(true);
+    expect(window.localStorage.getItem(STORE_KEY)).toBe(LOGGED_IN_STORE);
+  });
+
+  it('keeps a readable store when the restore failed for some other reason', async () => {
+    window.localStorage.setItem(STORE_KEY, SIGNED_OUT_STORE);
+    sdk.initFailure = OFFLINE;
+    const { result } = mount();
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(result.current.error).toMatch(/could not be restored/);
+    expect(window.localStorage.getItem(STORE_KEY)).toBe(SIGNED_OUT_STORE);
+  });
+
+  it('keeps a store the restore read cleanly, session in it or not', async () => {
+    window.localStorage.setItem(STORE_KEY, SIGNED_OUT_STORE);
+    const { result } = mount();
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.session?.isLoggedIn()).toBe(false);
+    expect(window.localStorage.getItem(STORE_KEY)).toBe(SIGNED_OUT_STORE);
+  });
+});

--- a/apps/web/src/auth/CoreKitProvider.tsx
+++ b/apps/web/src/auth/CoreKitProvider.tsx
@@ -10,11 +10,18 @@ const RESTORE_DEADLINE_MS = 10_000;
 
 const UNREACHABLE = 'the login provider is not responding — check your connection and reload';
 
+/**
+ * Deliberately says nothing about the cause: the throw that gets here is
+ * usually the SDK parsing its own store, and that message quotes the bytes it
+ * choked on, which are bearer key material.
+ */
+const RESTORE_FAILED = 'the saved sign-in could not be restored — please sign in again';
+
 export interface CoreKitContextValue {
   /** `null` until the session is built and its restore attempt has settled. */
   session: CoreKitSession | null;
   status: CoreKitStatus;
-  /** Why Core Kit is unusable at all — a bad build config, or silence. */
+  /** Why this tab has no session — a bad build config, silence, or a failed restore. */
   error: string | null;
 }
 
@@ -58,18 +65,18 @@ export function CoreKitProvider({ createSession, children }: CoreKitProviderProp
       if (live) setValue({ session: null, status: 'unavailable', error: UNREACHABLE });
     }, RESTORE_DEADLINE_MS);
 
-    const settled: CoreKitContextValue = {
-      session: session.current,
-      status: 'ready',
-      error: null,
-    };
-    // A failed restore just means there is no session to resume; the methods
-    // below still work, and a real breakage surfaces when one is used.
-    const settle = () => {
+    const restored = session.current;
+    const settle = (error: string | null) => {
       clearTimeout(deadline);
-      if (live) setValue(settled);
+      if (live) setValue({ session: restored, status: 'ready', error });
     };
-    restore.current.then(settle, settle);
+    // A rejected restore resumes nothing, so the tab still lands at the front
+    // door — but it lands there carrying the failure, not as a clean sign-out.
+    // The session stays in hand because logging in again is the way out of it.
+    restore.current.then(
+      () => settle(null),
+      () => settle(RESTORE_FAILED)
+    );
 
     return () => {
       live = false;

--- a/apps/web/src/auth/coreKit.ts
+++ b/apps/web/src/auth/coreKit.ts
@@ -40,7 +40,15 @@ class Web3AuthSession implements CoreKitSession {
   ) {}
 
   async restore(): Promise<void> {
-    await this.coreKit.init();
+    try {
+      await this.coreKit.init();
+    } catch (failure) {
+      // Only an unreadable store wedges the next login through that same read.
+      // A restore that failed for any other reason — the SDK's feature check
+      // has no network — must leave a good store standing.
+      if (!this.storeIsReadable()) this.clearStore();
+      throw failure;
+    }
   }
 
   isLoggedIn(): boolean {
@@ -86,10 +94,23 @@ class Web3AuthSession implements CoreKitSession {
   /**
    * The SDK's own logout blanks its session id in place and leaves the rest of
    * its store standing — a device factor share among it, once MFA is reachable.
-   * So every path that ends a session, refused or partial, clears it here.
+   * So every path that leaves this device without a usable session clears it
+   * here, whether the session ended, was refused, or was never readable.
    */
   private clearStore(): void {
     this.store.removeItem(this.coreKit._storageKey);
+  }
+
+  /** The SDK reads its store as `JSON.parse(raw || '{}')[key]`; nothing else opens. */
+  private storeIsReadable(): boolean {
+    const raw = this.store.getItem(this.coreKit._storageKey);
+    if (!raw) return true;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return typeof parsed === 'object' && parsed !== null;
+    } catch {
+      return false;
+    }
   }
 
   _UNSAFE_exportTssKey(): Promise<string> {


### PR DESCRIPTION
## Problem

`AsyncStorage.get` parses the Core Kit store with a bare `JSON.parse`, and `init()` has no guard around it, so an unreadable `corekit_store` threw out of `restore()`.

`CoreKitProvider` handed the same `settle` to both fulfil and reject, and `settled` was `{ session, status: 'ready', error: null }`. A rejected restore was therefore indistinguishable from "restored, signed out" — no unhandled rejection, no console surface, no error state. Nothing cleared the bad blob either, so the next login hit the same parse in the SDK's `createSession` and threw again, surfacing as a raw `SyntaxError` on the login page. The tab stayed wedged across reloads; the only escape was clicking sign out, whose unconditional `clearStore()` runs whether or not a session is live.

## Change

**`coreKit.ts`** — `Web3AuthSession.restore()` clears the store when the failure was the store itself, reusing the `clearStore()` that already backs every other teardown path.

The trigger is deliberately narrow. `init()` does not only read the store: it ends in `await this.featureRequest()`, a bare `fetch` of the Web3Auth feature-access endpoint with no `try`/`catch`, and its session rehydrate swallows its own failures and falls through to it. An unconditional purge would therefore delete a perfectly good store on an offline reload — origin-wide, so one background tab booting offline would evict the store every other tab's leader promotion depends on. The blob also carries the device factor share once MFA is reachable, which turns that into share destruction rather than a cache eviction. So `restore()` probes readability against the shape the SDK actually requires — `JSON.parse(raw || '{}')[key]`, i.e. parses *and* is a non-null object — and purges only when that fails.

**`CoreKitProvider.tsx`** — reject and resolve now settle differently, and a rejected restore records the failure.

The tab still lands at the front door and can never present as authenticated: `authStore` only flips on a completed engine handoff, and `init()` opens with `resetState()`, so a throw leaves `isLoggedIn()` false and the restore effect in `useAuth` returns early. But it lands there carrying the failure instead of a clean sign-out, and it keeps the session in hand rather than nulling it — signing in again is the way out of this state, and `useAuth` gates `login` on the session being present.

The surfaced message is a fixed string, not the underlying throw. V8 quotes the offending input in a `JSON.parse` failure — `JSON.parse('secret-key-bytes')` throws ``Unexpected token 's', "secret-key-bytes" is not valid JSON`` — and that input is bearer key material, so neither the UI nor the console gets the cause.

## Tests

New `apps/web/src/auth/CoreKitProvider.test.tsx`, mounting the provider over a *real* `createCoreKitSession` so the store under test is the real one, with the SDK class faked to reproduce its unguarded store read on both the restore and the login path:

- discards a store the restore could not read, and does not pass it off as a signed-out tab
- leaves a login after a failed restore able to establish a session
- keeps a readable store when the restore failed for some other reason
- keeps a store the restore read cleanly, session in it or not

Each was proven red by reverting the production code. Against unmodified `main` the first two fail. With only the provider change reverted, the first fails. With only the purge reverted, the first two fail. With the purge left unconditional, the third fails — `expected null to be '{"deviceFactor":"a-device-factor"}'`.

## Known residual

The recorded failure is latched in provider state for the tab's lifetime, and `useAuth` returns `error ?? coreKitError`. `auth.error` is rendered only by `LoginPage`, which is mounted only at `/` and redirects away on authentication, so this is invisible while signed in — but a clean sign-out in the same tab returns to a login page still showing the restore notice. Clearing it needs either new context API or new state in `useAuth`, both outside a fail-closed fix to the restore path.

Closes #1182


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix corrupt Core Kit store causing app to wedge on restore failure
> - On `Web3AuthSession.restore` failure, a new `storeIsReadable()` check determines whether the local MPC Core Kit store is corrupt; unreadable stores are cleared before rethrowing the error.
> - `CoreKitProvider` now distinguishes restore failures from success: a rejected restore sets `error` to a generic `RESTORE_FAILED` message instead of silently clearing it.
> - Readable stores (e.g. those that fail due to network issues) are preserved so the session can be recovered later.
> - Tests in [CoreKitProvider.test.tsx](https://github.com/FSM1/cipher-box/pull/1183/files#diff-9febeca2458faccdf3b0f24babd41975ef82b478b83d5bbd1f9254d81454fc12) cover truncated JSON, null stores, offline init failures, and successful login after a failed restore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7669450.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration when saved sign-in data is corrupted or unreadable.
  * Automatically clears invalid saved data so users can sign in again successfully.
  * Preserves valid saved data when restoration fails for unrelated reasons.
  * Displays a restoration error instead of incorrectly showing a clean signed-out state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->