### PR TITLE
fix: make put_staged_bytes failure-atomic and hold every host to it

### DIFF
--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -47,6 +47,65 @@ fn file_staging_store_passes_the_staging_store_kit() {
     }));
 }
 
+/// The failed-put kit case. The lever is a permission denial `atomic_write`
+/// hits on its way to the sidecar: on Unix the `staged/` directory is made
+/// unwritable, so the temp file cannot be created; on Windows the sidecar
+/// itself is made read-only, which `MoveFileEx` refuses to replace. Either way
+/// the failure lands before the sidecar's bytes can change.
+#[test]
+fn file_staging_store_passes_the_failed_put_kit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+    let denial = WriteDenial::for_store(&path);
+    block_on(conformance::staging_store::check_failed_put(
+        async || FileStagingStore::open(&path).unwrap(),
+        async || denial.arm(),
+    ));
+}
+
+/// Denies writes to the path `atomic_write` must touch, restoring access on
+/// drop so a kit panic still leaves the temp dir reclaimable.
+struct WriteDenial(std::path::PathBuf);
+
+impl WriteDenial {
+    fn for_store(store_root: &std::path::Path) -> Self {
+        let staged = store_root.join("staged");
+        // Windows honours a read-only file, not a read-only directory, so the
+        // denial has to sit on the sidecar the kit's key names.
+        Self(if cfg!(windows) {
+            let name: String = conformance::staging_store::FAILED_PUT_KEY
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect();
+            staged.join(format!("{name}.bin"))
+        } else {
+            staged
+        })
+    }
+
+    fn arm(&self) {
+        set_denied(&self.0, true);
+    }
+}
+
+impl Drop for WriteDenial {
+    fn drop(&mut self) {
+        set_denied(&self.0, false);
+    }
+}
+
+fn set_denied(path: &std::path::Path, denied: bool) {
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(if denied { 0o555 } else { 0o755 });
+    }
+    #[cfg(not(unix))]
+    perms.set_readonly(denied);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
 /// The retire ledger rides the durable staging store, so the desktop's
 /// owed-retirement contract is the file store's. Each reopened handle is leaked
 /// for the kit's borrow; the test process is its owner.

--- a/crates/desktop-seams/tests/conformance.rs
+++ b/crates/desktop-seams/tests/conformance.rs
@@ -63,6 +63,22 @@ fn file_staging_store_passes_the_failed_put_kit() {
     ));
 }
 
+/// The failed-put kit's fresh-backing case: a first put that fails must land
+/// nothing at the key. Unix only — the lever has to be armed before the key
+/// exists, and Windows honours no denial on a path that is not there yet, so
+/// its leg runs the replacement case above.
+#[cfg(unix)]
+#[test]
+fn file_staging_store_passes_the_failed_first_put_kit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("staging");
+    let denial = WriteDenial::for_store(&path);
+    block_on(conformance::staging_store::check_failed_first_put(
+        async || FileStagingStore::open(&path).unwrap(),
+        async || denial.arm(),
+    ));
+}
+
 /// Denies writes to the path `atomic_write` must touch, restoring access on
 /// drop so a kit panic still leaves the temp dir reclaimable.
 struct WriteDenial(std::path::PathBuf);
@@ -84,18 +100,21 @@ impl WriteDenial {
     }
 
     fn arm(&self) {
-        set_denied(&self.0, true);
+        set_denied(&self.0, true).expect("the kit's lever must be armed, or it proves nothing");
     }
 }
 
 impl Drop for WriteDenial {
     fn drop(&mut self) {
-        set_denied(&self.0, false);
+        // Best-effort: drop runs while a kit panic unwinds, and a second panic
+        // there aborts the process over the failure worth reporting. What is
+        // left behind is a temp dir the harness reclaims.
+        let _ = set_denied(&self.0, false);
     }
 }
 
-fn set_denied(path: &std::path::Path, denied: bool) {
-    let mut perms = std::fs::metadata(path).unwrap().permissions();
+fn set_denied(path: &std::path::Path, denied: bool) -> std::io::Result<()> {
+    let mut perms = std::fs::metadata(path)?.permissions();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -103,7 +122,7 @@ fn set_denied(path: &std::path::Path, denied: bool) {
     }
     #[cfg(not(unix))]
     perms.set_readonly(denied);
-    std::fs::set_permissions(path, perms).unwrap();
+    std::fs::set_permissions(path, perms)
 }
 
 /// The retire ledger rides the durable staging store, so the desktop's

--- a/crates/engine/src/seams/staging_store.rs
+++ b/crates/engine/src/seams/staging_store.rs
@@ -39,6 +39,13 @@ pub trait StagingStore {
 
     /// Stores staged bytes under an opaque staging key, replacing any
     /// previous bytes at that key.
+    ///
+    /// The replacement is failure-atomic: an `Err` leaves the previous bytes
+    /// readable and byte-identical, and leaves a key that held none absent —
+    /// never a truncated or half-written value. Callers store whole-set
+    /// records here (the retire ledger's owed reclaims, the drain's op-id
+    /// high-water marks), so a lost replacement is destroyed durable state,
+    /// not a retryable hiccup.
     async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()>;
 
     /// The staged bytes at a key, verbatim; `None` if absent.

--- a/crates/engine/src/testkit/conformance/staging_store.rs
+++ b/crates/engine/src/testkit/conformance/staging_store.rs
@@ -3,8 +3,8 @@
 
 use crate::seams::StagingStore;
 
-/// The staging key [`check_failed_put`] writes, so a host whose fault
-/// injector is scoped to one key can arm exactly the put the kit makes fail.
+/// The staging key the failed-put cases write, so a host whose fault injector
+/// is scoped to one key can arm exactly the put the kit makes fail.
 pub const FAILED_PUT_KEY: &[u8] = b"failed-put-key";
 
 /// Runs the `StagingStore` contract against an implementation.
@@ -13,8 +13,9 @@ pub const FAILED_PUT_KEY: &[u8] = b"failed-put-key";
 /// (reopen semantics); the backing must start empty.
 ///
 /// The failure-atomicity half of `put_staged_bytes` needs a fault lever this
-/// function cannot supply, so it lives in [`check_failed_put`]; a host passes
-/// both or it is only half held to the contract.
+/// function cannot supply, so it lives in [`check_failed_put`] and
+/// [`check_failed_first_put`]; a host passes all three or it is only part-held
+/// to the contract.
 ///
 /// # Panics
 /// Panics on the first contract violation.
@@ -132,9 +133,10 @@ where
     );
 }
 
-/// Runs the failure-atomicity half of [`StagingStore::put_staged_bytes`]
-/// against an implementation: a put that returns `Err` must leave the previous
-/// bytes exactly as it found them.
+/// Runs the replacement case of [`StagingStore::put_staged_bytes`]'s failure
+/// atomicity against an implementation: a put that returns `Err` over an
+/// existing record must leave the previous bytes exactly as it found them.
+/// [`check_failed_first_put`] covers the same put into fresh backing.
 ///
 /// Separate from [`check`] because it needs a lever [`check`] cannot supply —
 /// `arm_failed_put` must make the next `put_staged_bytes` at
@@ -192,5 +194,63 @@ where
         reopened.staged_bytes_total().await.unwrap(),
         total,
         "a failed put must leave the staging budget on the surviving bytes"
+    );
+}
+
+/// Runs the fresh-backing case of [`StagingStore::put_staged_bytes`]'s failure
+/// atomicity: a put that returns `Err` for a key that held nothing must leave
+/// that key absent — never an empty or half-written record.
+///
+/// A separate entry point rather than a phase of [`check_failed_put`] because
+/// the two cases cannot share one backing: this one needs the lever armed
+/// before the key's first put, while [`check_failed_put`] needs an unarmed put
+/// to establish the bytes it then defends.
+///
+/// `arm_failed_put` and `open` carry [`check_failed_put`]'s contracts, and the
+/// backing must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check_failed_first_put<S, F, G>(mut open: F, arm_failed_put: G)
+where
+    S: StagingStore,
+    F: AsyncFnMut() -> S,
+    G: AsyncFnOnce(),
+{
+    let store = open().await;
+    assert!(
+        store.staged_keys().await.unwrap().is_empty(),
+        "this case reads the key's absence as the result, so the backing must start empty"
+    );
+
+    arm_failed_put().await;
+    assert!(
+        store
+            .put_staged_bytes(FAILED_PUT_KEY, b"a-first-record-that-must-not-land")
+            .await
+            .is_err(),
+        "an armed put must report the failure rather than succeed"
+    );
+
+    // Read back through a fresh handle: what must be absent is the durable
+    // record, not what the handle that failed still remembers.
+    let reopened = open().await;
+    assert_eq!(
+        reopened.staged_bytes(FAILED_PUT_KEY).await.unwrap(),
+        None,
+        "a failed first put must leave no record at the key"
+    );
+    assert!(
+        !reopened
+            .staged_keys()
+            .await
+            .unwrap()
+            .contains(&FAILED_PUT_KEY.to_vec()),
+        "a failed first put must not publish a key the caller never staged"
+    );
+    assert_eq!(
+        reopened.staged_bytes_total().await.unwrap(),
+        0,
+        "a failed first put must charge the staging budget nothing"
     );
 }

--- a/crates/engine/src/testkit/conformance/staging_store.rs
+++ b/crates/engine/src/testkit/conformance/staging_store.rs
@@ -3,10 +3,18 @@
 
 use crate::seams::StagingStore;
 
+/// The staging key [`check_failed_put`] writes, so a host whose fault
+/// injector is scoped to one key can arm exactly the put the kit makes fail.
+pub const FAILED_PUT_KEY: &[u8] = b"failed-put-key";
+
 /// Runs the `StagingStore` contract against an implementation.
 ///
 /// `open` must return a handle over the same durable backing on every call
 /// (reopen semantics); the backing must start empty.
+///
+/// The failure-atomicity half of `put_staged_bytes` needs a fault lever this
+/// function cannot supply, so it lives in [`check_failed_put`]; a host passes
+/// both or it is only half held to the contract.
 ///
 /// # Panics
 /// Panics on the first contract violation.
@@ -121,5 +129,68 @@ where
     assert!(
         id_f > id_e,
         "an op id must never be reused, not even after the queue drains empty"
+    );
+}
+
+/// Runs the failure-atomicity half of [`StagingStore::put_staged_bytes`]
+/// against an implementation: a put that returns `Err` must leave the previous
+/// bytes exactly as it found them.
+///
+/// Separate from [`check`] because it needs a lever [`check`] cannot supply —
+/// `arm_failed_put` must make the next `put_staged_bytes` at
+/// [`FAILED_PUT_KEY`] fail (exhausted quota, a short write, a denied
+/// directory; the host picks its own). Everything the kit does after arming is
+/// a read, so the lever may stay armed. `open` carries [`check`]'s reopen
+/// semantics, and the backing must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check_failed_put<S, F, G>(mut open: F, arm_failed_put: G)
+where
+    S: StagingStore,
+    F: AsyncFnMut() -> S,
+    G: AsyncFnOnce(),
+{
+    let store = open().await;
+    let previous = b"the-previously-staged-record";
+    store
+        .put_staged_bytes(FAILED_PUT_KEY, previous)
+        .await
+        .unwrap();
+    let total = store.staged_bytes_total().await.unwrap();
+
+    arm_failed_put().await;
+    assert!(
+        store
+            .put_staged_bytes(FAILED_PUT_KEY, b"a-longer-replacement-that-must-not-land")
+            .await
+            .is_err(),
+        "an armed put must report the failure rather than succeed"
+    );
+
+    // Read back through a fresh handle: what must survive is the durable
+    // record, not what the handle that failed still remembers.
+    let reopened = open().await;
+    assert_eq!(
+        reopened
+            .staged_bytes(FAILED_PUT_KEY)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(previous.as_slice()),
+        "a failed put must leave the previous bytes readable and unchanged"
+    );
+    assert!(
+        reopened
+            .staged_keys()
+            .await
+            .unwrap()
+            .contains(&FAILED_PUT_KEY.to_vec()),
+        "a failed put must not unpublish the key it failed to replace"
+    );
+    assert_eq!(
+        reopened.staged_bytes_total().await.unwrap(),
+        total,
+        "a failed put must leave the staging budget on the surviving bytes"
     );
 }

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -14,6 +14,7 @@ struct Inner {
     enqueue_budget: Option<u64>,
     staged_write_budget: Option<(Vec<u8>, u64)>,
     destructive_write_budget: Option<(Vec<u8>, u64)>,
+    partial_write_budget: Option<(Vec<u8>, u64)>,
     staged_removal_budget: Option<(Vec<u8>, u64)>,
     dropped_removal_budget: Option<(Vec<u8>, u64)>,
 }
@@ -29,6 +30,7 @@ impl Default for Inner {
             enqueue_budget: None,
             staged_write_budget: None,
             destructive_write_budget: None,
+            partial_write_budget: None,
             staged_removal_budget: None,
             dropped_removal_budget: None,
         }
@@ -74,6 +76,14 @@ impl InMemoryStagingStore {
     /// replacement is not failure-atomic.
     pub fn destroy_staged_write_after(&self, staging_key: &[u8], budget: u64) {
         self.inner.lock().expect("lock").destructive_write_budget =
+            Some((staging_key.to_vec(), budget));
+    }
+
+    /// Fails the next write at `staging_key` past `budget` **after** landing
+    /// half of the new bytes — the write-in-place shape of a host whose failed
+    /// put strands a partial record where the key held none.
+    pub fn strand_staged_write_after(&self, staging_key: &[u8], budget: u64) {
+        self.inner.lock().expect("lock").partial_write_budget =
             Some((staging_key.to_vec(), budget));
     }
 
@@ -150,6 +160,11 @@ impl StagingStore for InMemoryStagingStore {
         }
         if interrupts(&mut inner.destructive_write_budget, staging_key) {
             inner.staged.remove(staging_key);
+            return Err(SeamError::new("put_staged_bytes unavailable"));
+        }
+        if interrupts(&mut inner.partial_write_budget, staging_key) {
+            let half = bytes[..bytes.len() / 2].to_vec();
+            inner.staged.insert(staging_key.to_vec(), half);
             return Err(SeamError::new("put_staged_bytes unavailable"));
         }
         inner.staged.insert(staging_key.to_vec(), bytes.to_vec());

--- a/crates/engine/src/testkit/fakes/staging_store.rs
+++ b/crates/engine/src/testkit/fakes/staging_store.rs
@@ -13,6 +13,7 @@ struct Inner {
     fail_remove_op: bool,
     enqueue_budget: Option<u64>,
     staged_write_budget: Option<(Vec<u8>, u64)>,
+    destructive_write_budget: Option<(Vec<u8>, u64)>,
     staged_removal_budget: Option<(Vec<u8>, u64)>,
     dropped_removal_budget: Option<(Vec<u8>, u64)>,
 }
@@ -27,6 +28,7 @@ impl Default for Inner {
             fail_remove_op: false,
             enqueue_budget: None,
             staged_write_budget: None,
+            destructive_write_budget: None,
             staged_removal_budget: None,
             dropped_removal_budget: None,
         }
@@ -65,6 +67,14 @@ impl InMemoryStagingStore {
     /// disarms — a caller dropped at an exact step whose retry still proceeds.
     pub fn interrupt_staged_write_after(&self, staging_key: &[u8], budget: u64) {
         self.inner.lock().expect("lock").staged_write_budget = Some((staging_key.to_vec(), budget));
+    }
+
+    /// Fails the next write at `staging_key` past `budget` **after** dropping
+    /// the bytes already there — the truncate-in-place shape of a host whose
+    /// replacement is not failure-atomic.
+    pub fn destroy_staged_write_after(&self, staging_key: &[u8], budget: u64) {
+        self.inner.lock().expect("lock").destructive_write_budget =
+            Some((staging_key.to_vec(), budget));
     }
 
     /// The removal counterpart of [`Self::interrupt_staged_write_after`]: the
@@ -136,6 +146,10 @@ impl StagingStore for InMemoryStagingStore {
     async fn put_staged_bytes(&self, staging_key: &[u8], bytes: &[u8]) -> SeamResult<()> {
         let mut inner = self.inner.lock().expect("lock");
         if interrupts(&mut inner.staged_write_budget, staging_key) {
+            return Err(SeamError::new("put_staged_bytes unavailable"));
+        }
+        if interrupts(&mut inner.destructive_write_budget, staging_key) {
+            inner.staged.remove(staging_key);
             return Err(SeamError::new("put_staged_bytes unavailable"));
         }
         inner.staged.insert(staging_key.to_vec(), bytes.to_vec());

--- a/crates/engine/tests/staging_atomic_put.rs
+++ b/crates/engine/tests/staging_atomic_put.rs
@@ -1,6 +1,8 @@
-//! The failed-put kit case run against the in-memory fake, both ways: with a
-//! write fault that leaves the stored value alone, and with one that destroys
-//! it first — the negative control that proves the kit actually holds a host to
+//! The failed-put kit cases run against the in-memory fake — the replacement
+//! case and the fresh-backing case, each paired with the fault a host that is
+//! not failure-atomic would show (the previous bytes destroyed; a partial
+//! record stranded where the key held none). The paired `should_panic` tests
+//! are the negative controls that prove each case actually holds a host to
 //! `put_staged_bytes`'s failure-atomicity.
 
 use cipherbox_engine::testkit::conformance::staging_store::FAILED_PUT_KEY;
@@ -23,5 +25,24 @@ fn the_failed_put_kit_catches_a_host_that_destroys_the_previous_bytes() {
     block_on(conformance::staging_store::check_failed_put(
         async || store.clone(),
         async || store.destroy_staged_write_after(FAILED_PUT_KEY, 0),
+    ));
+}
+
+#[test]
+fn the_in_memory_staging_store_passes_the_failed_first_put_kit() {
+    let store = InMemoryStagingStore::default();
+    block_on(conformance::staging_store::check_failed_first_put(
+        async || store.clone(),
+        async || store.interrupt_staged_write_after(FAILED_PUT_KEY, 0),
+    ));
+}
+
+#[test]
+#[should_panic(expected = "must leave no record at the key")]
+fn the_failed_first_put_kit_catches_a_host_that_strands_a_partial_record() {
+    let store = InMemoryStagingStore::default();
+    block_on(conformance::staging_store::check_failed_first_put(
+        async || store.clone(),
+        async || store.strand_staged_write_after(FAILED_PUT_KEY, 0),
     ));
 }

--- a/crates/engine/tests/staging_atomic_put.rs
+++ b/crates/engine/tests/staging_atomic_put.rs
@@ -1,0 +1,27 @@
+//! The failed-put kit case run against the in-memory fake, both ways: with a
+//! write fault that leaves the stored value alone, and with one that destroys
+//! it first — the negative control that proves the kit actually holds a host to
+//! `put_staged_bytes`'s failure-atomicity.
+
+use cipherbox_engine::testkit::conformance::staging_store::FAILED_PUT_KEY;
+use cipherbox_engine::testkit::fakes::InMemoryStagingStore;
+use cipherbox_engine::testkit::{block_on, conformance};
+
+#[test]
+fn the_in_memory_staging_store_passes_the_failed_put_kit() {
+    let store = InMemoryStagingStore::default();
+    block_on(conformance::staging_store::check_failed_put(
+        async || store.clone(),
+        async || store.interrupt_staged_write_after(FAILED_PUT_KEY, 0),
+    ));
+}
+
+#[test]
+#[should_panic(expected = "must leave the previous bytes readable and unchanged")]
+fn the_failed_put_kit_catches_a_host_that_destroys_the_previous_bytes() {
+    let store = InMemoryStagingStore::default();
+    block_on(conformance::staging_store::check_failed_put(
+        async || store.clone(),
+        async || store.destroy_staged_write_after(FAILED_PUT_KEY, 0),
+    ));
+}

--- a/crates/wasm/src/conformance.rs
+++ b/crates/wasm/src/conformance.rs
@@ -98,6 +98,26 @@ pub async fn run_staging_store_failed_put_conformance(factory: Function, arm_fai
     .await;
 }
 
+/// Runs the `StagingStore` failed-first-put kit case against a JS
+/// `StagingStoreSeam`: the same lever, armed before the key's first put, so the
+/// backing this runner is handed must start empty.
+#[wasm_bindgen(js_name = runStagingStoreFailedFirstPutConformance)]
+pub async fn run_staging_store_failed_first_put_conformance(
+    factory: Function,
+    arm_failed_put: Function,
+) {
+    console_error_panic_hook::set_once();
+    conformance::staging_store::check_failed_first_put(
+        async || StagingStoreAdapter {
+            js: open_seam(&factory).await.unchecked_into(),
+        },
+        async || {
+            call_async(&arm_failed_put, "failed-put arm").await;
+        },
+    )
+    .await;
+}
+
 /// Runs the `CredentialStore` conformance kit against a JS `CredentialStoreSeam`
 /// (web's no-op is a valid pass).
 #[wasm_bindgen(js_name = runCredentialStoreConformance)]

--- a/crates/wasm/src/conformance.rs
+++ b/crates/wasm/src/conformance.rs
@@ -30,18 +30,24 @@ use crate::seams_bridge::{
     SnapshotCacheAdapter, StagingStoreAdapter,
 };
 
+/// Calls a JS `() => Promise<T>` and awaits its resolution, labelling any
+/// misuse with `what`.
+async fn call_async(f: &Function, what: &str) -> JsValue {
+    let result = f
+        .call0(&JsValue::UNDEFINED)
+        .unwrap_or_else(|_| panic!("{what} must not throw"));
+    let promise: Promise = result
+        .dyn_into()
+        .unwrap_or_else(|_| panic!("{what} must return a Promise"));
+    JsFuture::from(promise)
+        .await
+        .unwrap_or_else(|_| panic!("{what} promise must resolve"))
+}
+
 /// Calls a JS `() => Promise<Seam>` factory and awaits the fresh seam handle
 /// (the conformance kits' "reopen" contract).
 async fn open_seam(factory: &Function) -> JsValue {
-    let result = factory
-        .call0(&JsValue::UNDEFINED)
-        .expect("seam factory must not throw");
-    let promise: Promise = result
-        .dyn_into()
-        .expect("seam factory must return a Promise");
-    JsFuture::from(promise)
-        .await
-        .expect("seam factory promise must resolve")
+    call_async(factory, "seam factory").await
 }
 
 /// Runs the `FloorStore` conformance kit against a JS `FloorStoreSeam`,
@@ -72,6 +78,23 @@ pub async fn run_staging_store_conformance(factory: Function) {
     conformance::staging_store::check(async || StagingStoreAdapter {
         js: open_seam(&factory).await.unchecked_into(),
     })
+    .await;
+}
+
+/// Runs the `StagingStore` failed-put kit case against a JS
+/// `StagingStoreSeam`. `armFailedPut` is the host's fault lever: it must make
+/// the seam's next `putStagedBytes` at the kit's key fail.
+#[wasm_bindgen(js_name = runStagingStoreFailedPutConformance)]
+pub async fn run_staging_store_failed_put_conformance(factory: Function, arm_failed_put: Function) {
+    console_error_panic_hook::set_once();
+    conformance::staging_store::check_failed_put(
+        async || StagingStoreAdapter {
+            js: open_seam(&factory).await.unchecked_into(),
+        },
+        async || {
+            call_async(&arm_failed_put, "failed-put arm").await;
+        },
+    )
     .await;
 }
 

--- a/packages/client/src/seams/opfs.d.ts
+++ b/packages/client/src/seams/opfs.d.ts
@@ -18,5 +18,7 @@ declare global {
 
   interface FileSystemFileHandle {
     createSyncAccessHandle(): Promise<FileSystemSyncAccessHandle>;
+    /** Renames within the directory, replacing any entry already at `name`. */
+    move(name: string): Promise<void>;
   }
 }

--- a/packages/client/src/seams/stagingStore.test.ts
+++ b/packages/client/src/seams/stagingStore.test.ts
@@ -1,8 +1,8 @@
 /**
  * Constrained-IO behaviour of the OPFS staging store against a fake sync access
- * handle — both the short-count and the thrown-storage-error signals. The real
- * OPFS round trip is covered by the browser conformance suite; neither failure
- * can be provoked there, so both are faked here.
+ * handle — the short-count and thrown-storage-error signals a constrained write
+ * reports, and the failed commit. The real OPFS round trip and the seam's
+ * failed-put kit case run in the browser conformance suite.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -15,7 +15,7 @@ interface Limits {
   /** Cap on bytes one `read` returns (a short read). */
   maxRead?: number;
   /** Handle method that raises `QuotaExceededError` instead of succeeding. */
-  throwFrom?: 'truncate' | 'write' | 'flush';
+  throwFrom?: 'write' | 'flush';
 }
 
 class FakeFile {
@@ -34,11 +34,6 @@ class FakeSyncHandle {
     if (this.limits.throwFrom === method) {
       throw new DOMException('quota exceeded', 'QuotaExceededError');
     }
-  }
-
-  truncate(size: number): void {
-    this.quotaGuard('truncate');
-    this.file.bytes = this.file.bytes.slice(0, size);
   }
 
   write(buffer: ArrayBufferView, options?: { at?: number }): number {
@@ -84,6 +79,11 @@ class FakeDirectory {
   readonly handles: FakeSyncHandle[] = [];
   limits: Limits = {};
   removeFails = false;
+  moveFails = false;
+
+  async *keys(): AsyncIterableIterator<string> {
+    for (const name of [...this.files.keys()]) yield name;
+  }
 
   getDirectoryHandle(): Promise<FakeDirectory> {
     return Promise.resolve(this);
@@ -104,6 +104,12 @@ class FakeDirectory {
         return Promise.resolve(handle);
       },
       getFile: (): Promise<{ size: number }> => Promise.resolve({ size: target.bytes.byteLength }),
+      move: (to: string): Promise<void> => {
+        if (this.moveFails) return Promise.reject(new DOMException('busy', 'InvalidStateError'));
+        this.files.delete(name);
+        this.files.set(to, target);
+        return Promise.resolve();
+      },
     });
   }
 
@@ -158,7 +164,7 @@ describe('OpfsStagingStore staged bytes', () => {
     expect((error as StagingIoError).cause).toBeInstanceOf(Error);
   });
 
-  it.each(['truncate', 'write', 'flush'] as const)(
+  it.each(['write', 'flush'] as const)(
     'rejects a throwing %s and drops the partial file',
     async (method) => {
       const dir = mount();
@@ -183,6 +189,24 @@ describe('OpfsStagingStore staged bytes', () => {
     expect(error).toBeInstanceOf(StagingIoError);
     expect((error as StagingIoError).cause).toBeInstanceOf(DOMException);
     expect((error as StagingIoError).cause).toMatchObject({ name: 'QuotaExceededError' });
+  });
+
+  it.each([
+    ['the write is short', (dir: FakeDirectory): void => void (dir.limits.maxWrite = 2)],
+    ['the write throws', (dir: FakeDirectory): void => void (dir.limits.throwFrom = 'write')],
+    ['the commit fails', (dir: FakeDirectory): void => void (dir.moveFails = true)],
+  ])('leaves the previous bytes readable when %s', async (_case, arm) => {
+    const dir = mount();
+    const store = new OpfsStagingStore('test');
+    await store.putStagedBytes(key, payload);
+    arm(dir);
+
+    await expect(store.putStagedBytes(key, new Uint8Array([1, 1, 1, 1, 1, 1]))).rejects.toThrow(
+      StagingIoError
+    );
+    expect(await store.stagedBytes(key)).toEqual(payload);
+    expect(await store.stagedKeys()).toEqual([key]);
+    expect(await store.stagedBytesTotal()).toBe(payload.byteLength);
   });
 
   it('rejects a short read rather than returning zero-padded bytes', async () => {

--- a/packages/client/src/seams/stagingStore.ts
+++ b/packages/client/src/seams/stagingStore.ts
@@ -19,6 +19,14 @@ import type { StagingStoreSeam } from './types.js';
 const OPS_STORE = 'ops';
 
 /**
+ * Names an in-flight staged write. Staged records are named in hex, so no key
+ * can collide with a temp, and enumeration skips temps: an unfinished write is
+ * not a staged record, must not be charged to the staging budget, and must not
+ * be handed to orphan GC as a key.
+ */
+const TEMP_PREFIX = '.cbtmp.';
+
+/**
  * A staged-byte read or write that did not move every requested byte. OPFS sync
  * access handles signal that either as a short count or as a thrown storage
  * error, so this is the seam's fail-closed signal for both, never a recoverable
@@ -44,6 +52,7 @@ async function removeIfPresent(dir: FileSystemDirectoryHandle, name: string): Pr
 export class OpfsStagingStore implements StagingStoreSeam {
   private readonly dirName: string;
   private readonly open: () => Promise<IDBDatabase>;
+  private stagedDirectory: Promise<FileSystemDirectoryHandle> | undefined;
 
   constructor(name = 'cipherbox-staging') {
     this.dirName = `${name}-staged`;
@@ -54,9 +63,37 @@ export class OpfsStagingStore implements StagingStoreSeam {
     });
   }
 
-  private async stagedDir(): Promise<FileSystemDirectoryHandle> {
+  private stagedDir(): Promise<FileSystemDirectoryHandle> {
+    // A failed open must not poison the memo, or every later staged op on this
+    // store fails with no retry path.
+    this.stagedDirectory ??= this.openStagedDir().catch((error: unknown) => {
+      this.stagedDirectory = undefined;
+      throw error;
+    });
+    return this.stagedDirectory;
+  }
+
+  /** Opens the staged directory, once per store, sweeping the temps a killed
+   * write left behind — enumeration skips them, so nothing else reclaims them. */
+  private async openStagedDir(): Promise<FileSystemDirectoryHandle> {
     const root = await navigator.storage.getDirectory();
-    return root.getDirectoryHandle(this.dirName, { create: true });
+    const dir = await root.getDirectoryHandle(this.dirName, { create: true });
+    const debris: string[] = [];
+    for await (const name of dir.keys()) {
+      if (name.startsWith(TEMP_PREFIX)) debris.push(name);
+    }
+    // Collected first: removing during the walk mutates what it iterates.
+    // Best-effort per entry, like the desktop sweep — a temp a killed writer
+    // still holds open must not fail the open; the next one reclaims it.
+    await Promise.all(debris.map((name) => removeIfPresent(dir, name).catch(() => undefined)));
+    return dir;
+  }
+
+  /** The staged record names in `dir`; an in-flight temp is not a record. */
+  private async *recordNames(dir: FileSystemDirectoryHandle): AsyncGenerator<string> {
+    for await (const name of dir.keys()) {
+      if (!name.startsWith(TEMP_PREFIX)) yield name;
+    }
   }
 
   async enqueueOp(op: Uint8Array): Promise<number> {
@@ -96,11 +133,14 @@ export class OpfsStagingStore implements StagingStoreSeam {
     const fileName = toHex(stagingKey);
     const staged = bytes.slice();
     const dir = await this.stagedDir();
-    const fileHandle = await dir.getFileHandle(fileName, { create: true });
-    const handle = await fileHandle.createSyncAccessHandle();
+    // Every byte lands in a temp the engine cannot see, and the rename is the
+    // commit point: a constrained write (a short count, or the throw the spec
+    // names QuotaExceededError) leaves the key's previous bytes untouched.
+    const tempName = `${TEMP_PREFIX}${globalThis.crypto.randomUUID()}`;
+    const tempHandle = await dir.getFileHandle(tempName, { create: true });
+    const handle = await tempHandle.createSyncAccessHandle();
     let failure: { message: string; cause?: unknown } | undefined;
     try {
-      handle.truncate(0);
       const written = handle.write(staged, { at: 0 });
       handle.flush();
       if (written !== staged.byteLength) {
@@ -113,13 +153,15 @@ export class OpfsStagingStore implements StagingStoreSeam {
     } finally {
       handle.close();
     }
-    if (!failure) return;
-    // A constrained write either returns a short count or throws (the spec names
-    // QuotaExceededError). Either way `truncate(0)` has already landed, so a
-    // partial file is on disk; staging a truncated block would later upload
-    // bytes whose CID the engine's read path always rejects. Fail closed and
-    // drop the file so a retry starts from empty rather than resuming it.
-    const cleanupError = await removeIfPresent(dir, fileName).then(
+    if (!failure) {
+      try {
+        await tempHandle.move(fileName);
+        return;
+      } catch (error) {
+        failure = { message: 'staged write commit failed', cause: error };
+      }
+    }
+    const cleanupError = await removeIfPresent(dir, tempName).then(
       () => undefined,
       (error: unknown) => error
     );
@@ -165,7 +207,7 @@ export class OpfsStagingStore implements StagingStoreSeam {
   async stagedKeys(): Promise<Uint8Array[]> {
     const dir = await this.stagedDir();
     const keys: Uint8Array[] = [];
-    for await (const name of dir.keys()) {
+    for await (const name of this.recordNames(dir)) {
       keys.push(fromHex(name));
     }
     return keys;
@@ -174,10 +216,16 @@ export class OpfsStagingStore implements StagingStoreSeam {
   async stagedBytesTotal(): Promise<number> {
     const dir = await this.stagedDir();
     let total = 0;
-    for await (const name of dir.keys()) {
-      const fileHandle = await dir.getFileHandle(name);
-      const file = await fileHandle.getFile();
-      total += file.size;
+    for await (const name of this.recordNames(dir)) {
+      try {
+        const fileHandle = await dir.getFileHandle(name);
+        total += (await fileHandle.getFile()).size;
+      } catch (error) {
+        // A record removed between the walk and the stat contributes zero,
+        // matching the desktop host rather than failing the budget read.
+        if (error instanceof DOMException && error.name === 'NotFoundError') continue;
+        throw error;
+      }
     }
     return total;
   }

--- a/packages/client/test/browser/conformance.spec.ts
+++ b/packages/client/test/browser/conformance.spec.ts
@@ -16,6 +16,7 @@ const kitSeams = [
   'snapshotCache',
   'stagingStore',
   'stagingStoreFailedPut',
+  'stagingStoreFailedFirstPut',
   'credentialStore',
   'scheduler',
   'recordTransport',

--- a/packages/client/test/browser/conformance.spec.ts
+++ b/packages/client/test/browser/conformance.spec.ts
@@ -15,6 +15,7 @@ const kitSeams = [
   'floorStore',
   'snapshotCache',
   'stagingStore',
+  'stagingStoreFailedPut',
   'credentialStore',
   'scheduler',
   'recordTransport',
@@ -50,6 +51,12 @@ test.describe('browser seam conformance', () => {
       expect(outcome.ok).toBe(true);
     });
   }
+
+  test('staging store hides and reclaims in-flight write debris', async ({ page }) => {
+    const outcome = await runSeam(page, 'stagingStoreDebris');
+    expect(outcome.error ?? '', 'staging debris behavioral failure').toBe('');
+    expect(outcome.ok).toBe(true);
+  });
 
   test('http seam moves bytes and surfaces non-2xx as a response', async ({ page }) => {
     const outcome = await runSeam(page, 'http');

--- a/packages/client/test/browser/conformance.worker.ts
+++ b/packages/client/test/browser/conformance.worker.ts
@@ -16,6 +16,7 @@ import init, {
   runSchedulerConformance,
   runSnapshotCacheConformance,
   runStagingStoreConformance,
+  runStagingStoreFailedPutConformance,
 } from './pkg/cipherbox_wasm.js';
 import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
 
@@ -57,6 +58,111 @@ async function clearOpfsDir(name: string): Promise<void> {
     if (error instanceof DOMException && error.name === 'NotFoundError') return;
     throw error;
   }
+}
+
+/**
+ * Replaces the next `createSyncAccessHandle` result with `patch`'s wrapper,
+ * then restores the platform method. This is the failed-put kit's fault lever:
+ * patching the OPFS boundary leaves the seam itself under test, and a
+ * constrained OPFS write is exactly a wrapped handle away — the spec lets it
+ * report either a short count or a throw.
+ */
+function patchNextSyncAccessHandle(
+  patch: (handle: FileSystemSyncAccessHandle) => FileSystemSyncAccessHandle
+): void {
+  const original = FileSystemFileHandle.prototype.createSyncAccessHandle;
+  FileSystemFileHandle.prototype.createSyncAccessHandle = async function (
+    this: FileSystemFileHandle
+  ) {
+    FileSystemFileHandle.prototype.createSyncAccessHandle = original;
+    return patch(await original.call(this));
+  };
+}
+
+/** Wraps `handle`, delegating every method of the type except `write`. */
+function withWrite(
+  handle: FileSystemSyncAccessHandle,
+  write: FileSystemSyncAccessHandle['write']
+): FileSystemSyncAccessHandle {
+  return {
+    write,
+    read: (buffer, options) => handle.read(buffer, options),
+    truncate: (size) => handle.truncate(size),
+    getSize: () => handle.getSize(),
+    flush: () => handle.flush(),
+    close: () => handle.close(),
+  };
+}
+
+/** Arms the next staged write to move every byte but the last. */
+function armShortWrite(): void {
+  patchNextSyncAccessHandle((handle) =>
+    withWrite(handle, (buffer, options) => {
+      const bytes = buffer as Uint8Array;
+      return handle.write(bytes.subarray(0, Math.max(0, bytes.byteLength - 1)), options);
+    })
+  );
+}
+
+/** Arms the next staged write to throw the way an over-quota write does. */
+function armThrowingWrite(): void {
+  patchNextSyncAccessHandle((handle) =>
+    withWrite(handle, () => {
+      throw new DOMException('simulated quota exhaustion', 'QuotaExceededError');
+    })
+  );
+}
+
+/**
+ * Asserts the staged directory holds exactly the records staged under it — an
+ * in-flight temp abandoned by a failed put is invisible to `stagedKeys` and
+ * `stagedBytesTotal`, so orphan GC could never reclaim it.
+ */
+async function assertStagedEntryCount(dirName: string, expected: number): Promise<void> {
+  const root = await navigator.storage.getDirectory();
+  const dir = await root.getDirectoryHandle(dirName);
+  const names: string[] = [];
+  for await (const name of dir.keys()) names.push(name);
+  if (names.length !== expected) {
+    throw new Error(
+      `staged dir holds ${names.length} entries [${names.join(', ')}], expected ${expected}`
+    );
+  }
+}
+
+/**
+ * In-flight write debris — the temp a killed put leaves behind — is not a
+ * staged record: it stays out of the orphan-GC enumeration and the staging
+ * budget, and a reopened store reclaims it (nothing else can, precisely
+ * because it is invisible to both).
+ */
+async function runStagingDebrisBehavioral(): Promise<void> {
+  const name = 'conf-staging-debris';
+  const dirName = `${name}-staged`;
+  await clearOpfsDir(dirName);
+
+  const store = new OpfsStagingStore(name);
+  const key = new Uint8Array([1, 2, 3]);
+  await store.putStagedBytes(key, new Uint8Array([9, 9, 9, 9]));
+
+  const dir = await (await navigator.storage.getDirectory()).getDirectoryHandle(dirName);
+  const strandedFile = await dir.getFileHandle('.cbtmp.stranded', { create: true });
+  const stranded = await strandedFile.createSyncAccessHandle();
+  stranded.write(new Uint8Array(64), { at: 0 });
+  stranded.flush();
+  stranded.close();
+
+  const keys = await store.stagedKeys();
+  if (keys.length !== 1 || toHex(keys[0]) !== toHex(key)) {
+    throw new Error(`stagedKeys surfaced write debris: [${keys.map(toHex).join(', ')}]`);
+  }
+  const total = await store.stagedBytesTotal();
+  if (total !== 4) {
+    throw new Error(`stagedBytesTotal charged write debris: ${total}`);
+  }
+
+  await new OpfsStagingStore(name).stagedKeys();
+  await assertStagedEntryCount(dirName, 1);
 }
 
 async function runHttpBehavioral(): Promise<void> {
@@ -145,6 +251,18 @@ async function run(seam: string): Promise<void> {
       await runStagingStoreConformance(() => Promise.resolve(new OpfsStagingStore(name)));
       return;
     }
+    case 'stagingStoreFailedPut': {
+      const name = 'conf-staging-failed-put';
+      for (const arm of [armShortWrite, armThrowingWrite]) {
+        await clearOpfsDir(`${name}-staged`);
+        await runStagingStoreFailedPutConformance(
+          () => Promise.resolve(new OpfsStagingStore(name)),
+          () => Promise.resolve(arm())
+        );
+        await assertStagedEntryCount(`${name}-staged`, 1);
+      }
+      return;
+    }
     case 'credentialStore': {
       await runCredentialStoreConformance(() => Promise.resolve(new NoopCredentialStore()));
       return;
@@ -170,6 +288,10 @@ async function run(seam: string): Promise<void> {
       const { origin } = scope.location;
       const mailbox = new ApiMailbox(new FetchHttp(), `${origin}/mock-api/${toHex(ownPublicKey)}`);
       await runMailboxConformance(mailbox, ownPublicKey);
+      return;
+    }
+    case 'stagingStoreDebris': {
+      await runStagingDebrisBehavioral();
       return;
     }
     case 'http': {

--- a/packages/client/test/browser/conformance.worker.ts
+++ b/packages/client/test/browser/conformance.worker.ts
@@ -16,6 +16,7 @@ import init, {
   runSchedulerConformance,
   runSnapshotCacheConformance,
   runStagingStoreConformance,
+  runStagingStoreFailedFirstPutConformance,
   runStagingStoreFailedPutConformance,
 } from './pkg/cipherbox_wasm.js';
 import wasmUrl from './pkg/cipherbox_wasm_bg.wasm?url';
@@ -260,6 +261,18 @@ async function run(seam: string): Promise<void> {
           () => Promise.resolve(arm())
         );
         await assertStagedEntryCount(`${name}-staged`, 1);
+      }
+      return;
+    }
+    case 'stagingStoreFailedFirstPut': {
+      const name = 'conf-staging-failed-first-put';
+      for (const arm of [armShortWrite, armThrowingWrite]) {
+        await clearOpfsDir(`${name}-staged`);
+        await runStagingStoreFailedFirstPutConformance(
+          () => Promise.resolve(new OpfsStagingStore(name)),
+          () => Promise.resolve(arm())
+        );
+        await assertStagedEntryCount(`${name}-staged`, 0);
       }
       return;
     }


### PR DESCRIPTION
`StagingStore::put_staged_bytes` promised only that a write replaces the previous bytes at a key, and the hosts diverged on what a *failed* write leaves behind. The desktop store renames a fully-written temp into place; the browser store called `handle.truncate(0)` before writing and deleted the file on a short count or a throw, so a constrained write destroyed the previous value. Nothing caught it: the staging-store conformance kit had no failed-put case.

Every whole-set record in that key space was exposed — the retire ledger's owed reclaims (`cbx/rl/<tag>`) and the drain's op-id high-water marks and attempt counts are all read-modify-write of a complete set, so a lost replacement is destroyed durable state, not a retryable hiccup.

## The fix, at the seam

- **Contract.** `put_staged_bytes` now states that the replacement is failure-atomic: an `Err` leaves the previous bytes readable and byte-identical.
- **Kit.** `conformance::staging_store::check_failed_put` asserts it. It is a second entry point rather than part of `check` because it needs a lever `check` cannot supply — the host arms its own fault (a denied directory, a short write, exhausted quota) at `FAILED_PUT_KEY`, and everything the kit does after arming is a read, so the lever may stay armed.
- **Browser host.** `putStagedBytes` writes into a uniquely named temp and `move()`s it over the destination; the rename is the commit point. Enumeration skips temps so an in-flight write is never a staging key or a budget charge, and the store sweeps stale temps once when it first opens the staged directory — nothing else could reclaim them.

The desktop `FileStagingStore` already used `atomic_write`; it passes the new kit case unchanged.

Consumers are deliberately untouched here: this is the seam fix, and the callers get simpler later.

## Tests

- `crates/engine/tests/staging_atomic_put.rs` drives the kit case against the in-memory fake twice: with a write fault that leaves the stored value alone (passes) and with `destroy_staged_write_after`, which drops the previous bytes first (the kit catches it) — the negative control that makes the positive assertion non-vacuous.
- `crates/desktop-seams/tests/conformance.rs` runs the kit case against `FileStagingStore`, arming it with a permission denial `atomic_write` hits on its way to the sidecar — the `staged/` directory on Unix, the sidecar itself on Windows, so the Windows CI leg exercises the case too.
- The browser suite runs the kit case against the real `OpfsStagingStore` over real OPFS, for both shapes of a constrained write (a short count and a `QuotaExceededError` throw), plus a behavioral check that in-flight write debris stays out of enumeration and is reclaimed on reopen.
- `packages/client/src/seams/stagingStore.test.ts` covers the three failure points against the fake sync access handle: a short write, a throwing write, and a failed commit.

Verified red before the fix: the new kit case fails against the current browser seam with `a failed put must leave the previous bytes readable and unchanged, left: None`.

Closes #1186


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `put_staged_bytes` failure-atomic across all staging store implementations
> - `OpfsStagingStore.putStagedBytes` now writes to a randomly named temp file, flushes, then renames it to the target as the commit point; on any write or move failure the temp file is removed and previous bytes are left intact.
> - Temp files (prefixed with `TEMP_PREFIX`) are excluded from `stagedKeys` and `stagedBytesTotal`, and swept on directory open to reclaim debris from killed writes.
> - Adds `check_failed_put` and `check_failed_first_put` conformance kit functions in the engine testkit, plus new WASM exports to run them from JS, so all host implementations are held to the failure-atomicity contract.
> - Extends `InMemoryStagingStore` with destructive and partial write fault injectors to validate that the conformance kits correctly detect violations.
> - Behavioral Change: a failed `put_staged_bytes` call must now leave previous staged bytes intact; partial or missing temp files are never visible to callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8550a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staged records are now protected from partial, failed, or interrupted writes.
  * Existing data remains intact when a write fails.
  * Temporary write files are hidden from listings and automatically reclaimed.
  * Improved recovery when storage initialization temporarily fails.

* **Tests**
  * Added cross-platform coverage for failed writes, cleanup, short writes, and commit failures.
  * Added browser conformance checks for staging-store data integrity and temporary-file cleanup.

* **Documentation**
  * Clarified failure-atomic write behavior and added support for OPFS file renaming declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->