### PR TITLE
fix: mint the write-plane history link and recover a resumed wave from published state

### DIFF
--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -37,7 +37,7 @@ use cipherbox_engine::mailbox::poll_verified;
 use cipherbox_engine::net::REGISTRY_BATCH_MAX;
 use cipherbox_engine::rotation::{
     PrevEpochSeed, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
-    ScopeRootPublishError, ScopeRootPublisher, SweepResolver, SweepTarget,
+    ScopeRootPublishError, ScopeRootPublisher, SweepResolver, SweepTarget, WriteHistory,
 };
 use cipherbox_engine::seams::{
     CredentialStore, Http, HttpCredentials, HttpMethod, HttpRequest, Mailbox,
@@ -1257,12 +1257,12 @@ async fn a_read_grant_delivers_its_share_pointer_through_the_live_mailbox() {
                 prev: None::<PrevEpochSeed<'_>>,
                 write_scope_seed: &parent_write_scope_seed,
                 write_epoch: 2,
+                write_history: WriteHistory::Carried(&[]),
                 pointer_read_key: &parent_pointer_read_key,
             },
             commitment: &parent_commitment,
             commitment_sig: &parent_commitment_sig,
             grant_ledger: &[],
-            write_history_link: &[],
             current_child_index: &[],
             carried_history_links: &[],
         },

--- a/crates/engine/examples/kat_gen.rs
+++ b/crates/engine/examples/kat_gen.rs
@@ -320,6 +320,7 @@ fn build_section_signer_vectors() -> (Vec<SectionSignerVector>, Vec<SectionSigne
         child_scope_index: Vec::new(),
         parent_node_seed: None,
         owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+        write_history_link: Vec::new(),
         grants: Vec::new(),
     });
     let owner_identity_pk = hex::encode(owner_identity.verifying_key().to_sec1());

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -5085,6 +5085,7 @@ mod tests {
                 // cold-seeded write floor opens it and the owner recovers its
                 // write-scope seed for the held-set renewal signer.
                 owner_write_blob_epoch: Some(EPOCH),
+                write_history_link: Vec::new(),
                 grants: Vec::new(),
             });
             (fx.head_block, fx.head_cid_str, fx.name)

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -46,8 +46,8 @@ use crate::grants::mint_grant_row;
 use crate::mailbox::post_sealed;
 use crate::rotation::{
     CommittedSet, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
-    ScopeRootPublishError, ScopeRootPublisher, SweepError, SweepResolver, derive_write_name,
-    reseal_scope_root, sweep_pass,
+    ScopeRootPublishError, ScopeRootPublisher, SweepError, SweepResolver, WriteHistory,
+    derive_write_name, reseal_scope_root, sweep_pass,
 };
 use crate::seams::{FloorStore, Mailbox, SeamError};
 use cipherbox_core::hex::lower as hex_lower;
@@ -133,8 +133,6 @@ pub struct ParentScopePlan<'a> {
     pub commitment_sig: &'a [u8; ECDSA_SIG_LEN],
     /// The parent's grant ledger (unchanged by this op).
     pub grant_ledger: &'a [GrantLedgerEntry],
-    /// The parent's write-plane history link (unchanged by this op).
-    pub write_history_link: &'a [u8],
     /// The parent's current direct-child-scope index (before this grant).
     pub current_child_index: &'a [ChildScopeRef],
     /// The parent's carried read-plane history links.
@@ -351,6 +349,7 @@ where
             prev: None,
             write_scope_seed: grantee.write_scope_seed,
             write_epoch: grantee.write_epoch,
+            write_history: WriteHistory::Carried(&[]),
             pointer_read_key: grantee.pointer_read_key,
         };
         // Mint-canonical: the adopted index carries the same canonicalization the
@@ -361,7 +360,6 @@ where
             commitment: &commitment,
             commitment_sig: &commitment_sig,
             grant_ledger: &ledger,
-            write_history_link: &[],
             direct_child_scope_index: &grantee_child_index,
         };
         reseal_scope_root(entropy, &identity, &seeds, &committed, &[])
@@ -414,6 +412,7 @@ where
             prev: None,
             write_scope_seed: &target.write_scope_seed,
             write_epoch: target.write_epoch,
+            write_history: WriteHistory::Carried(&target.write_history_link),
             pointer_read_key: &target.pointer_read_key,
         };
         let canonical_index = canonicalize(&target.direct_child_scope_index);
@@ -421,7 +420,6 @@ where
             commitment: &target.commitment,
             commitment_sig: &target.commitment_sig,
             grant_ledger: &target.grant_ledger,
-            write_history_link: &target.write_history_link,
             direct_child_scope_index: &canonical_index,
         };
         let section = reseal_scope_root(
@@ -466,7 +464,6 @@ where
             commitment: parent.commitment,
             commitment_sig: parent.commitment_sig,
             grant_ledger: parent.grant_ledger,
-            write_history_link: parent.write_history_link,
             direct_child_scope_index: &parent_index,
         };
         // The owner runs this leg, so the tag binding is not the caller's to
@@ -797,6 +794,7 @@ mod tests {
                 override_seed: &parent_override_seed,
                 read_epoch: 3,
                 prev: None::<PrevEpochSeed<'_>>,
+                write_history: WriteHistory::Carried(&[]),
                 write_scope_seed: &parent_write_scope_seed,
                 write_epoch: 2,
                 pointer_read_key: &parent_pointer_read_key,
@@ -804,7 +802,6 @@ mod tests {
             commitment: &parent_commitment,
             commitment_sig: &parent_commitment_sig,
             grant_ledger: &[],
-            write_history_link: &[],
             current_child_index: &[],
             carried_history_links: &[],
         };
@@ -915,6 +912,7 @@ mod tests {
                     override_seed: &parent_override_seed,
                     read_epoch: 3,
                     prev: None::<PrevEpochSeed<'_>>,
+                    write_history: WriteHistory::Carried(&[]),
                     write_scope_seed: &parent_write_scope_seed,
                     write_epoch: 2,
                     pointer_read_key: &parent_pointer_read_key,
@@ -922,7 +920,6 @@ mod tests {
                 commitment: &parent_commitment,
                 commitment_sig: &parent_commitment_sig,
                 grant_ledger: &parent_ledger,
-                write_history_link: &[],
                 current_child_index: &[],
                 carried_history_links: &[],
             };

--- a/crates/engine/src/grants/invite.rs
+++ b/crates/engine/src/grants/invite.rs
@@ -708,7 +708,7 @@ mod tests {
     use super::*;
     use crate::grants::{PublishedGrantBlob, enforce_committed_ledger, self_locate};
     use crate::rotation::{
-        CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+        CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory, reseal_scope_root,
     };
     use crate::testkit::SeededEntropy;
     use cipherbox_core::seal::{
@@ -803,12 +803,12 @@ mod tests {
                 write_scope_seed: &WRITE_SCOPE_SEED,
                 write_epoch: 1,
                 pointer_read_key: &POINTER_READ_KEY,
+                write_history: WriteHistory::Carried(&[]),
             },
             &CommittedSet {
                 commitment: &commitment,
                 commitment_sig: &sig,
                 grant_ledger: &ledger,
-                write_history_link: b"",
                 direct_child_scope_index: &[],
             },
             &[],

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -84,8 +84,9 @@ pub use rotation::{
     ChildIndexResolver, CommittedSet, EagerSet, EnumerationError, PrevEpochSeed, ResealError,
     ResealSeeds, ResealedScopeRoot, ResolveFailure, RevokeError, RevokedCommittedSet, RotateError,
     RotateScopePlan, RotationOutcome, RotationTrigger, ScopeExitReport, ScopeExitRotator,
-    ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, consume_scope_exit_triggers,
-    enumerate_eager_set, reseal_scope_root, revoke_read_grant, rotate_scope,
+    ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, WriteHistory,
+    consume_scope_exit_triggers, enumerate_eager_set, reseal_scope_root, revoke_read_grant,
+    rotate_scope,
 };
 pub use seams::{OwedRetire, RetireLedger, SeamError, SeamResult, SeamSet, SeamTypes};
 pub use settings::{

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -424,26 +424,38 @@ impl<H: Http, F: FloorStore> RootAdopter<'_, H, F> {
         else {
             return Ok(None);
         };
-        let aad = AadContext {
-            v: env.v,
-            id: env.id,
-            scope: env.scope,
-            epoch: wf,
-            struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
-        };
-        let Ok(payload) =
-            open_owner_write_blob(self.owner_enc_secret, &owb.enc, &aad, &owb.ciphertext)
-        else {
-            return Ok(None);
-        };
-        // Belt-and-suspenders: the HPKE AAD already binds `epoch == wf`, so a
-        // successful open implies equality; a mismatch means something is off —
-        // treat as re-authorable, never adopt the seed.
-        if payload.write_epoch != wf {
-            return Ok(None);
-        }
-        Ok(Some(Zeroizing::new(*payload.write_scope_seed())))
+        Ok(open_write_scope_seed_at(
+            self.owner_enc_secret,
+            env,
+            owb,
+            wf,
+        ))
     }
+}
+
+/// Open `owb` at `write_epoch` and hand back the write scope seed it wraps, or
+/// `None` when it does not open there.
+///
+/// `write_epoch` is the caller's authority on the write plane's clock: the
+/// durable floor for a cold-start adopt, the owner-signed re-point object for a
+/// resumed name wave (`net/rotation.rs`).
+pub(crate) fn open_write_scope_seed_at(
+    owner_enc_secret: &X25519Secret,
+    env: &Envelope,
+    owb: &SignedOwnerWriteBlob,
+    write_epoch: u64,
+) -> Option<Zeroizing<[u8; 32]>> {
+    let aad = AadContext {
+        v: env.v,
+        id: env.id,
+        scope: env.scope,
+        epoch: write_epoch,
+        struct_tag: STRUCT_TAG_OWNER_WRITE_BLOB,
+    };
+    let payload = open_owner_write_blob(owner_enc_secret, &owb.enc, &aad, &owb.ciphertext).ok()?;
+    // Belt-and-suspenders: the HPKE AAD already binds the epoch, so a successful
+    // open implies equality; a mismatch means something is off.
+    (payload.write_epoch == write_epoch).then(|| Zeroizing::new(*payload.write_scope_seed()))
 }
 
 /// A head block the caller already holds — the write path's own just-uploaded
@@ -618,6 +630,7 @@ mod tests {
                 child_scope_index: Vec::new(),
                 parent_node_seed: None,
                 owner_write_blob_epoch: owb_write_epoch,
+                write_history_link: Vec::new(),
                 grants: Vec::new(),
             });
 

--- a/crates/engine/src/net/author.rs
+++ b/crates/engine/src/net/author.rs
@@ -429,6 +429,7 @@ mod tests {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: None,
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         })
     }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -4323,29 +4323,43 @@ mod tests {
 
     #[test]
     fn a_reseal_seam_failure_stays_retryable_and_a_trust_failure_does_not() {
-        assert_eq!(
-            reseal_verdict(ResealError::Entropy(EntropyError::new("seam down"))),
-            WritePublishError::NotLanded,
-            "the entropy seam being down is availability, not a verdict on the section"
-        );
-
-        for terminal in [
+        // One sample per `ResealError` variant. The `match` below is the
+        // enforcement: a variant added without a classification here stops this
+        // test compiling, so none can be silently omitted from the axis.
+        for sample in [
+            ResealError::Entropy(EntropyError::new("seam down")),
             ResealError::LedgerDivergesFromCommitment,
             ResealError::SignerNotCommitted,
             ResealError::UnusableRecipientKey,
+            ResealError::TagNotBoundToRecipient,
             ResealError::AscentLinkMismatch,
             ResealError::TooManyHistoryLinks,
             ResealError::TooManyCommittedGrants,
+            ResealError::HistoryLinkNotDescending,
             ResealError::Encode(CodecError::Malformed(Malformed::DepthExceeded {
                 offset: 0,
             })),
         ] {
-            let check = terminal.check();
-            assert_eq!(
-                reseal_verdict(terminal),
-                WritePublishError::Rejected,
-                "{check} is deterministic on inputs the wave already gated; retrying never converges"
-            );
+            let (expected, why) = match &sample {
+                ResealError::Entropy(_) => (
+                    WritePublishError::NotLanded,
+                    "the entropy seam being down is availability, not a verdict on the section",
+                ),
+                ResealError::LedgerDivergesFromCommitment
+                | ResealError::SignerNotCommitted
+                | ResealError::UnusableRecipientKey
+                | ResealError::TagNotBoundToRecipient
+                | ResealError::AscentLinkMismatch
+                | ResealError::TooManyHistoryLinks
+                | ResealError::TooManyCommittedGrants
+                | ResealError::HistoryLinkNotDescending
+                | ResealError::Encode(_) => (
+                    WritePublishError::Rejected,
+                    "deterministic on inputs the wave already gated; retrying never converges",
+                ),
+            };
+            let check = sample.check();
+            assert_eq!(reseal_verdict(sample), expected, "{check}: {why}");
         }
     }
 

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -25,16 +25,17 @@ use cipherbox_core::seal::{
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
-use cipherbox_core::suite::secret::SECRET_LEN;
+use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 use zeroize::Zeroizing;
 
-use super::adopter::RootAdopter;
+use super::adopter::{RootAdopter, open_write_scope_seed_at};
 use super::author::{
     AuthorError, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
     author_scope_root_with_section,
 };
 use super::child::ChildAdopter;
+use super::pointer_fetch::RecordPointerFetch;
 use super::publish::{InlineRecordRequest, PublishError, PublishOutcome, publish_inline};
 use super::record_publish::{
     HeadBinding, RecordPublishError, RecordPublishRequest, preflight, publish_record,
@@ -49,14 +50,15 @@ use crate::net::fanout_get_verify;
 use crate::net::resolve::Adopter;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
-    CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, RepointChannel,
-    RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure,
-    ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, WritePublishError,
-    WriteScopeNode, WriteSubtreeResolver, WriteWavePublisher, derive_write_name, reseal_scope_root,
+    CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, PrevEpochSeed,
+    RepointChannel, RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure,
+    ResumedWriteWave, ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, WriteHistory,
+    WritePublishError, WriteScopeNode, WriteSubtreeResolver, WriteWavePublisher, derive_write_name,
+    reseal_scope_root,
 };
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 use crate::session::SessionIdentity;
-use crate::sync::pointer::{scope_pointer_name, scope_pointer_signer};
+use crate::sync::pointer::{PointerFetch, open_repoint, scope_pointer_name, scope_pointer_signer};
 
 /// The owner key material the rotation edges run under. The owner is the
 /// terminal owner of its own key material, so nothing here is zeroized.
@@ -760,6 +762,9 @@ pub struct WriteWaveNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     pub authorized_commitment: &'a GrantSetCommitment,
     /// Derives the scope pointer's name and its record signer (owner-only).
     pub owner_pointer_seed: &'a [u8; SECRET_LEN],
+    /// The pointer-payload envelope version the scope pointer is read under
+    /// (`RotateScopeWritePlan::payload_version`).
+    pub payload_version: u64,
     /// The root name the wave is moving off. It lingers serving the tombstone, so
     /// [`WriteWaveNet::retire`] refuses a batch naming it.
     pub current_root_name: &'a IpnsName,
@@ -882,6 +887,9 @@ struct RootPlane {
     section: GrantSection,
     read_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
     write_body: WriteBody,
+    /// The write scope seed the root's own owner-write blob yielded — the one the
+    /// wave retires, sealed into the moved root's fresh write-plane history link.
+    write_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
     /// The write epoch the section was sealed at — the floor the wave advances
     /// past.
     write_epoch: u64,
@@ -969,6 +977,7 @@ fn reseal_verdict(error: ResealError) -> WritePublishError {
         | ResealError::AscentLinkMismatch
         | ResealError::TooManyHistoryLinks
         | ResealError::TooManyCommittedGrants
+        | ResealError::HistoryLinkNotDescending
         | ResealError::Encode(_) => WritePublishError::Rejected,
     }
 }
@@ -1052,18 +1061,7 @@ where
         record_bytes: &[u8],
     ) -> Result<WaveSource, WritePublishError> {
         let identity = self.owner.verifying_key();
-        let mut adopter = RootAdopter::new(
-            self.gateway,
-            self.http,
-            self.floors,
-            self.owner_enc_secret,
-            &identity,
-            self.scope_id,
-        );
-        if let Some(seed) = self.parent_node_seed {
-            adopter = adopter.under_parent_node_seed(Zeroizing::new(*seed));
-        }
-        let gated = gated_scope_root(&adopter, name, record_bytes)
+        let gated = gated_scope_root(&self.root_adopter(&identity), name, record_bytes)
             .await
             .map_err(wave_read_verdict)?;
         let envelope = gated.envelope;
@@ -1097,6 +1095,7 @@ where
                 section: gated.section,
                 read_scope_seed,
                 write_body,
+                write_scope_seed,
                 write_epoch,
             }),
         })
@@ -1146,6 +1145,23 @@ where
             self.subtree.record_child_scope(child.scope_id);
         }
         Ok(())
+    }
+
+    /// The adopter every root read of this scope runs through, under the
+    /// rotating root's own ancestor seed when it has one.
+    fn root_adopter<'i>(&'i self, identity: &'i EcdsaVerifier) -> RootAdopter<'i, H, F> {
+        let adopter = RootAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            self.owner_enc_secret,
+            identity,
+            self.scope_id,
+        );
+        match self.parent_node_seed {
+            Some(seed) => adopter.under_parent_node_seed(Zeroizing::new(*seed)),
+            None => adopter,
+        }
     }
 }
 
@@ -1330,13 +1346,16 @@ where
                 prev: None,
                 write_scope_seed: fresh_write_scope_seed,
                 write_epoch: node.write_epoch,
+                write_history: WriteHistory::Cut(PrevEpochSeed {
+                    seed: &plane.write_scope_seed,
+                    epoch: plane.write_epoch,
+                }),
                 pointer_read_key: &pointer_read_key,
             },
             &CommittedSet {
                 commitment: &commitment,
                 commitment_sig: &commitment_sig,
                 grant_ledger: &remint.ledger,
-                write_history_link: &plane.write_body.write_history_link,
                 direct_child_scope_index: &plane.write_body.direct_child_scope_index,
             },
             &plane.section.history_links,
@@ -1552,6 +1571,75 @@ where
             child_node_ids,
         })
     }
+
+    /// Recover an in-flight wave from the canonical scope pointer.
+    ///
+    /// The moved root's name derives from the very seed a resume needs, so the
+    /// owner-signed pointer is the one published anchor that breaks that circle;
+    /// the seed itself still comes from the moved root's own blob through the
+    /// gate, never from the pointer.
+    async fn recover_wave(&self) -> Result<Option<ResumedWriteWave>, ResolveFailure> {
+        let pointer = scope_pointer_name(self.owner_pointer_seed, &self.scope_id);
+        let block = match RecordPointerFetch::new(self.transport)
+            .fetch(&pointer)
+            .await
+        {
+            Ok(Some(block)) => block,
+            // No pointer record: this scope has never been re-pointed, so there is
+            // no wave to pick up. A seam failure is not that answer — reporting it
+            // as one mints a second seed for a wave already in flight and orphans
+            // every name the first one registered.
+            Ok(None) => return Ok(None),
+            Err(_) => return Err(ResolveFailure::Unavailable),
+        };
+        let pointer_read_key = self.scope_keys.pointer_read_key(&self.scope_id);
+        let repoint = open_repoint(
+            &pointer_read_key,
+            self.payload_version,
+            &self.scope_id,
+            &self.owner.verifying_key(),
+            &block,
+        )
+        .map_err(|_| ResolveFailure::Rejected)?;
+        if repoint.prev_root.as_ref() != Some(self.current_root_name) {
+            return Ok(None);
+        }
+        let Some((_, record_bytes)) =
+            fanout_get_verify(self.transport, &repoint.current_root).await
+        else {
+            return Err(ResolveFailure::Unavailable);
+        };
+        let identity = self.owner.verifying_key();
+        let gated = gated_scope_root(
+            &self.root_adopter(&identity),
+            &repoint.current_root,
+            &record_bytes,
+        )
+        .await?;
+        if gated.envelope.v != ENVELOPE_V || gated.envelope.id != self.scope_id {
+            return Err(ResolveFailure::Rejected);
+        }
+        // The re-point object is the owner's own signed statement of the write
+        // epoch, so the blob is opened there rather than at the durable floor —
+        // which a resume must leave where the pre-wave root can still be read.
+        let owb = gated
+            .section
+            .owner_write_blob
+            .as_ref()
+            .ok_or(ResolveFailure::Rejected)?;
+        let seed = open_write_scope_seed_at(
+            self.owner_enc_secret,
+            &gated.envelope,
+            owb,
+            repoint.write_epoch,
+        )
+        .ok_or(ResolveFailure::Rejected)?;
+        Ok(Some(ResumedWriteWave {
+            write_scope_seed: SecretBytes::new(*seed),
+            root_name: repoint.current_root,
+            write_epoch: repoint.write_epoch,
+        }))
+    }
 }
 
 impl<T, H: Http, C: CredentialStore, F, Sch, E> WriteWavePublisher
@@ -1645,10 +1733,11 @@ mod tests {
     use cipherbox_core::ipns::{IpnsRecord, VerifiedRecord};
     use cipherbox_core::seal::{
         AscentLink, ChildRef, GrantBlobPayload, GrantSetCommitment, NodeKind, Permission,
-        STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_OWNER_WRITE_BLOB,
-        decode_envelope, decode_grant_section, encode_envelope, encode_grant_section,
-        grant_section_bytes, open_ascent_link, open_grant_blob, open_owner_write_blob,
-        open_read_body, seal_read_body, set_grant_section, sign_grant_set, verify_grant_set,
+        STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK,
+        STRUCT_TAG_OWNER_WRITE_BLOB, decode_envelope, decode_grant_section, encode_envelope,
+        encode_grant_section, grant_section_bytes, open_ascent_link, open_grant_blob,
+        open_history_link, open_owner_write_blob, open_read_body, seal_read_body,
+        set_grant_section, sign_grant_set, verify_grant_set,
     };
     use cipherbox_core::suite::ecdsa::{EcdsaSignature, IDENTITY_PUBLIC_LEN};
     use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -1739,6 +1828,7 @@ mod tests {
             child_scope_index,
             parent_node_seed,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         })
     }
@@ -2151,13 +2241,13 @@ mod tests {
                 }),
                 write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
                 write_epoch: OWNER_ROOT_EPOCH,
+                write_history: WriteHistory::Carried(&[]),
                 pointer_read_key: &POINTER_READ_KEY,
             },
             &CommittedSet {
                 commitment: &fixture.grant_section.commitment,
                 commitment_sig: &fixture.grant_section.commitment_sig,
                 grant_ledger: &[],
-                write_history_link: &[],
                 direct_child_scope_index: &[],
             },
             &[],
@@ -2442,13 +2532,13 @@ mod tests {
                     commitment: &root.grant_section.commitment,
                     commitment_sig: &root.grant_section.commitment_sig,
                     grant_ledger: &[],
-                    write_history_link: &[],
                     direct_child_scope_index: &[],
                 },
                 current_override_seed: &OWNER_ROOT_SCOPE_SEED,
                 current_read_epoch: OWNER_ROOT_EPOCH,
                 write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
                 write_epoch: OWNER_ROOT_EPOCH,
+                write_history_link: &[],
                 pointer_read_key: &POINTER_READ_KEY,
                 carried_history_links: &[],
             },
@@ -2537,13 +2627,13 @@ mod tests {
                 prev: None,
                 write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
                 write_epoch: OWNER_ROOT_EPOCH,
+                write_history: WriteHistory::Carried(&[]),
                 pointer_read_key: &pointer_read_key,
             },
             &CommittedSet {
                 commitment: &commitment,
                 commitment_sig: &commitment_sig,
                 grant_ledger: &[],
-                write_history_link: &[],
                 direct_child_scope_index: children,
             },
             &[],
@@ -2884,13 +2974,13 @@ mod tests {
                     commitment: &root.grant_section.commitment,
                     commitment_sig: &root.grant_section.commitment_sig,
                     grant_ledger: &[],
-                    write_history_link: &[],
                     direct_child_scope_index: index,
                 },
                 current_override_seed: override_seed,
                 current_read_epoch: read_epoch,
                 write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
                 write_epoch: OWNER_ROOT_EPOCH,
+                write_history_link: &[],
                 pointer_read_key: &pointer_read_key,
                 carried_history_links: &[],
             },
@@ -3138,6 +3228,9 @@ mod tests {
     // --- The write-plane name wave ([`WriteWaveNet`]) ---
 
     /// The write scope seed the wave moves TO — every new name derives from it.
+    /// Used where a test hands the publisher its own orders; a test that runs
+    /// `rotate_scope_write` takes the seed the wave mints
+    /// ([`SeededEntropy::first_draw`]).
     const FRESH_WRITE_SCOPE_SEED: [u8; 32] = [0xa5; 32];
 
     /// The wave's owner arm. `writer_pseudonym` must be the signer the fixture's
@@ -3201,6 +3294,7 @@ mod tests {
             gated_root: GatedWaveRoot::default(),
             subtree: WaveSubtree::default(),
             owner_pointer_seed: &OWNER_POINTER_SEED,
+            payload_version: 1,
             current_root_name: current_root,
         }
     }
@@ -3380,6 +3474,7 @@ mod tests {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         });
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
@@ -3431,6 +3526,7 @@ mod tests {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         });
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
@@ -3545,6 +3641,7 @@ mod tests {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
             grants,
         })
     }
@@ -4000,6 +4097,7 @@ mod tests {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         });
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
@@ -4054,6 +4152,7 @@ mod tests {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         });
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
@@ -4267,6 +4366,16 @@ mod tests {
         harness: &Harness<InMemoryRecordStore>,
         index: impl FnOnce(&OwnerRootFixture, &IpnsName) -> Vec<ChildScopeRef>,
     ) -> StagedScope {
+        staged_scope_with(harness, index, Vec::new())
+    }
+
+    /// The same staging, with `write_history_link` planted in the root's write
+    /// body — bytes any committed writer can author.
+    fn staged_scope_with(
+        harness: &Harness<InMemoryRecordStore>,
+        index: impl FnOnce(&OwnerRootFixture, &IpnsName) -> Vec<ChildScopeRef>,
+        write_history_link: Vec<u8>,
+    ) -> StagedScope {
         let leaf_old = stage_node(harness, LEAF, &folder(Vec::new()));
         let mid_name = stage_node(harness, MID, &folder(vec![ref_to(LEAF, &leaf_old)]));
         let descendant = interior(CHILD_SCOPE, &OWNER_ROOT_SCOPE_SEED, Vec::new());
@@ -4278,6 +4387,7 @@ mod tests {
                 ref_to(CHILD_SCOPE, &descendant.name),
             ],
             index(&descendant, &mid_name),
+            write_history_link,
         );
         StagedScope {
             root,
@@ -4292,12 +4402,13 @@ mod tests {
         })
     }
 
-    /// A staged, gate-passing scope root naming `children` and committing
-    /// `child_scope_index`.
+    /// A staged, gate-passing scope root naming `children`, committing
+    /// `child_scope_index`, and publishing `write_history_link` in its write body.
     fn staged_root(
         harness: &Harness<InMemoryRecordStore>,
         children: Vec<ChildRef>,
         child_scope_index: Vec<ChildScopeRef>,
+        write_history_link: Vec<u8>,
     ) -> OwnerRootFixture {
         let root = owner_root_fixture(OwnerRootSpec {
             owner_identity: &owner_identity(),
@@ -4308,6 +4419,7 @@ mod tests {
             child_scope_index,
             parent_node_seed: None,
             owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link,
             grants: Vec::new(),
         });
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
@@ -4329,7 +4441,6 @@ mod tests {
             current_write_epoch: OWNER_ROOT_EPOCH,
             min_read_epoch: OWNER_ROOT_EPOCH,
             current_root_name: &root.name,
-            resume_write_scope_seed: Some(&FRESH_WRITE_SCOPE_SEED),
         }
     }
 
@@ -4435,6 +4546,7 @@ mod tests {
             &harness,
             vec![ref_to(MID, &mid_old), ref_to(LEAF, &leaf_old)],
             Vec::new(),
+            Vec::new(),
         );
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
@@ -4452,7 +4564,7 @@ mod tests {
         let served = stage_node(&harness, LEAF, &folder(Vec::new()));
         // The root names a node id at a record that claims a different id — the
         // transplant the child gate refuses.
-        let root = staged_root(&harness, vec![ref_to(MID, &served)], Vec::new());
+        let root = staged_root(&harness, vec![ref_to(MID, &served)], Vec::new(), Vec::new());
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let mut entropy = SeededEntropy::new(13);
@@ -4486,7 +4598,12 @@ mod tests {
     fn an_unresolvable_node_aborts_the_wave_rather_than_truncating_the_subtree() {
         let harness = Harness::plain();
         let unserved = derive_write_name(&OWNER_ROOT_WRITE_SCOPE_SEED, &LEAF);
-        let root = staged_root(&harness, vec![ref_to(LEAF, &unserved)], Vec::new());
+        let root = staged_root(
+            &harness,
+            vec![ref_to(LEAF, &unserved)],
+            Vec::new(),
+            Vec::new(),
+        );
         let owner = owner_identity();
         let net = wave(&harness, &owner, &root.name, &root.grant_section.commitment);
         let mut entropy = SeededEntropy::new(13);
@@ -4533,11 +4650,9 @@ mod tests {
         ))
         .expect("the wave completes over the production seams");
 
+        let fresh = SeededEntropy::first_draw(13);
         assert_eq!(outcome.new_write_epoch, OWNER_ROOT_EPOCH + 1);
-        assert_eq!(
-            outcome.new_root_name,
-            derive_write_name(&FRESH_WRITE_SCOPE_SEED, &SCOPE)
-        );
+        assert_eq!(outcome.new_root_name, derive_write_name(&fresh, &SCOPE));
         assert_eq!(
             outcome.interior_node_count, 2,
             "MID and LEAF, and not the descendant scope root"
@@ -4575,9 +4690,7 @@ mod tests {
             let next = refs
                 .iter()
                 .map(|bytes| core::str::from_utf8(bytes).expect("a utf8 name"))
-                .find(|text| {
-                    *text == derive_write_name(&FRESH_WRITE_SCOPE_SEED, &expected).as_str()
-                })
+                .find(|text| *text == derive_write_name(&fresh, &expected).as_str())
                 .expect("the parent names the child at the name the wave moved it to");
             name = IpnsName::parse(next).expect("a canonical name");
             node_id = expected;
@@ -4591,6 +4704,152 @@ mod tests {
             child_names_of(&read_only_open(&harness, SCOPE, &outcome.new_root_name))
                 .contains(&staged.descendant.name.as_str().as_bytes().to_vec()),
             "the descendant scope root keeps the name its own wave will move"
+        );
+    }
+
+    #[test]
+    fn a_planted_write_history_link_is_never_re_signed_into_the_moved_root() {
+        // No owner signature covers `writeHistoryLink`, and the resume reads a
+        // seed from exactly there (`WriteHistory`). The cut mints its own.
+        const PLANTED: &[u8] = b"planted-by-a-write-grantee";
+        let harness = Harness::plain();
+        let staged = staged_scope_with(
+            &harness,
+            |descendant, _| vec![child_ref(CHILD_SCOPE, descendant)],
+            PLANTED.to_vec(),
+        );
+        let owner = owner_identity();
+        let net = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
+        let mut entropy = SeededEntropy::new(61);
+
+        let outcome = block_on(rotate_scope_write(
+            &mut entropy,
+            &net,
+            &net,
+            &write_plan(&staged.root, &owner),
+        ))
+        .expect("the wave completes");
+
+        let fresh = SeededEntropy::first_draw(61);
+        let new_epoch = OWNER_ROOT_EPOCH + 1;
+        let (_, envelope) = published_head(&harness, &outcome.new_root_name);
+        let section = published_section(&harness, &outcome.new_root_name);
+        let body = open_write_body(&envelope, &section, &SCOPE, &fresh, new_epoch)
+            .expect("the moved root's write body opens under the fresh write scope seed");
+
+        assert_ne!(
+            body.write_history_link.as_slice(),
+            PLANTED,
+            "the planted bytes are not what the owner re-signed"
+        );
+        let key = kdf::structure_key(&fresh, STRUCT_TAG_HISTORY_LINK);
+        let link_ctx = AadContext {
+            v: ENVELOPE_V,
+            id: SCOPE,
+            scope: SCOPE,
+            epoch: new_epoch,
+            struct_tag: STRUCT_TAG_HISTORY_LINK,
+        };
+        let payload = open_history_link(key.as_bytes(), &link_ctx, &body.write_history_link)
+            .expect("the wave's own link opens under the seed it published");
+        assert!(ct_eq(payload.prev_seed(), &OWNER_ROOT_WRITE_SCOPE_SEED));
+        assert_eq!(payload.prev_epoch, OWNER_ROOT_EPOCH);
+    }
+
+    #[test]
+    fn the_recovery_seam_reads_the_fresh_seed_off_the_published_root() {
+        // #26 D8: no checkpoints. A wave that flipped the pointer leaves its fresh
+        // write scope seed reachable from published records alone — the pointer
+        // names the moved root, the moved root's owner-write blob carries the seed
+        // — so a brand-new orchestrator resumes on it.
+        let harness = Harness::plain();
+        let staged = staged_scope(&harness);
+        let owner = owner_identity();
+        let outcome = {
+            let net = wave(
+                &harness,
+                &owner,
+                &staged.root.name,
+                &staged.root.grant_section.commitment,
+            );
+            let mut entropy = SeededEntropy::new(62);
+            block_on(rotate_scope_write(
+                &mut entropy,
+                &net,
+                &net,
+                &write_plan(&staged.root, &owner),
+            ))
+            .expect("the wave completes")
+        };
+
+        // A fresh net: no gated root parked, no subtree index, nothing carried.
+        let resumed = wave(
+            &harness,
+            &owner,
+            &staged.root.name,
+            &staged.root.grant_section.commitment,
+        );
+        let recovered = block_on(resumed.recover_wave())
+            .expect("the recovery reads published state")
+            .expect("a flipped pointer names an in-flight wave");
+        assert_eq!(recovered.root_name, outcome.new_root_name);
+        assert!(
+            ct_eq(
+                recovered.write_scope_seed.as_bytes(),
+                &SeededEntropy::first_draw(62)
+            ),
+            "the seed comes back off the published root, not from memory"
+        );
+        assert_eq!(
+            derive_write_name(recovered.write_scope_seed.as_bytes(), &SCOPE),
+            recovered.root_name,
+            "the recovered pair satisfies the check rotate_scope_write imposes"
+        );
+    }
+
+    #[test]
+    fn a_scope_pointer_naming_another_predecessor_is_not_this_waves_recovery() {
+        // The pointer is scope-wide and outlives any one rotation: only a re-point
+        // whose `prevRoot` is the root THIS wave is moving off describes this
+        // wave. Anything else is an earlier rotation's, and resuming on its seed
+        // would move the subtree to names the current root never had.
+        let harness = Harness::plain();
+        let staged = staged_scope(&harness);
+        let owner = owner_identity();
+        {
+            let net = wave(
+                &harness,
+                &owner,
+                &staged.root.name,
+                &staged.root.grant_section.commitment,
+            );
+            let mut entropy = SeededEntropy::new(63);
+            block_on(rotate_scope_write(
+                &mut entropy,
+                &net,
+                &net,
+                &write_plan(&staged.root, &owner),
+            ))
+            .expect("the wave completes");
+        }
+
+        let elsewhere = derive_write_name(&[0x3c; 32], &SCOPE);
+        let other = wave(
+            &harness,
+            &owner,
+            &elsewhere,
+            &staged.root.grant_section.commitment,
+        );
+        assert!(
+            block_on(other.recover_wave())
+                .expect("the recovery reads published state")
+                .is_none(),
+            "a re-point off another predecessor is not this wave's to resume"
         );
     }
 

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -64,7 +64,8 @@ use cipherbox_core::suite::x25519::X25519Public;
 
 use super::eager_set::{ResolveFailure, bind_child_labels};
 use super::reseal::{
-    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory,
+    reseal_scope_root,
 };
 use super::rotate::{
     ResealedScopeRoot, RotateScopePlan, ScopeRootPublishError, ScopeRootPublisher,
@@ -361,6 +362,7 @@ where
         }),
         write_scope_seed: plan.write_scope_seed,
         write_epoch: plan.write_epoch,
+        write_history: WriteHistory::Carried(plan.write_history_link),
         pointer_read_key: plan.pointer_read_key,
     };
 
@@ -534,13 +536,13 @@ where
                     commitment: &target.commitment,
                     commitment_sig: &target.commitment_sig,
                     grant_ledger: &target.grant_ledger,
-                    write_history_link: &target.write_history_link,
                     direct_child_scope_index: &target.direct_child_scope_index,
                 },
                 current_override_seed: &target.override_seed,
                 current_read_epoch: target.current_read_epoch,
                 write_scope_seed: &target.write_scope_seed,
                 write_epoch: target.write_epoch,
+                write_history_link: &target.write_history_link,
                 pointer_read_key: &target.pointer_read_key,
                 carried_history_links: &target.carried_history_links,
             };
@@ -935,13 +937,13 @@ mod tests {
                     commitment: &self.commitment,
                     commitment_sig: &self.commitment_sig,
                     grant_ledger: &self.grant_ledger,
-                    write_history_link: b"",
                     direct_child_scope_index: root_children,
                 },
                 current_override_seed: &self.current_seed,
                 current_read_epoch: 4,
                 write_scope_seed: &self.write_scope_seed,
                 write_epoch: 3,
+                write_history_link: b"",
                 pointer_read_key: &self.pointer_read_key,
                 carried_history_links: &[],
             }

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -50,16 +50,17 @@ pub use eager_set::{
     ChildIndexResolver, EagerSet, EnumerationError, ResolveFailure, enumerate_eager_set,
 };
 pub use reseal::{
-    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory,
+    reseal_scope_root,
 };
 pub use rotate::{
     ResealedScopeRoot, RotateError, RotateScopePlan, RotationOutcome, ScopeRootPublishError,
     ScopeRootPublisher, rotate_scope,
 };
 pub use rotate_write::{
-    RepointChannel, RepublishedNode, RotateScopeWritePlan, WritePublishError, WriteRotateError,
-    WriteRotationOutcome, WriteScopeNode, WriteSubtreeResolver, WriteWavePublisher,
-    build_repoint_object, derive_write_name, rotate_scope_write,
+    RepointChannel, RepublishedNode, ResumedWriteWave, RotateScopeWritePlan, WritePublishError,
+    WriteRotateError, WriteRotationOutcome, WriteScopeNode, WriteSubtreeResolver,
+    WriteWavePublisher, build_repoint_object, derive_write_name, rotate_scope_write,
 };
 pub use sweep::{SweepError, SweepOutcome, SweepResolver, SweepTarget, run_sweep, sweep_pass};
 pub use trigger::{

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -371,6 +371,13 @@ pub fn reseal_scope_root<E: Entropy>(
         return Err(ResealError::TooManyCommittedGrants);
     }
 
+    // Fail-closed BEFORE any seal (see `ResealError::HistoryLinkNotDescending`).
+    if let WriteHistory::Cut(prev) = &seeds.write_history
+        && prev.epoch >= seeds.write_epoch
+    {
+        return Err(ResealError::HistoryLinkNotDescending);
+    }
+
     // Fail-closed BEFORE any seal (see `ResealError::LedgerDivergesFromCommitment`
     // and the module's revocation-completeness rule).
     enforce_committed_ledger(committed.commitment, committed.grant_ledger)
@@ -542,19 +549,14 @@ pub fn reseal_scope_root<E: Entropy>(
     // --- The write-plane history link: carried, or minted by the cut itself. ---
     let write_history_link = match &seeds.write_history {
         WriteHistory::Carried(sealed) => sealed.to_vec(),
-        WriteHistory::Cut(prev) => {
-            if prev.epoch >= seeds.write_epoch {
-                return Err(ResealError::HistoryLinkNotDescending);
-            }
-            mint_history_link(
-                entropy,
-                identity.v,
-                scope_id,
-                seeds.write_scope_seed,
-                seeds.write_epoch,
-                prev,
-            )?
-        }
+        WriteHistory::Cut(prev) => mint_history_link(
+            entropy,
+            identity.v,
+            scope_id,
+            seeds.write_scope_seed,
+            seeds.write_epoch,
+            prev,
+        )?,
     };
 
     // --- Write-body: sealed under the write key at the write epoch. ---
@@ -656,6 +658,16 @@ mod tests {
     const SCOPE: [u8; 16] = [0x5c; 16];
     /// The name every honestly minted fixture set binds.
     const MINTED_NAME: &[u8] = b"minted-scope-root-name";
+
+    /// An entropy seam that panics the moment it is drawn — the probe that turns
+    /// "eventually refused" into "refused before the first seal", since every
+    /// seal `reseal_scope_root` performs draws a nonce or an HPKE scalar first.
+    struct UndrawnEntropy;
+    impl Entropy for UndrawnEntropy {
+        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+            panic!("the guard must reject before any seal draws entropy");
+        }
+    }
 
     struct Fixture {
         owner_enc: X25519Secret,
@@ -1338,15 +1350,7 @@ mod tests {
     #[test]
     fn a_committed_ledger_past_the_codec_bound_fails_closed_before_any_seal() {
         // The commitment stays inside the bound, so only the ledger — the side the
-        // wrap loop walks — trips the guard. Entropy panics if drawn, pinning the
-        // rejection ahead of the first HPKE wrap rather than merely eventual.
-        struct UndrawnEntropy;
-        impl Entropy for UndrawnEntropy {
-            fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-                panic!("the bound rejects before any wrap draws entropy");
-            }
-        }
-
+        // wrap loop walks — trips the guard.
         let fx = Fixture::new();
         let owner_pub = fx.owner_enc.public();
         let (commitment, sig, _) = fx.committed();
@@ -1794,14 +1798,16 @@ mod tests {
     }
 
     #[test]
-    fn a_write_cut_that_does_not_advance_the_write_epoch_is_refused_release_active() {
+    fn a_write_cut_that_does_not_advance_the_write_epoch_is_refused_before_any_seal() {
         // A link over an epoch the cut does not advance past is one the ratchet
         // could only drop, so it is never sealed. `assert_eq!` on the verdict, not
-        // a `debug_assert!` — this must fire in a release build.
+        // a `debug_assert!` — this must fire in a release build. An interior
+        // scope root, so `UndrawnEntropy` pins the refusal ahead of every seal
+        // the section carries, the ascent link included.
         let fx = Fixture::new();
         let (commitment, sig, ledger) = fx.committed();
         let owner_pub = fx.owner_enc.public();
-        let id = identity(&fx, &owner_pub, MINTED_NAME, None);
+        let id = identity(&fx, &owner_pub, MINTED_NAME, Some(&fx.parent_node_seed));
         let override_seed = [0x0e; 32];
         let cs = committed_set(&commitment, &sig, &ledger);
         for prev_epoch in [5, 6] {
@@ -1814,9 +1820,8 @@ mod tests {
                 },
                 5,
             );
-            let mut e = SeededEntropy::new(71);
             assert_eq!(
-                reseal_scope_root(&mut e, &id, &s, &cs, &[])
+                reseal_scope_root(&mut UndrawnEntropy, &id, &s, &cs, &[])
                     .expect_err("a non-advancing cut seals nothing")
                     .check(),
                 "history-link-not-descending"

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -8,13 +8,16 @@
 //! rotator's writer pseudonym. It is a **pure composition** of `crates/core`'s
 //! seal primitives: no crypto of its own, it samples no entropy (the injected
 //! [`Entropy`] seam supplies every HPKE ephemeral scalar and seal nonce), and
-//! reads no clock. Its [`ResealSeeds`] source is the axis both callers share:
+//! reads no clock. Its [`ResealSeeds`] source is the axis its callers differ on:
 //!
 //! - **`rotateScope`** passes a fresh random override seed at a new read epoch
 //!   plus the prior seed for a fresh history link — the read-plane root cut.
 //! - **the sweep** passes the scope's *existing* seed at the *current* epoch with
 //!   `prev = None` — a metadata-only catch-up minting no new seed or history link
 //!   (blueprint/engine.md "Sweeps re-seal metadata only").
+//! - **`rotateScopeWrite`**'s name wave leaves the read plane alone and passes a
+//!   fresh write scope seed at an advanced write epoch with
+//!   [`WriteHistory::Cut`].
 //!
 //! # Revocation completeness is the point
 //!
@@ -90,13 +93,32 @@ pub struct ScopeRootIdentity<'a> {
     pub pseudonym_signer: &'a Ed25519Signer,
 }
 
-/// The previous epoch's read seed, sealed into a fresh history link under the
-/// new epoch's structure key (the key-regression ratchet).
+/// The previous epoch's plane seed, sealed into a fresh history link under the
+/// new epoch's structure key (the key-regression ratchet). Used on both planes:
+/// the read plane's `historyLinks`, and the write-body's single write-plane
+/// link.
 pub struct PrevEpochSeed<'a> {
-    /// The previous epoch's override (read scope) seed.
+    /// The previous epoch's scope seed on this plane.
     pub seed: &'a [u8; SECRET_LEN],
     /// The previous epoch it belongs to.
     pub epoch: u64,
+}
+
+/// The write-plane history link a re-seal publishes in the write-body.
+///
+/// A **cut cannot carry**, and the type is what makes that unrepresentable. The
+/// pre-cut link is authored under the retiring `writeScopeSeed`, which every
+/// write grantee holds — including the one a write rotation revokes — so
+/// carrying it would owner-sign a revokee's opaque bytes into the moved root,
+/// where the seed they name is the one an orphaned-name walk would follow.
+pub enum WriteHistory<'a> {
+    /// The write plane is untouched (a read rotation or a sweep): the root's
+    /// existing opaque link stays byte-for-byte, still openable under the write
+    /// scope seed and write epoch that minted it.
+    Carried(&'a [u8]),
+    /// The write plane is being cut: mint a fresh link over the retiring write
+    /// scope seed, sealed under the fresh one at the advanced write epoch.
+    Cut(PrevEpochSeed<'a>),
 }
 
 /// The seed source of a re-seal — the axis that distinguishes a rotation cut
@@ -116,6 +138,9 @@ pub struct ResealSeeds<'a> {
     pub write_scope_seed: &'a [u8; SECRET_LEN],
     /// The write epoch the write-body publishes at (unchanged by a read rotation).
     pub write_epoch: u64,
+    /// The write-plane history link: carried, or minted over the retiring write
+    /// scope seed when this re-seal cuts the write plane.
+    pub write_history: WriteHistory<'a>,
     /// The stable per-scope pointer read key carried in every grant blob.
     pub pointer_read_key: &'a [u8; SECRET_LEN],
 }
@@ -131,8 +156,6 @@ pub struct CommittedSet<'a> {
     /// The authoritative grant ledger — one grant blob is re-wrapped per entry.
     /// MUST equal `commitment` as a `(tag → permission)` set (enforced closed).
     pub grant_ledger: &'a [GrantLedgerEntry],
-    /// The opaque write-plane history-link blob (carried through a read rotation).
-    pub write_history_link: &'a [u8],
     /// The directly-descendant scope roots (the F-4 cascade index, #38 D6).
     pub direct_child_scope_index: &'a [cipherbox_core::seal::ChildScopeRef],
 }
@@ -175,6 +198,10 @@ pub enum ResealError {
     /// More committed grants than the codec's frozen bound admits — a set that
     /// could only ever produce a section this build's own encoder rejects.
     TooManyCommittedGrants,
+    /// A [`WriteHistory::Cut`] would mint a link over a write epoch at or above
+    /// the one it is sealed under — a link the ratchet, which only ever steps
+    /// backward, could not walk. Release-active (AGENTS.md rule 8).
+    HistoryLinkNotDescending,
     /// A re-sealed structure could not be encoded — a duplicate ledger tag, or
     /// nesting past the codec's `MAX_DEPTH`.
     Encode(cipherbox_core::error::CodecError),
@@ -205,6 +232,9 @@ impl core::fmt::Display for ResealError {
             ResealError::TooManyCommittedGrants => {
                 f.write_str("committed grants exceed the codec's frozen bound")
             }
+            ResealError::HistoryLinkNotDescending => {
+                f.write_str("history link would not step the ratchet backward")
+            }
             ResealError::Encode(e) => write!(f, "structure encode failed: {}", e.check()),
         }
     }
@@ -224,6 +254,7 @@ impl ResealError {
             ResealError::Entropy(_) => "entropy-error",
             ResealError::TooManyHistoryLinks => "too-many-history-links",
             ResealError::TooManyCommittedGrants => "too-many-committed-grants",
+            ResealError::HistoryLinkNotDescending => "history-link-not-descending",
             ResealError::Encode(_) => "structure-encode-failed",
         }
     }
@@ -261,6 +292,23 @@ fn walkable_chain_start(
         epoch = payload.prev_epoch;
     }
     0
+}
+
+/// Seal one history link — `prev`'s seed under `seed`'s structure key, bound to
+/// `epoch` — the ratchet's single backward step, on either plane.
+fn mint_history_link<E: Entropy>(
+    entropy: &mut E,
+    v: u64,
+    scope_id: [u8; 16],
+    seed: &[u8; SECRET_LEN],
+    epoch: u64,
+    prev: &PrevEpochSeed<'_>,
+) -> Result<Vec<u8>, ResealError> {
+    let structure_key = kdf::structure_key(seed, STRUCT_TAG_HISTORY_LINK);
+    let nonce = fill::<{ aead::NONCE_LEN }, E>(entropy)?;
+    let ctx = ctx_for(v, scope_id, epoch, STRUCT_TAG_HISTORY_LINK);
+    let payload = HistoryLinkPayload::new(*prev.seed, prev.epoch);
+    seal_history_link(structure_key.as_bytes(), &nonce, &ctx, &payload).map_err(ResealError::Encode)
 }
 
 /// Fill an `N`-byte array from the entropy seam, fail-closed.
@@ -475,12 +523,14 @@ pub fn reseal_scope_root<E: Entropy>(
         })
         .collect();
     if let Some(prev) = &seeds.prev {
-        let structure_key = kdf::structure_key(seeds.override_seed, STRUCT_TAG_HISTORY_LINK);
-        let nonce = fill::<{ aead::NONCE_LEN }, E>(entropy)?;
-        let ctx = ctx_for(identity.v, scope_id, read_epoch, STRUCT_TAG_HISTORY_LINK);
-        let payload = HistoryLinkPayload::new(*prev.seed, prev.epoch);
-        let sealed = seal_history_link(structure_key.as_bytes(), &nonce, &ctx, &payload)
-            .map_err(ResealError::Encode)?;
+        let sealed = mint_history_link(
+            entropy,
+            identity.v,
+            scope_id,
+            seeds.override_seed,
+            read_epoch,
+            prev,
+        )?;
         let signature = sign_over(STRUCT_TAG_HISTORY_LINK, None, &sealed);
         history_links.push(SignedSealed {
             sealed,
@@ -489,11 +539,29 @@ pub fn reseal_scope_root<E: Entropy>(
         });
     }
 
+    // --- The write-plane history link: carried, or minted by the cut itself. ---
+    let write_history_link = match &seeds.write_history {
+        WriteHistory::Carried(sealed) => sealed.to_vec(),
+        WriteHistory::Cut(prev) => {
+            if prev.epoch >= seeds.write_epoch {
+                return Err(ResealError::HistoryLinkNotDescending);
+            }
+            mint_history_link(
+                entropy,
+                identity.v,
+                scope_id,
+                seeds.write_scope_seed,
+                seeds.write_epoch,
+                prev,
+            )?
+        }
+    };
+
     // --- Write-body: sealed under the write key at the write epoch. ---
     let write_body = {
         let wb = WriteBody {
             grant_ledger: committed.grant_ledger.to_vec(),
-            write_history_link: committed.write_history_link.to_vec(),
+            write_history_link,
             direct_child_scope_index: committed.direct_child_scope_index.to_vec(),
             unknown: PreservedFields::new(),
         };
@@ -731,6 +799,7 @@ mod tests {
             prev,
             write_scope_seed,
             write_epoch: 1,
+            write_history: WriteHistory::Carried(b""),
             pointer_read_key,
         }
     }
@@ -744,7 +813,6 @@ mod tests {
             commitment,
             commitment_sig: sig,
             grant_ledger: ledger,
-            write_history_link: b"",
             direct_child_scope_index: &[],
         }
     }
@@ -1403,7 +1471,6 @@ mod tests {
             commitment: &cut.commitment,
             commitment_sig: &cut.commitment_sig,
             grant_ledger: &cut.grant_ledger,
-            write_history_link: b"",
             direct_child_scope_index: &[],
         };
         let mut e = SeededEntropy::new(4);
@@ -1642,5 +1709,118 @@ mod tests {
             build(),
             "same entropy seed → byte-identical section"
         );
+    }
+
+    /// The write scope seed a cut moves TO, and the one it retires.
+    const FRESH_WRITE_SCOPE_SEED: [u8; 32] = [0xc1; 32];
+    const RETIRING_WRITE_SCOPE_SEED: [u8; 32] = [0xc2; 32];
+
+    /// A cut's seeds: the read plane stands still, the write plane advances from
+    /// `prev_write_epoch` to `write_epoch` over a fresh write scope seed.
+    fn cut_seeds<'a>(
+        override_seed: &'a [u8; 32],
+        pointer_read_key: &'a [u8; 32],
+        prev: PrevEpochSeed<'a>,
+        write_epoch: u64,
+    ) -> ResealSeeds<'a> {
+        ResealSeeds {
+            override_seed,
+            read_epoch: 5,
+            prev: None,
+            write_scope_seed: &FRESH_WRITE_SCOPE_SEED,
+            write_epoch,
+            write_history: WriteHistory::Cut(prev),
+            pointer_read_key,
+        }
+    }
+
+    /// The write-body a section publishes, opened as any write-key holder does.
+    fn opened_write_body(
+        section: &GrantSection,
+        write_scope_seed: &[u8; 32],
+        write_epoch: u64,
+    ) -> cipherbox_core::seal::WriteBody {
+        let write_seed = kdf::write_seed(write_scope_seed, &SCOPE);
+        let write_key = kdf::write_key(write_seed.as_bytes());
+        let ctx = ctx_for(V, SCOPE, write_epoch, STRUCT_TAG_WRITE_BODY);
+        let plaintext =
+            cipherbox_core::seal::unseal(write_key.as_bytes(), &ctx, &section.write_body.sealed)
+                .expect("the write body opens under the fresh write key");
+        cipherbox_core::seal::decode_write_body(&plaintext).expect("decodes")
+    }
+
+    #[test]
+    fn a_write_cut_mints_its_history_link_over_the_retiring_seed() {
+        // The link is the cut's own product: it opens only under the FRESH write
+        // scope seed at the NEW write epoch, and yields exactly the seed and epoch
+        // being retired — the one step a resumed wave walks back.
+        let fx = Fixture::new();
+        let (commitment, sig, ledger) = fx.committed();
+        let owner_pub = fx.owner_enc.public();
+        let id = identity(&fx, &owner_pub, MINTED_NAME, None);
+        let override_seed = [0x0e; 32];
+        let s = cut_seeds(
+            &override_seed,
+            &fx.pointer_read_key,
+            PrevEpochSeed {
+                seed: &RETIRING_WRITE_SCOPE_SEED,
+                epoch: 4,
+            },
+            5,
+        );
+        let cs = committed_set(&commitment, &sig, &ledger);
+        let mut e = SeededEntropy::new(70);
+        let section = reseal_scope_root(&mut e, &id, &s, &cs, &[]).expect("reseal");
+
+        let body = opened_write_body(&section, &FRESH_WRITE_SCOPE_SEED, 5);
+        assert!(
+            !body.write_history_link.is_empty(),
+            "the cut mints a link rather than publishing an empty field"
+        );
+        let key = kdf::structure_key(&FRESH_WRITE_SCOPE_SEED, STRUCT_TAG_HISTORY_LINK);
+        let ctx = ctx_for(V, SCOPE, 5, STRUCT_TAG_HISTORY_LINK);
+        let payload = open_history_link(key.as_bytes(), &ctx, &body.write_history_link)
+            .expect("the link opens under the fresh write scope seed at the new write epoch");
+        assert!(ct_eq(payload.prev_seed(), &RETIRING_WRITE_SCOPE_SEED));
+        assert_eq!(payload.prev_epoch, 4);
+
+        // The retiring seed is not a second key for the same link: an old-seed
+        // holder can never walk forward (CONTEXT.md "History link").
+        let stale = kdf::structure_key(&RETIRING_WRITE_SCOPE_SEED, STRUCT_TAG_HISTORY_LINK);
+        assert!(
+            open_history_link(stale.as_bytes(), &ctx, &body.write_history_link).is_err(),
+            "the retiring seed opens nothing"
+        );
+    }
+
+    #[test]
+    fn a_write_cut_that_does_not_advance_the_write_epoch_is_refused_release_active() {
+        // A link over an epoch the cut does not advance past is one the ratchet
+        // could only drop, so it is never sealed. `assert_eq!` on the verdict, not
+        // a `debug_assert!` — this must fire in a release build.
+        let fx = Fixture::new();
+        let (commitment, sig, ledger) = fx.committed();
+        let owner_pub = fx.owner_enc.public();
+        let id = identity(&fx, &owner_pub, MINTED_NAME, None);
+        let override_seed = [0x0e; 32];
+        let cs = committed_set(&commitment, &sig, &ledger);
+        for prev_epoch in [5, 6] {
+            let s = cut_seeds(
+                &override_seed,
+                &fx.pointer_read_key,
+                PrevEpochSeed {
+                    seed: &RETIRING_WRITE_SCOPE_SEED,
+                    epoch: prev_epoch,
+                },
+                5,
+            );
+            let mut e = SeededEntropy::new(71);
+            assert_eq!(
+                reseal_scope_root(&mut e, &id, &s, &cs, &[])
+                    .expect_err("a non-advancing cut seals nothing")
+                    .check(),
+                "history-link-not-descending"
+            );
+        }
     }
 }

--- a/crates/engine/src/rotation/rotate.rs
+++ b/crates/engine/src/rotation/rotate.rs
@@ -39,7 +39,8 @@ use cipherbox_core::seal::{GrantSection, SignedSealed};
 use cipherbox_core::suite::secret::SECRET_LEN;
 
 use super::reseal::{
-    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+    CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory,
+    reseal_scope_root,
 };
 use crate::entropy::Entropy;
 use crate::seams::{BoxedTask, FloorStore, Scheduler, SeamError};
@@ -140,6 +141,9 @@ pub struct RotateScopePlan<'a> {
     pub write_scope_seed: &'a [u8; SECRET_LEN],
     /// The write epoch (unchanged by a read rotation).
     pub write_epoch: u64,
+    /// The root's existing write-plane history link. A read rotation cuts no
+    /// write plane, so it is carried verbatim ([`WriteHistory::Carried`]).
+    pub write_history_link: &'a [u8],
     /// The stable per-scope pointer read key carried in every grant blob.
     pub pointer_read_key: &'a [u8; SECRET_LEN],
     /// The scope's existing per-epoch history links, oldest first. Re-signed and
@@ -251,6 +255,7 @@ where
         }),
         write_scope_seed: plan.write_scope_seed,
         write_epoch: plan.write_epoch,
+        write_history: WriteHistory::Carried(plan.write_history_link),
         pointer_read_key: plan.pointer_read_key,
     };
 
@@ -439,13 +444,13 @@ mod tests {
                     commitment: &commitment,
                     commitment_sig: &sig,
                     grant_ledger: &ledger,
-                    write_history_link: b"",
                     direct_child_scope_index: &[],
                 },
                 current_override_seed: &current_seed,
                 current_read_epoch: 4,
                 write_scope_seed: &fx.write_scope_seed,
                 write_epoch: 3,
+                write_history_link: b"",
                 pointer_read_key: &fx.pointer_read_key,
                 carried_history_links: &[],
             };
@@ -548,13 +553,13 @@ mod tests {
                     commitment: &commitment,
                     commitment_sig: &sig,
                     grant_ledger: &ledger,
-                    write_history_link: b"",
                     direct_child_scope_index: &[],
                 },
                 current_override_seed: &current_seed,
                 current_read_epoch: 1,
                 write_scope_seed: &fx.write_scope_seed,
                 write_epoch: 1,
+                write_history_link: b"",
                 pointer_read_key: &fx.pointer_read_key,
                 carried_history_links: &[],
             };
@@ -616,13 +621,13 @@ mod tests {
                     commitment: &commitment,
                     commitment_sig: &sig,
                     grant_ledger: &ledger,
-                    write_history_link: b"",
                     direct_child_scope_index: &[],
                 },
                 current_override_seed: &current_seed,
                 current_read_epoch: 4,
                 write_scope_seed: &fx.write_scope_seed,
                 write_epoch: 3,
+                write_history_link: b"",
                 pointer_read_key: &fx.pointer_read_key,
                 carried_history_links: &[],
             };
@@ -679,13 +684,13 @@ mod tests {
                     commitment: &commitment,
                     commitment_sig: &sig,
                     grant_ledger: &ledger,
-                    write_history_link: b"",
                     direct_child_scope_index: &[],
                 },
                 current_override_seed: &current_seed,
                 current_read_epoch: u64::MAX,
                 write_scope_seed: &fx.write_scope_seed,
                 write_epoch: 3,
+                write_history_link: b"",
                 pointer_read_key: &fx.pointer_read_key,
                 carried_history_links: &[],
             };

--- a/crates/engine/src/rotation/rotate_write.rs
+++ b/crates/engine/src/rotation/rotate_write.rs
@@ -35,12 +35,14 @@
 //! No cross-crash state: a resumed wave re-derives each node's deterministic new
 //! name and skips already-republished nodes via
 //! [`WriteWavePublisher::is_republished`]; every effect is idempotent, so it
-//! converges to the same terminal state. The fresh write scope seed is recovered
-//! from the published root — that wiring is not landed, faked here via
-//! [`RotateScopeWritePlan::resume_write_scope_seed`]. Accepted limitation: a crash
+//! converges to the same terminal state. The fresh write scope seed comes from
+//! the published moved root through [`WriteSubtreeResolver::recover_wave`], and
+//! is refused unless it derives that root's own name
+//! ([`WriteRotateError::ResumedSeedNotAtItsRoot`]). Accepted limitation: a crash
 //! after the pointer flip but before interior retirement orphans the prior run's
 //! interior old names — the fail-safe direction (leaking a registration beats
-//! retiring a live name); reclaiming those orphaned names is not landed.
+//! retiring a live name); reclaiming those orphaned names from the moved root's
+//! write-plane history link is not landed.
 //!
 //! # Owner-only, fail-closed, deterministic
 //!
@@ -142,6 +144,19 @@ pub struct RepublishedNode {
     pub is_root: bool,
 }
 
+/// A prior wave over this scope, read back from published records: the fresh
+/// write scope seed it minted and the `ipnsName` its moved root was published at.
+/// The pair travels together because the name is what makes the seed checkable —
+/// see [`rotate_scope_write`].
+pub struct ResumedWriteWave {
+    /// The fresh write scope seed the crashed wave minted.
+    pub write_scope_seed: SecretBytes,
+    /// The `ipnsName` the moved root was published at.
+    pub root_name: IpnsName,
+    /// The write epoch the moved root was published at, as the owner signed it.
+    pub write_epoch: u64,
+}
+
 /// Resolve the write scope's subtree from published records — the read edge, the
 /// analogue of the cascade's `CascadeResealResolver`. Resolve + adoption-gate +
 /// unseal live behind this trait (`net/rotation.rs::WriteWaveNet`). A resolve
@@ -151,6 +166,12 @@ pub trait WriteSubtreeResolver {
     /// fail-closed [`ResolveFailure`] if its record cannot be authoritatively
     /// obtained.
     async fn resolve_node(&self, node_id: &[u8; 16]) -> Result<WriteScopeNode, ResolveFailure>;
+
+    /// The in-flight wave to pick up, read from published records; `None` when
+    /// no moved root of this scope is published, which is a fresh rotation.
+    /// The whole of the crash-recovery seam (#26 D8): entropy versus a published
+    /// record, never an in-memory checkpoint a crash would have taken with it.
+    async fn recover_wave(&self) -> Result<Option<ResumedWriteWave>, ResolveFailure>;
 }
 
 /// The write edge of the name wave: CAS republish, batch retire, and the
@@ -243,12 +264,6 @@ pub struct RotateScopeWritePlan<'a> {
     pub min_read_epoch: u64,
     /// The scope root's current `ipnsName` — becomes `prevRootName` and lingers.
     pub current_root_name: &'a IpnsName,
-    /// On a **resumed** wave, the fresh write scope seed recovered from the
-    /// published root (the write-plane history link); `None` on a fresh rotation,
-    /// which mints one via the entropy seam. Recovery wiring is not landed
-    /// (faked in tests); the seam boundary is
-    /// [`Entropy`]-vs-published-record, never in-memory carry.
-    pub resume_write_scope_seed: Option<&'a [u8; SECRET_LEN]>,
 }
 
 /// A completed write rotation. Holding one is proof the whole subtree was
@@ -300,6 +315,19 @@ pub enum WriteRotateError {
     IdentityRepoint,
     /// Minting the fresh write scope seed failed (entropy seam). Retryable.
     Entropy(EntropyError),
+    /// The write scope seed recovered from a published moved root does not derive
+    /// that root's own `ipnsName` — the reverse of the check the republish makes
+    /// forward. Resuming on it would move the whole subtree to names derived from
+    /// a seed nothing owner-authentic ties to this scope, so the wave refuses
+    /// before a single republish. Release-active.
+    ResumedSeedNotAtItsRoot,
+    /// The recovered wave targets a different write epoch than this run does.
+    /// The pointer plane carries no adoption gate, so an older owner-signed
+    /// re-point stays replayable at the scope's one stable pointer name for ever;
+    /// requiring the recovered epoch to be the one this run publishes at is what
+    /// makes a resume pick up **this** wave rather than a superseded one.
+    /// Release-active.
+    ResumedWaveAtAnotherEpoch,
     /// A subtree node could not be authoritatively resolved (gate rejection or host
     /// unavailability), so the wave is not provably complete.
     Resolve {
@@ -341,6 +369,12 @@ impl core::fmt::Display for WriteRotateError {
                 f.write_str("re-point points the scope to its own predecessor name")
             }
             WriteRotateError::Entropy(e) => write!(f, "write-seed entropy error: {e}"),
+            WriteRotateError::ResumedSeedNotAtItsRoot => f.write_str(
+                "recovered write scope seed does not derive the root it was published at",
+            ),
+            WriteRotateError::ResumedWaveAtAnotherEpoch => {
+                f.write_str("recovered wave targets a different write epoch than this rotation")
+            }
             WriteRotateError::Resolve { node_id, reason } => write!(
                 f,
                 "subtree resolve of node [{}] failed: {reason}",
@@ -372,6 +406,8 @@ impl WriteRotateError {
             WriteRotateError::WriteEpochNotAdvancing => "write-epoch-not-advancing",
             WriteRotateError::IdentityRepoint => "identity-repoint",
             WriteRotateError::Entropy(_) => "entropy-error",
+            WriteRotateError::ResumedSeedNotAtItsRoot => "resumed-seed-not-at-its-root",
+            WriteRotateError::ResumedWaveAtAnotherEpoch => "resumed-wave-at-another-epoch",
             WriteRotateError::Resolve { .. } => "resolve-failed",
             WriteRotateError::Publish { .. } => "publish-failed",
             WriteRotateError::Repoint(_) => "repoint-seal-failed",
@@ -386,7 +422,9 @@ impl WriteRotateError {
             | WriteRotateError::CommitmentScopeMismatch
             | WriteRotateError::EpochExhausted
             | WriteRotateError::WriteEpochNotAdvancing
-            | WriteRotateError::IdentityRepoint => false,
+            | WriteRotateError::IdentityRepoint
+            | WriteRotateError::ResumedSeedNotAtItsRoot
+            | WriteRotateError::ResumedWaveAtAnotherEpoch => false,
             WriteRotateError::Entropy(_) => true,
             WriteRotateError::Publish { error, .. } => *error != WritePublishError::Rejected,
             WriteRotateError::Resolve { reason, .. } => *reason == ResolveFailure::Unavailable,
@@ -434,7 +472,7 @@ pub fn build_repoint_object(
 
 /// Perform the owner-only write-plane rotation for the scope in `plan`.
 ///
-/// Owner-checks the caller, mints (or resumes with) the fresh write scope seed,
+/// Owner-checks the caller, recovers or mints the fresh write scope seed,
 /// bumps `writeEpoch`, then runs the child-first name wave: descendants
 /// register-first + republish at their freshly derived names, the root **last**,
 /// then the owner-signed re-point publishes to all three channels, and finally the
@@ -479,12 +517,28 @@ where
         .checked_add(1)
         .ok_or(WriteRotateError::EpochExhausted)?;
 
-    // 3) The fresh write override seed — RANDOM via the entropy seam (never KDF-
-    //    derived), or the seed a resumed wave recovered from the published root.
+    // 3) The fresh write override seed — the seed a crashed wave already published
+    //    at its moved root, or RANDOM via the entropy seam (never KDF-derived).
     //    `Zeroizing` wipes it on every return path, including a panic unwind; this
     //    orchestrator is its terminal owner.
-    let write_scope_seed: Zeroizing<[u8; SECRET_LEN]> = match plan.resume_write_scope_seed {
-        Some(seed) => Zeroizing::new(*seed),
+    let resumed = resolver
+        .recover_wave()
+        .await
+        .map_err(|reason| WriteRotateError::Resolve {
+            node_id: scope_id,
+            reason,
+        })?;
+    let write_scope_seed: Zeroizing<[u8; SECRET_LEN]> = match resumed {
+        Some(wave) => {
+            if wave.write_epoch != new_write_epoch {
+                return Err(WriteRotateError::ResumedWaveAtAnotherEpoch);
+            }
+            let seed = Zeroizing::new(*wave.write_scope_seed.as_bytes());
+            if derive_write_name(&seed, &scope_id) != wave.root_name {
+                return Err(WriteRotateError::ResumedSeedNotAtItsRoot);
+            }
+            seed
+        }
         None => {
             let mut seed = Zeroizing::new([0u8; SECRET_LEN]);
             entropy
@@ -704,6 +758,8 @@ mod tests {
     use std::rc::Rc;
 
     const SCOPE: [u8; 16] = [0x5c; 16];
+    /// The write epoch every test's [`plan`] publishes at (`current_write_epoch + 1`).
+    const ROTATED_WRITE_EPOCH: u64 = 5;
     const OLD_WRITE_SCOPE_SEED: [u8; 32] = [0x0d; 32];
     const OWNER_POINTER_SEED: [u8; 32] = [0x0e; 32];
 
@@ -743,6 +799,10 @@ mod tests {
         derive_write_name(&OLD_WRITE_SCOPE_SEED, node_id)
     }
 
+    /// The moved root as published state holds it: where it landed, the seed its
+    /// grant section publishes, and the write epoch it published at.
+    type PublishedRoot = (IpnsName, [u8; SECRET_LEN], u64);
+
     /// One recorded wave effect, in call order — the tape the ordering invariants
     /// are asserted over.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -752,9 +812,29 @@ mod tests {
         Repoint(RepointChannel),
     }
 
+    /// The recovery a resolver reads back out of published state: the moved root
+    /// the publisher landed, and the write scope seed its grant section carries.
+    /// Nothing else crosses a crash, so a resume that works here works off
+    /// published records alone.
+    fn recover_from(state: &WaveState) -> Result<Option<ResumedWriteWave>, ResolveFailure> {
+        Ok(state.published_root.borrow().as_ref().map(resumed))
+    }
+
+    fn resumed((name, seed, write_epoch): &PublishedRoot) -> ResumedWriteWave {
+        ResumedWriteWave {
+            write_scope_seed: SecretBytes::new(*seed),
+            root_name: name.clone(),
+            write_epoch: *write_epoch,
+        }
+    }
+
     /// A fake subtree resolver over a fixed `node_id -> children` map.
     struct FakeResolver {
         nodes: HashMap<[u8; 16], Vec<[u8; 16]>>,
+        state: WaveState,
+        /// Overrides the published-state recovery, so a test can hand back a pair
+        /// whose seed and root name disagree.
+        recovery: Option<PublishedRoot>,
     }
 
     impl WriteSubtreeResolver for FakeResolver {
@@ -770,6 +850,13 @@ mod tests {
                 child_node_ids: children,
             })
         }
+
+        async fn recover_wave(&self) -> Result<Option<ResumedWriteWave>, ResolveFailure> {
+            match &self.recovery {
+                Some(pair) => Ok(Some(resumed(pair))),
+                None => recover_from(&self.state),
+            }
+        }
     }
 
     /// A resolver modelling a resume AFTER the pointer already flipped: every node
@@ -778,6 +865,7 @@ mod tests {
     struct PostFlipResolver {
         nodes: HashMap<[u8; 16], Vec<[u8; 16]>>,
         seed: [u8; 32],
+        state: WaveState,
     }
 
     impl WriteSubtreeResolver for PostFlipResolver {
@@ -792,6 +880,10 @@ mod tests {
                 current_name: derive_write_name(&self.seed, node_id),
                 child_node_ids: children,
             })
+        }
+
+        async fn recover_wave(&self) -> Result<Option<ResumedWriteWave>, ResolveFailure> {
+            recover_from(&self.state)
         }
     }
 
@@ -808,6 +900,10 @@ mod tests {
             }
             self.inner.resolve_node(node_id).await
         }
+
+        async fn recover_wave(&self) -> Result<Option<ResumedWriteWave>, ResolveFailure> {
+            self.inner.recover_wave().await
+        }
     }
 
     /// Shared, "durable" published state plus the effect tape. Cloning the handle
@@ -816,6 +912,10 @@ mod tests {
     #[derive(Clone, Default)]
     struct WaveState {
         published: Rc<RefCell<HashSet<String>>>,
+        /// The moved root as published state holds it: the name it landed at and
+        /// the write scope seed its grant section publishes. The one thing a
+        /// resumed wave reads back — the recovery seam's whole source.
+        published_root: Rc<RefCell<Option<PublishedRoot>>>,
         retired: Rc<RefCell<HashSet<String>>>,
         events: Rc<RefCell<Vec<Event>>>,
         republish_calls: Rc<RefCell<HashMap<String, usize>>>,
@@ -879,6 +979,14 @@ mod tests {
                 .entry(key.clone())
                 .or_insert(0) += 1;
             self.state.published.borrow_mut().insert(key);
+            if let Some(seed) = node
+                .is_root
+                .then_some(node.write_scope_seed.as_ref())
+                .flatten()
+            {
+                *self.state.published_root.borrow_mut() =
+                    Some((node.new_name.clone(), *seed.as_bytes(), node.write_epoch));
+            }
             self.state.orders.borrow_mut().push(node.clone());
             self.state.events.borrow_mut().push(Event::Republish {
                 node_id: node.node_id,
@@ -912,13 +1020,23 @@ mod tests {
 
     /// A three-level tree: root(0x5c) → {0x02, 0x03}; 0x02 → {0x04, 0x05}.
     fn tree() -> FakeResolver {
+        tree_on(WaveState::default())
+    }
+
+    /// The same tree, reading its recovery out of `state` — the shared published
+    /// backing a resumed wave picks up from.
+    fn tree_on(state: WaveState) -> FakeResolver {
         let mut nodes = HashMap::new();
         nodes.insert(SCOPE, vec![nid(0x02), nid(0x03)]);
         nodes.insert(nid(0x02), vec![nid(0x04), nid(0x05)]);
         nodes.insert(nid(0x03), Vec::new());
         nodes.insert(nid(0x04), Vec::new());
         nodes.insert(nid(0x05), Vec::new());
-        FakeResolver { nodes }
+        FakeResolver {
+            nodes,
+            state,
+            recovery: None,
+        }
     }
 
     fn plan<'a>(
@@ -926,7 +1044,6 @@ mod tests {
         commitment: &'a GrantSetCommitment,
         sig: &'a [u8; ECDSA_SIG_LEN],
         current_root: &'a IpnsName,
-        resume: Option<&'a [u8; 32]>,
     ) -> RotateScopeWritePlan<'a> {
         RotateScopeWritePlan {
             scope_id: SCOPE,
@@ -938,7 +1055,6 @@ mod tests {
             current_write_epoch: 4,
             min_read_epoch: 7,
             current_root_name: current_root,
-            resume_write_scope_seed: resume,
         }
     }
 
@@ -957,7 +1073,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1063,7 +1179,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1099,7 +1215,7 @@ mod tests {
         let state = WaveState::default();
         let publisher = FakePublisher::new(state.clone());
         let current_root = old_name_of(&SCOPE);
-        let seed = [0x5e; 32];
+        let seed = SeededEntropy::first_draw(11);
 
         block_on(async {
             let mut e = SeededEntropy::new(11);
@@ -1107,7 +1223,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, Some(&seed)),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1170,7 +1286,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1208,7 +1324,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1241,43 +1357,36 @@ mod tests {
 
     #[test]
     fn mid_wave_crash_resumes_from_published_records_only() {
-        // Crash the wave after two republishes, then resume with a FRESH orchestrator
-        // over the SAME published state (no in-memory carry) and the recovered seed.
-        // The resumed wave completes, republishes each remaining node exactly once
-        // (already-done nodes skipped via published state), and re-points last.
+        // Crash the wave at the canonical re-point — past the root republish, so
+        // published state holds the moved root — then resume with a FRESH
+        // orchestrator, a fresh publisher, and an entropy stream that would mint a
+        // DIFFERENT seed. Nothing is handed in: the resume converges on the first
+        // run's names or not at all.
         let owner = owner();
         let (c, sig) = commitment(&owner);
-        let resolver = tree();
         let state = WaveState::default();
+        let resolver = tree_on(state.clone());
         let current_root = old_name_of(&SCOPE);
+        let minted = SeededEntropy::first_draw(9);
 
-        // The seed a fresh wave WOULD mint — captured so the resume threads it back
-        // in, standing in for recovery from the published root.
-        let recovered_seed = {
-            let mut e = SeededEntropy::new(9);
-            let mut seed = [0u8; 32];
-            e.fill(&mut seed).unwrap();
-            seed
-        };
-
-        // First attempt crashes after two republishes.
-        let crashing = FakePublisher::failing_after(state.clone(), 2);
+        // First attempt lands every republish, then dies on the pointer flip.
+        let crashing = FakePublisher::refusing(state.clone(), RepointChannel::ScopePointer);
         let err = block_on(async {
             let mut e = SeededEntropy::new(9);
             rotate_scope_write(
                 &mut e,
                 &resolver,
                 &crashing,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
         .expect_err("the wave crashes mid-flight");
         assert_eq!(err.check(), "publish-failed");
-        let published_after_crash = state.published.borrow().len();
-        assert!(
-            (1..5).contains(&published_after_crash),
-            "a strict, non-empty subset republished before the crash (got {published_after_crash})"
+        assert_eq!(
+            state.published.borrow().len(),
+            5,
+            "the whole subtree republished before the flip failed"
         );
         assert!(
             state.repoint_channels.borrow().is_empty(),
@@ -1287,12 +1396,12 @@ mod tests {
         // Resume: a brand-new orchestrator + publisher over the same durable state.
         let resume_pub = FakePublisher::new(state.clone());
         let outcome = block_on(async {
-            let mut e = SeededEntropy::new(123); // a DIFFERENT stream — no fresh mint on resume
+            let mut e = SeededEntropy::new(123); // a DIFFERENT stream — a fresh mint would diverge
             rotate_scope_write(
                 &mut e,
                 &resolver,
                 &resume_pub,
-                &plan(&owner, &c, &sig, &current_root, Some(&recovered_seed)),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1301,7 +1410,13 @@ mod tests {
         assert_eq!(outcome.new_write_epoch, 5);
         assert_eq!(
             outcome.new_root_name,
-            derive_write_name(&recovered_seed, &SCOPE)
+            derive_write_name(&minted, &SCOPE),
+            "the resume ran on the first run's published seed, not a fresh mint"
+        );
+        assert_ne!(
+            minted,
+            SeededEntropy::first_draw(123),
+            "the resume's own stream would have minted a different seed"
         );
 
         // Every node republished exactly once across BOTH runs — the resume skipped
@@ -1336,6 +1451,144 @@ mod tests {
     }
 
     #[test]
+    fn a_recovered_wave_at_another_write_epoch_is_refused_before_any_publish() {
+        // Nothing gates the scope pointer, and every re-point this scope ever
+        // published lives at the same stable name — so an older owner-signed
+        // re-point stays replayable for ever. Requiring the recovered epoch to be
+        // the one this run publishes at is what pins a resume to THIS wave.
+        let owner = owner();
+        let (c, sig) = commitment(&owner);
+        let state = WaveState::default();
+        let stale_seed = [0x93; SECRET_LEN];
+        let resolver = FakeResolver {
+            recovery: Some((
+                derive_write_name(&stale_seed, &SCOPE),
+                stale_seed,
+                ROTATED_WRITE_EPOCH - 1,
+            )),
+            ..tree_on(state.clone())
+        };
+        let publisher = FakePublisher::new(state.clone());
+        let current_root = old_name_of(&SCOPE);
+
+        let err = block_on(async {
+            let mut e = SeededEntropy::new(32);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &publisher,
+                &plan(&owner, &c, &sig, &current_root),
+            )
+            .await
+        })
+        .expect_err("a wave at another write epoch is not this run's to resume");
+        assert_eq!(err.check(), "resumed-wave-at-another-epoch");
+        assert!(!err.is_retryable(), "a replayed re-point is not a stall");
+        assert!(
+            state.published.borrow().is_empty(),
+            "nothing published on a refused recovery"
+        );
+    }
+
+    #[test]
+    fn a_recovered_seed_that_does_not_derive_its_root_name_is_refused() {
+        // The recovery's two halves must agree: a seed that derives some other
+        // name is what a forged write-plane history link, or a root published
+        // under a seed nothing ties to it, would hand back. Resuming on it would
+        // republish the whole subtree under attacker-chosen names, so the wave
+        // refuses before it touches the publisher.
+        let owner = owner();
+        let (c, sig) = commitment(&owner);
+        let state = WaveState::default();
+        let resolver = FakeResolver {
+            // A real published root name, but not the one that seed derives.
+            recovery: Some((
+                derive_write_name(&[0x92; SECRET_LEN], &SCOPE),
+                [0x91; SECRET_LEN],
+                ROTATED_WRITE_EPOCH,
+            )),
+            ..tree_on(state.clone())
+        };
+        let publisher = FakePublisher::new(state.clone());
+        let current_root = old_name_of(&SCOPE);
+
+        let err = block_on(async {
+            let mut e = SeededEntropy::new(31);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &publisher,
+                &plan(&owner, &c, &sig, &current_root),
+            )
+            .await
+        })
+        .expect_err("a seed that does not derive its own root name is refused");
+        assert_eq!(err.check(), "resumed-seed-not-at-its-root");
+        assert!(!err.is_retryable(), "no retry reconciles the two halves");
+        assert!(
+            state.published.borrow().is_empty(),
+            "nothing published on a refused recovery"
+        );
+    }
+
+    #[test]
+    fn a_crash_before_the_root_publishes_has_no_seed_to_recover() {
+        // The moved root is the only published carrier of the fresh seed, so a
+        // crash before it lands leaves nothing to recover: the retry mints its own
+        // and the first run's interior names are orphaned — the fail-safe
+        // direction the module documents.
+        let owner = owner();
+        let (c, sig) = commitment(&owner);
+        let state = WaveState::default();
+        let resolver = tree_on(state.clone());
+        let current_root = old_name_of(&SCOPE);
+
+        let crashing = FakePublisher::failing_after(state.clone(), 2);
+        block_on(async {
+            let mut e = SeededEntropy::new(41);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &crashing,
+                &plan(&owner, &c, &sig, &current_root),
+            )
+            .await
+        })
+        .expect_err("the wave crashes before the root republish");
+        assert!(
+            state.published_root.borrow().is_none(),
+            "no moved root published, so nothing carries the seed"
+        );
+        let orphaned: Vec<String> = state.published.borrow().iter().cloned().collect();
+        assert_eq!(orphaned.len(), 2, "two interior names landed");
+
+        let resume_pub = FakePublisher::new(state.clone());
+        let outcome = block_on(async {
+            let mut e = SeededEntropy::new(42);
+            rotate_scope_write(
+                &mut e,
+                &resolver,
+                &resume_pub,
+                &plan(&owner, &c, &sig, &current_root),
+            )
+            .await
+        })
+        .expect("the retry completes on a freshly minted seed");
+
+        assert_eq!(
+            outcome.new_root_name,
+            derive_write_name(&SeededEntropy::first_draw(42), &SCOPE),
+            "the retry minted its own seed"
+        );
+        for name in &orphaned {
+            assert!(
+                !state.retired.borrow().contains(name),
+                "the first run's names are orphaned, never retired"
+            );
+        }
+    }
+
+    #[test]
     fn resume_after_flip_never_retires_a_live_name() {
         // A resume AFTER the pointer already flipped: the resolver reports every
         // node's NEW name as current (the migrated records the flipped pointer now
@@ -1351,12 +1604,14 @@ mod tests {
         nodes.insert(nid(0x03), Vec::new());
         nodes.insert(nid(0x04), Vec::new());
         nodes.insert(nid(0x05), Vec::new());
+        let state = WaveState::default();
         let resolver = PostFlipResolver {
             nodes,
             seed: recovered_seed,
+            state: state.clone(),
         };
-        let state = WaveState::default();
-        // The fully-migrated published state: every new name already landed.
+        // The fully-migrated published state: every new name already landed, and
+        // the moved root carries the seed the resume recovers.
         for id in [SCOPE, nid(0x02), nid(0x03), nid(0x04), nid(0x05)] {
             let name = derive_write_name(&recovered_seed, &id);
             state
@@ -1364,6 +1619,11 @@ mod tests {
                 .borrow_mut()
                 .insert(name.as_str().to_owned());
         }
+        *state.published_root.borrow_mut() = Some((
+            derive_write_name(&recovered_seed, &SCOPE),
+            recovered_seed,
+            ROTATED_WRITE_EPOCH,
+        ));
         let publisher = FakePublisher::new(state.clone());
         let current_root = old_name_of(&SCOPE);
 
@@ -1373,7 +1633,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, Some(&recovered_seed)),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1398,7 +1658,7 @@ mod tests {
 
         let err = block_on(async {
             let mut e = SeededEntropy::new(3);
-            let mut p = plan(&owner, &c, &sig, &current_root, None);
+            let mut p = plan(&owner, &c, &sig, &current_root);
             p.owner_identity_signer = &impostor;
             rotate_scope_write(&mut e, &resolver, &publisher, &p).await
         })
@@ -1435,7 +1695,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1469,7 +1729,7 @@ mod tests {
                 &mut e,
                 &resolver,
                 &publisher,
-                &plan(&owner, &c, &sig, &current_root, None),
+                &plan(&owner, &c, &sig, &current_root),
             )
             .await
         })
@@ -1491,7 +1751,7 @@ mod tests {
 
         let err = block_on(async {
             let mut e = SeededEntropy::new(5);
-            let mut p = plan(&owner, &c, &sig, &current_root, None);
+            let mut p = plan(&owner, &c, &sig, &current_root);
             p.current_write_epoch = u64::MAX;
             rotate_scope_write(&mut e, &resolver, &publisher, &p).await
         })

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -59,7 +59,9 @@ use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::X25519Public;
 
 use super::eager_set::{ChildIndexResolver, EnumerationError, ResolveFailure, enumerate_eager_set};
-use super::reseal::{CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, reseal_scope_root};
+use super::reseal::{
+    CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory, reseal_scope_root,
+};
 use super::rotate::{ResealedScopeRoot, ScopeRootPublishError, ScopeRootPublisher};
 use crate::entropy::Entropy;
 use crate::gate::floor;
@@ -364,13 +366,13 @@ where
             prev: None,
             write_scope_seed: &target.write_scope_seed,
             write_epoch: target.write_epoch,
+            write_history: WriteHistory::Carried(&target.write_history_link),
             pointer_read_key: &target.pointer_read_key,
         };
         let committed = CommittedSet {
             commitment: &target.commitment,
             commitment_sig: &target.commitment_sig,
             grant_ledger: &target.grant_ledger,
-            write_history_link: &target.write_history_link,
             direct_child_scope_index: &canonical_index,
         };
 

--- a/crates/engine/src/testkit/entropy.rs
+++ b/crates/engine/src/testkit/entropy.rs
@@ -17,6 +17,14 @@ impl SeededEntropy {
         Self { state: seed }
     }
 
+    /// The first 32-byte draw off `seed` — what a primitive that mints one seed
+    /// before anything else gets, so a test can name every derived value.
+    pub fn first_draw(seed: u64) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        Self::new(seed).fill(&mut out).expect("infallible");
+        out
+    }
+
     fn next_u64(&mut self) -> u64 {
         // SplitMix64: tiny, well-distributed, dependency-free.
         self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);

--- a/crates/engine/src/testkit/owner_root.rs
+++ b/crates/engine/src/testkit/owner_root.rs
@@ -81,6 +81,10 @@ pub struct OwnerRootSpec<'a> {
     /// epoch (its structure signature still binds the read epoch — mirrors
     /// reseal); `None` leaves the root held keyless.
     pub owner_write_blob_epoch: Option<u64>,
+    /// The write-body's opaque write-plane history link. Any committed writer can
+    /// author these bytes, so a fixture plants them to prove where they do and do
+    /// not survive a re-seal.
+    pub write_history_link: Vec<u8>,
 }
 
 /// The authored owner root: the head block plus the pieces a caller asserts on.
@@ -109,6 +113,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         parent_node_seed,
         owner_write_blob_epoch,
         grants,
+        write_history_link,
     } = spec;
     let owner_pseudonym = Ed25519Signer::from_seed(OWNER_ROOT_PSEUDONYM_SEED);
 
@@ -154,7 +159,7 @@ pub fn owner_root_fixture(spec: OwnerRootSpec<'_>) -> OwnerRootFixture {
         &aad(OWNER_ROOT_EPOCH, STRUCT_TAG_WRITE_BODY),
         &encode_write_body(&WriteBody {
             grant_ledger: grants.iter().map(|g| g.ledger_entry.clone()).collect(),
-            write_history_link: Vec::new(),
+            write_history_link,
             direct_child_scope_index: child_scope_index,
             unknown: PreservedFields::new(),
         })

--- a/crates/engine/tests/adoption_gate.rs
+++ b/crates/engine/tests/adoption_gate.rs
@@ -37,7 +37,7 @@ use cipherbox_engine::gate::{
 };
 use cipherbox_engine::net::MAX_RECORD_BYTES;
 use cipherbox_engine::rotation::{
-    CommittedSet, PrevEpochSeed, ResealSeeds, ScopeRootIdentity, reseal_scope_root,
+    CommittedSet, PrevEpochSeed, ResealSeeds, ScopeRootIdentity, WriteHistory, reseal_scope_root,
 };
 use cipherbox_engine::seams::{FloorStore, RecordTransport, Scheduler};
 use cipherbox_engine::testkit::fakes::InMemoryFloorStore;
@@ -1600,7 +1600,6 @@ impl ResealedFixture {
             commitment: &commitment,
             commitment_sig: &commitment_sig,
             grant_ledger: &[],
-            write_history_link: b"",
             direct_child_scope_index: &[],
         };
         let reseal = |read_epoch: u64,
@@ -1616,6 +1615,7 @@ impl ResealedFixture {
                     prev: Some(prev),
                     write_scope_seed: &RESEAL_WRITE_SCOPE_SEED,
                     write_epoch: RESEAL_WRITE_EPOCH,
+                    write_history: WriteHistory::Carried(&[]),
                     pointer_read_key: &pointer_read_key,
                 },
                 &committed,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -473,6 +473,7 @@ fn seed_account(world: &FakeWorld, blocks: &Blocks) -> IpnsName {
         // owner-write-blob and the owner recovers its scope write seed — the
         // seed the drain derives every new node's name and signer from.
         owner_write_blob_epoch: Some(EPOCH),
+        write_history_link: Vec::new(),
         grants: Vec::new(),
     });
     blocks.put(fixture.head_block.clone());
@@ -5830,6 +5831,7 @@ fn concurrent_root_add(records: &InMemoryRecordStore, blocks: &Blocks, extra: Ch
         child_scope_index: Vec::new(),
         parent_node_seed: None,
         owner_write_blob_epoch: Some(EPOCH),
+        write_history_link: Vec::new(),
         grants: Vec::new(),
     });
     blocks.put(fixture.head_block.clone());

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -1306,6 +1306,7 @@ mod published {
             child_scope_index: Vec::new(),
             parent_node_seed: None,
             owner_write_blob_epoch: Some(EPOCH),
+            write_history_link: Vec::new(),
             grants: Vec::new(),
         });
         blocks.put(fixture.head_block.clone());


### PR DESCRIPTION
Two halves of one change. Landing the recovery without the guard would be a write-plane takeover, so they ship together.

`WriteWaveNet::reseal_root` carried the writer-authored `writeHistoryLink` verbatim into the owner-signed moved root. `WriteBody` is sealed under `writeScopeSeed`, which **every** write grantee holds — including the one the rotation is cutting — and no owner signature covers that field. Nothing minted the field either, so a genuine mid-wave crash had no published source for the fresh write scope seed and the subtree stranded half-moved; the existing crash-recovery tests passed only because the test handed the seed back in memory.

## Design choice

Of the two options #1179 sketches, this takes the second — extend `ResealSeeds` with a write-plane `prev` and mint the link — because it is the one that also satisfies #1139, and because the empty-link option would have deleted a field the blueprint makes load-bearing (`blueprint/api.md`: "interior old names are batch-retired at wave completion — a resumed wave enumerates them via the write-plane history link").

The shape is a two-variant enum rather than an extra field, so the invariant is structural rather than a runtime guard:

```rust
pub enum WriteHistory<'a> {
    Carried(&'a [u8]),      // the write plane is untouched
    Cut(PrevEpochSeed<'a>), // the write plane is being cut
}
```

`CommittedSet.write_history_link` is removed, so **a cut has no channel to carry through** — it is unrepresentable rather than checked. `Carried` keeps the existing byte-for-byte behaviour on every path that leaves the write plane alone (read rotation, sweep, cascade, grant create), so no live carry is dropped.

The link mirrors the read plane exactly: `seal_history_link` under `kdf::structure_key(fresh_write_scope_seed, history-link)`, AAD at the **new write epoch**, payload = the **retiring** seed and epoch. That is a use of the existing frozen `structure-key` edge — `blueprint/core.md`'s catalog row reads "nodeSeed **or scope seed**, structTag" — not a new edge, so no KAT regeneration and no wire-format change (`WriteBody.writeHistoryLink` is unchanged in shape).

## Recovery

`WriteSubtreeResolver::recover_wave` replaces `RotateScopeWritePlan::resume_write_scope_seed`, which was faked in every test. The production arm reads the scope pointer, verifies the owner-signed re-point object, requires `prevRoot` to be the root **this** rotation is moving off, runs the moved root through the full adoption gate, and opens its owner-write blob at the epoch the re-point names. The durable write-epoch floor is deliberately not raised here — a resume still re-reads the pre-wave root, whose write plane sits an epoch below.

`rotate_scope_write` then refuses:

- a recovered wave at a write epoch other than the one this run publishes at (the pointer plane has no adoption gate, so an older owner-signed re-point stays replayable at the scope's one stable pointer name);
- a recovered seed that does not derive the published root name — the reverse of the check `publish_moved` already makes forward.

A cut that does not advance the write epoch is refused release-active with `ResealError::HistoryLinkNotDescending`, never a `debug_assert!`; the ratchet only steps backward, so such a link is one every reader's walk drops. Covered by a test that also passes under `cargo test --release`.

## Tests

New, each proven red by reverting the production line via an edit and re-running:

- `a_write_cut_mints_its_history_link_over_the_retiring_seed`
- `a_write_cut_that_does_not_advance_the_write_epoch_is_refused_release_active`
- `a_planted_write_history_link_is_never_re_signed_into_the_moved_root`
- `the_recovery_seam_reads_the_fresh_seed_off_the_published_root`
- `a_scope_pointer_naming_another_predecessor_is_not_this_waves_recovery`
- `a_recovered_seed_that_does_not_derive_its_root_name_is_refused`
- `a_recovered_wave_at_another_write_epoch_is_refused_before_any_publish`
- `a_crash_before_the_root_publishes_has_no_seed_to_recover`

`mid_wave_crash_resumes_from_published_records_only` was rewritten to be honest: it now crashes at the canonical re-point (past the root republish, so published state holds the moved root), resumes with a fresh orchestrator on an entropy stream that would mint a *different* seed, and asserts the resume converged on the first run's published seed. The fake publisher records what the moved root's grant section publishes; the fake resolver reads it back. Nothing crosses the crash in memory.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` all exit 0.

## Not fixed here

The non-atomicity between the write-floor guard and the root publish is untouched. Review findings on the `Carried` path's unauthenticated, unbounded bytes and on the minted link's audience are filed as follow-ups rather than folded in — they are pre-existing or spec-level, and nothing reads the field yet.

Closes #1139
Closes #1179


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix write-plane history link minting and recover a resumed wave from published state
> - `rotate_scope_write` now calls `WriteSubtreeResolver::recover_wave` before minting fresh entropy; if a published seed is found, it validates the recovered epoch and root name before resuming, returning new non-retryable errors (`ResumedWaveAtAnotherEpoch`, `ResumedSeedNotAtItsRoot`) on mismatch.
> - `WriteWaveNet.recover_wave` implements recovery by reading the scope pointer and moved root to extract the write scope seed and epoch from the published owner-write blob.
> - `reseal_scope_root` now receives write-plane history context via `ResealSeeds.write_history` (either `WriteHistory::Carried` or `WriteHistory::Cut`) instead of `CommittedSet.write_history_link`, and mints a sealed history link during a write cut while rejecting non-advancing cuts with `ResealError::HistoryLinkNotDescending`.
> - `RotateScopeWritePlan` no longer accepts a caller-injected `resume_write_scope_seed`; resume seeds now come exclusively from `recover_wave` or fresh entropy.
> - Risk: `WriteSubtreeResolver` is a breaking trait change — all implementors must now provide `recover_wave`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28007a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved write-scope rotation and resealing by preserving or safely creating write history.
  * Enhanced crash recovery to restore write operations from published state with stronger epoch and root validation.
  * Added safeguards that reject stale or invalid history links and prevent unsafe re-signing.
* **Testing**
  * Expanded coverage for recovery scenarios, predecessor validation, seed derivation, and post-rotation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->