### PR TITLE
feat: persist imported contacts and collapse the received-shares store to one key

### DIFF
--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -40,7 +40,7 @@ use crate::content::{
 };
 use crate::entropy::Entropy;
 use crate::gate::{GateError, floor};
-use crate::grants::{Contact, import_contact};
+use crate::grants::{Contact, ContactStore, ContactStoreError, StagingContactStore};
 use crate::net::retire::{OrphanHeads, retire};
 use crate::net::{
     Adopter, ChildAdopter, ChildResolveError, EolRenewResult, FolderRefresh, HeldMaterial,
@@ -1455,14 +1455,7 @@ impl Drop for StreamSlot {
 /// into a memory and key-pinning DoS ([`EngineError::TooManyStreams`]).
 pub const MAX_OPEN_STREAMS: usize = 256;
 
-/// The largest contact code [`Command::ImportContact`] will decode.
-///
-/// The bundle is three fixed-width keys — a real one is under 200 bytes — and
-/// the bytes arrive as an unbounded host paste or camera scan. Decoding is
-/// linear in length, but a decoded `Value` costs far more than the byte it came
-/// from, so the cap is what stops a paste from exhausting the engine worker
-/// (the resolve path bounds its own reads the same way).
-pub const MAX_CONTACT_CODE_BYTES: usize = 1024;
+pub use crate::grants::MAX_CONTACT_CODE_BYTES;
 
 /// The engine's live read streams, bounded by [`MAX_OPEN_STREAMS`].
 #[derive(Default)]
@@ -2351,15 +2344,27 @@ impl<T: SeamTypes> Engine<T> {
                         check: "contact-code-too-large",
                     });
                 }
-                import_contact(&contact_code)
+                let session = self.session.as_ref().ok_or(EngineError::NotStarted)?;
+                StagingContactStore::new(&self.seams.staging_store, session.enc_subkey())
+                    .record(&contact_code)
+                    .await
                     .map(CommandOutcome::ContactImported)
                     .map_err(|err| match err {
-                        CodecError::Trust(_) => EngineError::TrustViolation {
-                            message: format!("contact code rejected: {}", err.check()),
-                        },
-                        CodecError::Malformed(_) => {
-                            EngineError::MalformedInput { check: err.check() }
+                        ContactStoreError::Import(e @ CodecError::Malformed(_)) => {
+                            EngineError::MalformedInput { check: e.check() }
                         }
+                        ContactStoreError::Full => EngineError::MalformedInput {
+                            check: "contact-book-full",
+                        },
+                        ContactStoreError::Seam(e) => EngineError::Seam {
+                            message: e.message().to_owned(),
+                        },
+                        // A rejected binding, and a stored book this build
+                        // cannot read: both are fail-closed trust verdicts, not
+                        // outages a host should retry.
+                        other => EngineError::TrustViolation {
+                            message: other.to_string(),
+                        },
                     })
             }
             Command::SiweLogin { message, signature } => {

--- a/crates/engine/src/grants/accept.rs
+++ b/crates/engine/src/grants/accept.rs
@@ -217,23 +217,13 @@ impl ReceivedSharesList {
     }
 }
 
-/// The durable received-shares body: the bookmarks plus the monotonic revision
-/// the two-slot store picks a winner by
-/// ([`StagingReceivedShareStore`](super::StagingReceivedShareStore)).
-///
-/// This is a frozen at-rest format. A renamed field or a changed width orphans
-/// every stored list, and the mailbox items that delivered those shares are
-/// acked — hence [`STORED_LIST_V`] and the byte vector pinning it.
-pub(crate) struct StoredList {
-    /// Strictly increasing per persist; the higher slot wins a load.
-    pub(crate) revision: u64,
-    /// The bookmarks themselves.
-    pub(crate) shares: ReceivedSharesList,
-}
-
 /// The stored-body grammar version this build writes and can read. Distinct
 /// from the seal frame's version, which the blob carries: this one versions the
 /// engine's list shape inside it.
+///
+/// The body is a frozen at-rest format. A renamed field or a changed width
+/// orphans every stored list, and the mailbox items that delivered those shares
+/// are acked — hence this constant and the byte vector pinning the encoding.
 pub(crate) const STORED_LIST_V: u64 = 1;
 
 /// The frozen bound on bookmarked shares, and on the two attacker-supplied
@@ -251,147 +241,160 @@ pub(crate) const MAX_DISPLAY_NAME_BYTES: usize = 256;
 /// The bound on a bookmarked scope root's opaque `ipnsName`.
 pub(crate) const MAX_SCOPE_ROOT_NAME_BYTES: usize = 128;
 
+/// A collection or field past its frozen bound. Shared by the grants layer's
+/// stored-body codecs, which all enforce their bounds in both directions
+/// (AGENTS.md rule 8).
+#[derive(Debug)]
+pub struct TooLong {
+    /// Which bounded field breached.
+    pub field: &'static str,
+    /// The length found.
+    pub len: usize,
+    /// The frozen bound.
+    pub limit: usize,
+}
+
+impl fmt::Display for TooLong {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { field, len, limit } = self;
+        write!(f, "{field} is {len}, past its bound {limit}")
+    }
+}
+
 /// A bound both codec directions enforce.
-fn within(field: &'static str, len: usize, limit: usize) -> Result<(), ReceivedSharesCodecError> {
+pub(super) fn within(field: &'static str, len: usize, limit: usize) -> Result<(), TooLong> {
     if len > limit {
-        return Err(ReceivedSharesCodecError::TooLong { field, len, limit });
+        return Err(TooLong { field, len, limit });
     }
     Ok(())
 }
 
-impl StoredList {
-    /// Encode to det-CBOR for the durable store, entries in scope-root order so
-    /// one list has one spelling.
-    ///
-    /// Rejects a duplicate scope root release-active, the invariant
-    /// [`decode`](Self::decode) hard-rejects (AGENTS.md rule 8): a list with two
-    /// bookmarks for one scope has no defined authority, and emitting one would
-    /// durably store bytes this build's own reader refuses.
-    pub(crate) fn encode(
-        shares: &ReceivedSharesList,
-        revision: u64,
-    ) -> Result<Zeroizing<Vec<u8>>, ReceivedSharesCodecError> {
-        let mut sorted: Vec<&ReceivedShare> = shares.entries.iter().collect();
-        sorted.sort_by(|a, b| name_cmp(&a.scope_root_name, &b.scope_root_name));
-        if sorted
-            .windows(2)
-            .any(|pair| pair[0].scope_root_name == pair[1].scope_root_name)
-        {
+/// Encode the durable received-shares body to det-CBOR, entries in scope-root
+/// order so one list has one spelling.
+///
+/// Rejects a duplicate scope root release-active, the invariant
+/// [`decode_stored_list`] hard-rejects (AGENTS.md rule 8): a list with two
+/// bookmarks for one scope has no defined authority, and emitting one would
+/// durably store bytes this build's own reader refuses.
+pub(crate) fn encode_stored_list(
+    shares: &ReceivedSharesList,
+) -> Result<Zeroizing<Vec<u8>>, ReceivedSharesCodecError> {
+    let mut sorted: Vec<&ReceivedShare> = shares.entries.iter().collect();
+    sorted.sort_by(|a, b| name_cmp(&a.scope_root_name, &b.scope_root_name));
+    if sorted
+        .windows(2)
+        .any(|pair| pair[0].scope_root_name == pair[1].scope_root_name)
+    {
+        return Err(ReceivedSharesCodecError::DuplicateScopeRoot);
+    }
+    within("shares", sorted.len(), MAX_RECEIVED_SHARES)?;
+    for share in &sorted {
+        within(
+            "displayName",
+            share.display_name.len(),
+            MAX_DISPLAY_NAME_BYTES,
+        )?;
+        within(
+            "scopeRootName",
+            share.scope_root_name.len(),
+            MAX_SCOPE_ROOT_NAME_BYTES,
+        )?;
+    }
+    let encoded_shares = sorted
+        .into_iter()
+        .map(|share| {
+            let mut m = Map::new();
+            m.insert("displayName", Value::Text(share.display_name.clone()));
+            m.insert(
+                "permission",
+                Value::Text(share.permission.as_wire().to_string()),
+            );
+            m.insert(
+                "pointerReadKey",
+                Value::Bytes(share.pointer_read_key().to_vec()),
+            );
+            m.insert("scopeRootName", Value::Bytes(share.scope_root_name.clone()));
+            m.insert(
+                "sharerIdentityPk",
+                Value::Bytes(share.sharer_identity_pk.to_vec()),
+            );
+            Value::Map(m)
+        })
+        .collect();
+    let mut body = Map::new();
+    body.insert("shares", Value::Array(encoded_shares));
+    body.insert("v", Value::Unsigned(STORED_LIST_V));
+    // Terminal owner of the transient tree: it holds a verbatim copy of
+    // every bookmark's pointer read key.
+    let mut tree = Value::Map(body);
+    let encoded = Zeroizing::new(encode_fixed_depth(&tree));
+    tree.zeroize_bytes();
+    Ok(encoded)
+}
+
+/// Decode a stored body (strict det-CBOR). A missing/mistyped field, an
+/// unknown key, an unreadable version, or a duplicate scope root is a
+/// [`ReceivedSharesCodecError`].
+pub(crate) fn decode_stored_list(
+    bytes: &[u8],
+) -> Result<ReceivedSharesList, ReceivedSharesCodecError> {
+    let mut tree = decode(bytes)?;
+    let decoded = read_stored_list(&tree);
+    // Terminal owner of the decoded tree: every pointer read key inside is
+    // wiped on every exit, the early returns a malformed body takes included.
+    tree.zeroize_bytes();
+    decoded
+}
+
+fn read_stored_list(tree: &Value) -> Result<ReceivedSharesList, ReceivedSharesCodecError> {
+    let map = tree.as_map()?;
+    reject_unknown(map, &["shares", "v"])?;
+    let version = req(map, "v")?.as_unsigned()?;
+    if version != STORED_LIST_V {
+        return Err(ReceivedSharesCodecError::UnsupportedVersion { version });
+    }
+    let raw = req(map, "shares")?.as_array()?;
+    within("shares", raw.len(), MAX_RECEIVED_SHARES)?;
+    let mut entries: Vec<ReceivedShare> = Vec::with_capacity(raw.len());
+    for item in raw {
+        let share = item.as_map()?;
+        reject_unknown(
+            share,
+            &[
+                "displayName",
+                "permission",
+                "pointerReadKey",
+                "scopeRootName",
+                "sharerIdentityPk",
+            ],
+        )?;
+        let scope_root_name = req(share, "scopeRootName")?.as_bytes()?.to_vec();
+        within(
+            "scopeRootName",
+            scope_root_name.len(),
+            MAX_SCOPE_ROOT_NAME_BYTES,
+        )?;
+        if entries.iter().any(|e| e.scope_root_name == scope_root_name) {
             return Err(ReceivedSharesCodecError::DuplicateScopeRoot);
         }
-        within("shares", sorted.len(), MAX_RECEIVED_SHARES)?;
-        for share in &sorted {
-            within(
-                "displayName",
-                share.display_name.len(),
-                MAX_DISPLAY_NAME_BYTES,
-            )?;
-            within(
-                "scopeRootName",
-                share.scope_root_name.len(),
-                MAX_SCOPE_ROOT_NAME_BYTES,
-            )?;
-        }
-        let encoded_shares = sorted
-            .into_iter()
-            .map(|share| {
-                let mut m = Map::new();
-                m.insert("displayName", Value::Text(share.display_name.clone()));
-                m.insert(
-                    "permission",
-                    Value::Text(share.permission.as_wire().to_string()),
-                );
-                m.insert(
-                    "pointerReadKey",
-                    Value::Bytes(share.pointer_read_key().to_vec()),
-                );
-                m.insert("scopeRootName", Value::Bytes(share.scope_root_name.clone()));
-                m.insert(
-                    "sharerIdentityPk",
-                    Value::Bytes(share.sharer_identity_pk.to_vec()),
-                );
-                Value::Map(m)
-            })
-            .collect();
-        let mut body = Map::new();
-        body.insert("revision", Value::Unsigned(revision));
-        body.insert("shares", Value::Array(encoded_shares));
-        body.insert("v", Value::Unsigned(STORED_LIST_V));
-        // Terminal owner of the transient tree: it holds a verbatim copy of
-        // every bookmark's pointer read key.
-        let mut tree = Value::Map(body);
-        let encoded = Zeroizing::new(encode_fixed_depth(&tree));
-        tree.zeroize_bytes();
-        Ok(encoded)
+        let display_name = req(share, "displayName")?.as_text()?.to_string();
+        within("displayName", display_name.len(), MAX_DISPLAY_NAME_BYTES)?;
+        entries.push(ReceivedShare {
+            sharer_identity_pk: fixed::<IDENTITY_PUBLIC_LEN>(
+                req(share, "sharerIdentityPk")?,
+                "sharerIdentityPk",
+            )?,
+            display_name,
+            permission: Permission::from_wire(req(share, "permission")?.as_text()?)
+                .ok_or(Malformed::InvalidPermission)?,
+            pointer_read_key: SecretBytes::new(fixed::<32>(
+                req(share, "pointerReadKey")?,
+                "pointerReadKey",
+            )?),
+            scope_root_name,
+        });
     }
-
-    /// Decode a stored body (strict det-CBOR). A missing/mistyped field, an
-    /// unknown key, an unreadable version, or a duplicate scope root is a
-    /// [`ReceivedSharesCodecError`].
-    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, ReceivedSharesCodecError> {
-        let mut tree = decode(bytes)?;
-        let decoded = Self::read(&tree);
-        // Terminal owner of the decoded tree: every pointer read key inside is
-        // wiped on every exit, the early returns a malformed body takes
-        // included.
-        tree.zeroize_bytes();
-        decoded
-    }
-
-    fn read(tree: &Value) -> Result<Self, ReceivedSharesCodecError> {
-        let map = tree.as_map()?;
-        reject_unknown(map, &["revision", "shares", "v"])?;
-        let version = req(map, "v")?.as_unsigned()?;
-        if version != STORED_LIST_V {
-            return Err(ReceivedSharesCodecError::UnsupportedVersion { version });
-        }
-        let revision = req(map, "revision")?.as_unsigned()?;
-        let raw = req(map, "shares")?.as_array()?;
-        within("shares", raw.len(), MAX_RECEIVED_SHARES)?;
-        let mut entries: Vec<ReceivedShare> = Vec::with_capacity(raw.len());
-        for item in raw {
-            let share = item.as_map()?;
-            reject_unknown(
-                share,
-                &[
-                    "displayName",
-                    "permission",
-                    "pointerReadKey",
-                    "scopeRootName",
-                    "sharerIdentityPk",
-                ],
-            )?;
-            let scope_root_name = req(share, "scopeRootName")?.as_bytes()?.to_vec();
-            within(
-                "scopeRootName",
-                scope_root_name.len(),
-                MAX_SCOPE_ROOT_NAME_BYTES,
-            )?;
-            if entries.iter().any(|e| e.scope_root_name == scope_root_name) {
-                return Err(ReceivedSharesCodecError::DuplicateScopeRoot);
-            }
-            let display_name = req(share, "displayName")?.as_text()?.to_string();
-            within("displayName", display_name.len(), MAX_DISPLAY_NAME_BYTES)?;
-            entries.push(ReceivedShare {
-                sharer_identity_pk: fixed::<IDENTITY_PUBLIC_LEN>(
-                    req(share, "sharerIdentityPk")?,
-                    "sharerIdentityPk",
-                )?,
-                display_name,
-                permission: Permission::from_wire(req(share, "permission")?.as_text()?)
-                    .ok_or(Malformed::InvalidPermission)?,
-                pointer_read_key: SecretBytes::new(fixed::<32>(
-                    req(share, "pointerReadKey")?,
-                    "pointerReadKey",
-                )?),
-                scope_root_name,
-            });
-        }
-        Ok(Self {
-            revision,
-            shares: ReceivedSharesList { entries },
-        })
-    }
+    Ok(ReceivedSharesList { entries })
 }
 
 /// Why encoding or decoding a stored received-shares body failed.
@@ -411,11 +414,7 @@ pub(crate) enum ReceivedSharesCodecError {
     /// interpret them.
     UnsupportedVersion { version: u64 },
     /// A collection or field past its frozen bound.
-    TooLong {
-        field: &'static str,
-        len: usize,
-        limit: usize,
-    },
+    TooLong(TooLong),
 }
 
 impl fmt::Display for ReceivedSharesCodecError {
@@ -428,17 +427,18 @@ impl fmt::Display for ReceivedSharesCodecError {
             ReceivedSharesCodecError::UnsupportedVersion { version } => {
                 write!(f, "received-shares body version {version} is not readable")
             }
-            ReceivedSharesCodecError::TooLong { field, len, limit } => {
-                write!(
-                    f,
-                    "received-shares {field} is {len}, past its bound {limit}"
-                )
-            }
+            ReceivedSharesCodecError::TooLong(e) => write!(f, "received-shares {e}"),
         }
     }
 }
 
 impl std::error::Error for ReceivedSharesCodecError {}
+
+impl From<TooLong> for ReceivedSharesCodecError {
+    fn from(e: TooLong) -> Self {
+        ReceivedSharesCodecError::TooLong(e)
+    }
+}
 
 impl<E: Into<CodecError>> From<E> for ReceivedSharesCodecError {
     fn from(e: E) -> Self {
@@ -448,7 +448,7 @@ impl<E: Into<CodecError>> From<E> for ReceivedSharesCodecError {
 
 /// Reject any key outside `known` — this build wrote the bytes, so a key it does
 /// not emit is not a list it may act on.
-fn reject_unknown(map: &Map, known: &[&str]) -> Result<(), CodecError> {
+pub(super) fn reject_unknown(map: &Map, known: &[&str]) -> Result<(), CodecError> {
     match map
         .entries()
         .iter()
@@ -804,13 +804,13 @@ pub async fn accept_share<F: FloorStore, M: Mailbox, S: ReceivedShareStore>(
 }
 
 /// A required map field, or [`Malformed::MissingField`].
-fn req<'a>(map: &'a Map, field: &'static str) -> Result<&'a Value, CodecError> {
+pub(super) fn req<'a>(map: &'a Map, field: &'static str) -> Result<&'a Value, CodecError> {
     map.get(field)
         .ok_or_else(|| Malformed::MissingField { field }.into())
 }
 
 /// A fixed-length byte field, or [`Malformed::InvalidFieldLength`].
-fn fixed<const N: usize>(v: &Value, field: &'static str) -> Result<[u8; N], CodecError> {
+pub(super) fn fixed<const N: usize>(v: &Value, field: &'static str) -> Result<[u8; N], CodecError> {
     let b = v.as_bytes()?;
     b.try_into().map_err(|_| {
         Malformed::InvalidFieldLength {
@@ -961,17 +961,16 @@ mod tests {
         let mut list = ReceivedSharesList::new();
         list.reconcile(share(b"zzz", 0x9C));
         list.reconcile(share(b"aaa", 0x8A));
-        let bytes = StoredList::encode(&list, 7).expect("encodes");
+        let bytes = encode_stored_list(&list).expect("encodes");
 
-        let decoded = StoredList::decode(&bytes).expect("decodes");
-        assert_eq!(decoded.revision, 7, "the revision round-trips");
-        assert_eq!(decoded.shares.len(), 2);
+        let decoded = decode_stored_list(&bytes).expect("decodes");
+        assert_eq!(decoded.len(), 2);
         assert_eq!(
-            StoredList::encode(&decoded.shares, 7).expect("re-encodes"),
+            encode_stored_list(&decoded).expect("re-encodes"),
             bytes,
             "byte-stable"
         );
-        let first = decoded.shares.iter().next().unwrap();
+        let first = decoded.iter().next().unwrap();
         assert_eq!(first.scope_root_name, b"aaa", "entries ride in scope order");
         assert!(ct_eq(first.pointer_read_key(), &[0x8A; 32]));
     }
@@ -986,7 +985,7 @@ mod tests {
         duplicated.entries.push(share(b"n", 0x9C));
         assert!(
             matches!(
-                StoredList::encode(&duplicated, 1),
+                encode_stored_list(&duplicated),
                 Err(ReceivedSharesCodecError::DuplicateScopeRoot)
             ),
             "the encoder refuses a list with no defined authority for a scope"
@@ -994,14 +993,14 @@ mod tests {
 
         let mut one = ReceivedSharesList::new();
         one.reconcile(share(b"n", 0x8A));
-        let single = decode(&StoredList::encode(&one, 1).unwrap()).unwrap();
+        let single = decode(&encode_stored_list(&one).unwrap()).unwrap();
         let mut map = single.as_map().unwrap().clone();
         let mut shares = map.get("shares").unwrap().as_array().unwrap().to_vec();
         shares.push(shares[0].clone());
         map.insert("shares", Value::Array(shares));
         assert!(
             matches!(
-                StoredList::decode(&encode(&Value::Map(map)).unwrap()),
+                decode_stored_list(&encode(&Value::Map(map)).unwrap()),
                 Err(ReceivedSharesCodecError::DuplicateScopeRoot)
             ),
             "the decoder refuses the same list it would never emit"
@@ -1012,10 +1011,10 @@ mod tests {
     fn a_stored_list_with_an_unknown_key_is_refused() {
         let mut list = ReceivedSharesList::new();
         list.reconcile(share(b"n", 0x8A));
-        let decoded = decode(&StoredList::encode(&list, 1).unwrap()).unwrap();
+        let decoded = decode(&encode_stored_list(&list).unwrap()).unwrap();
         let mut map = decoded.as_map().unwrap().clone();
         map.insert("extra", Value::Unsigned(1));
-        assert!(StoredList::decode(&encode(&Value::Map(map)).unwrap()).is_err());
+        assert!(decode_stored_list(&encode(&Value::Map(map)).unwrap()).is_err());
     }
 
     /// Frozen: this is the durable at-rest format. A renamed field, a reordered
@@ -1023,19 +1022,18 @@ mod tests {
     /// that delivered those shares are acked — so a byte vector pins it rather
     /// than a self-referential round trip.
     const STORED_LIST_V1: &str = concat!(
-        "a36176016673686172657381a56a7065726d697373696f6e64726561646b646973706c",
+        "a26176016673686172657381a56a7065726d697373696f6e64726561646b646973706c",
         "61794e616d6561736d73636f7065526f6f744e616d654c6b353173636f7065726f6f74",
         "6e706f696e746572526561644b657958208a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a",
         "8a8a8a8a8a8a8a8a8a8a8a8a8a8a707368617265724964656e74697479506b58210202",
-        "0202020202020202020202020202020202020202020202020202020202020268726576",
-        "6973696f6e07",
+        "02020202020202020202020202020202020202020202020202020202020202",
     );
 
     #[test]
     fn the_stored_list_encoding_is_frozen() {
         let mut list = ReceivedSharesList::new();
         list.reconcile(share(b"k51scoperoot", 0x8A));
-        let bytes = StoredList::encode(&list, 7).expect("encodes");
+        let bytes = encode_stored_list(&list).expect("encodes");
         assert_eq!(
             bytes.iter().map(|b| format!("{b:02x}")).collect::<String>(),
             STORED_LIST_V1,
@@ -1045,11 +1043,10 @@ mod tests {
         let raw: Vec<u8> = (0..STORED_LIST_V1.len() / 2)
             .map(|i| u8::from_str_radix(&STORED_LIST_V1[i * 2..i * 2 + 2], 16).expect("hex"))
             .collect();
-        let decoded = StoredList::decode(&raw).expect("the frozen bytes still decode");
-        assert_eq!(decoded.revision, 7);
-        assert_eq!(decoded.shares.len(), 1);
+        let decoded = decode_stored_list(&raw).expect("the frozen bytes still decode");
+        assert_eq!(decoded.len(), 1);
         assert!(ct_eq(
-            decoded.shares.iter().next().unwrap().pointer_read_key(),
+            decoded.iter().next().unwrap().pointer_read_key(),
             &[0x8A; 32]
         ));
     }
@@ -1058,12 +1055,12 @@ mod tests {
     fn a_stored_body_at_an_unreadable_version_is_refused() {
         let mut list = ReceivedSharesList::new();
         list.reconcile(share(b"n", 0x8A));
-        let decoded = decode(&StoredList::encode(&list, 1).unwrap()).unwrap();
+        let decoded = decode(&encode_stored_list(&list).unwrap()).unwrap();
         let mut map = decoded.as_map().unwrap().clone();
         map.insert("v", Value::Unsigned(STORED_LIST_V + 1));
         assert!(
             matches!(
-                StoredList::decode(&encode(&Value::Map(map)).unwrap()),
+                decode_stored_list(&encode(&Value::Map(map)).unwrap()),
                 Err(ReceivedSharesCodecError::UnsupportedVersion { .. })
             ),
             "a forward body version is named, never read as empty"
@@ -1081,27 +1078,27 @@ mod tests {
             ..share(b"n", 0x8A)
         });
         assert!(matches!(
-            StoredList::encode(&long_label, 1),
-            Err(ReceivedSharesCodecError::TooLong {
+            encode_stored_list(&long_label),
+            Err(ReceivedSharesCodecError::TooLong(TooLong {
                 field: "displayName",
                 ..
-            })
+            }))
         ));
 
         let mut long_name = ReceivedSharesList::new();
         long_name.reconcile(share(&[b'n'; MAX_SCOPE_ROOT_NAME_BYTES + 1], 0x8A));
         assert!(matches!(
-            StoredList::encode(&long_name, 1),
-            Err(ReceivedSharesCodecError::TooLong {
+            encode_stored_list(&long_name),
+            Err(ReceivedSharesCodecError::TooLong(TooLong {
                 field: "scopeRootName",
                 ..
-            })
+            }))
         ));
 
         // The decoder refuses the same shapes its encoder will not emit.
         let mut one = ReceivedSharesList::new();
         one.reconcile(share(b"n", 0x8A));
-        let decoded = decode(&StoredList::encode(&one, 1).unwrap()).unwrap();
+        let decoded = decode(&encode_stored_list(&one).unwrap()).unwrap();
         let mut map = decoded.as_map().unwrap().clone();
         let mut entry = map.get("shares").unwrap().as_array().unwrap()[0]
             .as_map()
@@ -1113,11 +1110,11 @@ mod tests {
         );
         map.insert("shares", Value::Array(vec![Value::Map(entry)]));
         assert!(matches!(
-            StoredList::decode(&encode(&Value::Map(map)).unwrap()),
-            Err(ReceivedSharesCodecError::TooLong {
+            decode_stored_list(&encode(&Value::Map(map)).unwrap()),
+            Err(ReceivedSharesCodecError::TooLong(TooLong {
                 field: "displayName",
                 ..
-            })
+            }))
         ));
     }
 
@@ -1128,11 +1125,11 @@ mod tests {
             list.reconcile(share(format!("n{i}").as_bytes(), 0x8A));
         }
         assert!(matches!(
-            StoredList::encode(&list, 1),
-            Err(ReceivedSharesCodecError::TooLong {
+            encode_stored_list(&list),
+            Err(ReceivedSharesCodecError::TooLong(TooLong {
                 field: "shares",
                 ..
-            })
+            }))
         ));
     }
 

--- a/crates/engine/src/grants/contact.rs
+++ b/crates/engine/src/grants/contact.rs
@@ -41,6 +41,15 @@ impl Contact {
     }
 }
 
+/// The largest contact code [`import_contact`] will decode.
+///
+/// The bundle is three fixed-width keys — a real one is under 200 bytes — and
+/// the bytes arrive as an unbounded host paste or camera scan. Decoding is
+/// linear in length, but a decoded `Value` costs far more than the byte it came
+/// from, so the cap is what stops a paste from exhausting the engine worker
+/// (the resolve path bounds its own reads the same way).
+pub const MAX_CONTACT_CODE_BYTES: usize = 1024;
+
 /// Import a contact code, verifying the subkey binding mandatorily and
 /// fail-closed. A structural defect surfaces as [`CodecError`] of class
 /// `malformed`; a well-formed code whose binding does not verify surfaces as

--- a/crates/engine/src/grants/contact.rs
+++ b/crates/engine/src/grants/contact.rs
@@ -11,20 +11,29 @@
 //! trust an unverified identity by construction.
 
 use cipherbox_core::error::CodecError;
-use cipherbox_core::suite::contact::import_contact_code;
+use cipherbox_core::suite::contact::{ContactCode, import_contact_code};
 use cipherbox_core::suite::ecdsa::EcdsaVerifier;
 use cipherbox_core::suite::x25519::X25519Public;
 
 /// A verified contact: an identity (signing) key and the encryption subkey it
-/// bound. There is deliberately no public constructor — the only way to hold a
-/// `Contact` is [`import_contact`], which fails closed on a bad binding, so a
-/// `Contact` in hand is proof the binding verified. This is the engine-side
-/// anchor the mailbox sender-check and the adoption gate's commitment-verify
-/// authenticate against.
+/// bound. There is deliberately no field constructor — a `Contact` is only ever
+/// built from a [`ContactCode`], which [`import_contact_code`] returns only on a
+/// passing binding verify, so a `Contact` in hand is proof the binding verified.
+/// This is the engine-side anchor the mailbox sender-check and the adoption
+/// gate's commitment-verify authenticate against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Contact {
     identity_pk: EcdsaVerifier,
     enc_subkey: X25519Public,
+}
+
+impl From<&ContactCode> for Contact {
+    fn from(code: &ContactCode) -> Self {
+        Self {
+            identity_pk: code.identity_pk(),
+            enc_subkey: code.enc_subkey(),
+        }
+    }
 }
 
 impl Contact {
@@ -41,7 +50,10 @@ impl Contact {
     }
 }
 
-/// The largest contact code [`import_contact`] will decode.
+/// The largest contact code the engine accepts. Every entry point applies it to
+/// the offered bytes before [`import_contact`] sees them — the `ImportContact`
+/// command and the stored-book codec in
+/// [`contact_store`](super::contact_store) — so a new caller must apply it too.
 ///
 /// The bundle is three fixed-width keys — a real one is under 200 bytes — and
 /// the bytes arrive as an unbounded host paste or camera scan. Decoding is
@@ -56,11 +68,7 @@ pub const MAX_CONTACT_CODE_BYTES: usize = 1024;
 /// class `trust` (`subkey-binding-invalid`) — the caller distinguishes them via
 /// [`CodecError::class`], but neither ever yields a `Contact`.
 pub fn import_contact(bytes: &[u8]) -> Result<Contact, CodecError> {
-    let code = import_contact_code(bytes)?;
-    Ok(Contact {
-        identity_pk: code.identity_pk(),
-        enc_subkey: code.enc_subkey(),
-    })
+    Ok(Contact::from(&import_contact_code(bytes)?))
 }
 
 #[cfg(test)]

--- a/crates/engine/src/grants/contact_store.rs
+++ b/crates/engine/src/grants/contact_store.rs
@@ -35,7 +35,7 @@ use crate::seams::{SeamError, StagingStore};
 use crate::sync::owner_scoped_key;
 
 use super::accept::{TooLong, reject_unknown, req, within};
-use super::contact::{Contact, MAX_CONTACT_CODE_BYTES, import_contact};
+use super::contact::{Contact, MAX_CONTACT_CODE_BYTES};
 
 /// The staging-key prefix the contact book is stored under, scoped per identity
 /// by [`owner_scoped_key`]. `is_bookkeeping` treats the whole prefix as
@@ -219,7 +219,7 @@ struct Recorded {
 /// Verify a contact code and return it alongside its canonical re-encoding.
 fn import_recorded(bytes: &[u8]) -> Result<(Contact, Vec<u8>), CodecError> {
     let code = import_contact_code(bytes)?;
-    Ok((import_contact(bytes)?, code.encode()))
+    Ok((Contact::from(&code), code.encode()))
 }
 
 /// The contact book the engine ships over a host's [`StagingStore`], under one
@@ -377,6 +377,7 @@ mod tests {
     use cipherbox_core::suite::contact::ContactCode;
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
+    use super::super::contact::import_contact;
     use super::*;
     use crate::testkit::fakes::InMemoryStagingStore;
     use crate::testkit::{block_on, conformance};

--- a/crates/engine/src/grants/contact_store.rs
+++ b/crates/engine/src/grants/contact_store.rs
@@ -1,0 +1,711 @@
+//! The owner's durable contact book — what gives a grant command a verified
+//! [`Contact`] to resolve a recipient from.
+//!
+//! A grant command names its recipient by identity key alone, but the grant
+//! blob and the blinded tag both need that recipient's X25519 encryption
+//! subkey. Pairing an identity key from one source with a subkey from another
+//! is the key-substitution attack contact import exists to close, so the subkey
+//! may only ever come from a passing binding verify.
+//!
+//! This store therefore persists the self-authenticating **contact code**, not
+//! the imported pair: [`ContactStore::record`] is itself the fail-closed
+//! import, and every load re-runs that same verify. Host bytes never produce a
+//! [`Contact`], so a tampered backing can never re-point an identity key at a
+//! subkey its holder did not sign.
+//!
+//! What that does *not* cover, because the book carries no owner attestation
+//! and a contact code carries no counter: a tamperer can insert any validly
+//! signed third-party code, roll an identity back to a subkey its holder signed
+//! **once** but has since rotated away from, or delete an entry and turn a
+//! later revoke into [`ContactStoreError::RecipientNotImported`]. The book is
+//! also plaintext at rest, so it discloses the owner's contact graph to a local
+//! reader; the grant ledger that would otherwise carry those identity keys is
+//! sealed under the scope's write key, so this is a new disclosure rather than
+//! a restatement of a published one. Closing all four wants the book sealed
+//! HPKE-to-self, which needs a frozen structure tag of its own.
+
+use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
+use cipherbox_core::error::CodecError;
+use cipherbox_core::suite::contact::import_contact_code;
+use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
+use cipherbox_core::suite::x25519::X25519Secret;
+use core::fmt;
+
+use crate::seams::{SeamError, StagingStore};
+use crate::sync::owner_scoped_key;
+
+use super::accept::{TooLong, reject_unknown, req, within};
+use super::contact::{Contact, MAX_CONTACT_CODE_BYTES, import_contact};
+
+/// The staging-key prefix the contact book is stored under, scoped per identity
+/// by [`owner_scoped_key`]. `is_bookkeeping` treats the whole prefix as
+/// referenced.
+pub const CONTACTS_PREFIX: &[u8] = b"cbx/cb/";
+
+/// The stored-body grammar version this build writes and can read.
+const CONTACT_BOOK_V: u64 = 1;
+
+/// The frozen bound on recorded contacts, enforced release-active in both codec
+/// directions (AGENTS.md rule 8).
+///
+/// It bounds reader CPU as well as the staging budget
+/// ([`MAX_RECEIVED_SHARES`](super::accept::MAX_RECEIVED_SHARES)'s rationale):
+/// every load re-verifies one binding signature per stored code.
+pub const MAX_CONTACTS: usize = 1024;
+
+/// Why a contact-book operation failed.
+#[derive(Debug)]
+pub enum ContactStoreError {
+    /// The offered contact code is malformed, or its subkey binding does not
+    /// verify — a hard trust rejection, never a degraded import.
+    Import(CodecError),
+    /// The grant names an identity key no import ever verified. There is no
+    /// directory to re-fetch a subkey from, so this is terminal rather than a
+    /// prompt to source one elsewhere.
+    RecipientNotImported,
+    /// Stored bytes this build cannot read as a contact book. Never reported as
+    /// an empty book: a recipient resolved against one would look un-imported
+    /// while the owner's real book sits unread.
+    Unreadable(BookCodecError),
+    /// The book already holds [`MAX_CONTACTS`]. The stored bytes are fine — the
+    /// set this import would make is the one past the bound — so a host can
+    /// offer [`ContactStore::forget`] rather than report corruption.
+    Full,
+    /// The durable backing failed.
+    Seam(SeamError),
+}
+
+impl fmt::Display for ContactStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ContactStoreError::Import(e) => write!(f, "contact code rejected: {}", e.check()),
+            ContactStoreError::RecipientNotImported => {
+                f.write_str("no imported contact holds that identity key")
+            }
+            ContactStoreError::Unreadable(e) => write!(f, "the stored contact book {e}"),
+            ContactStoreError::Full => {
+                write!(f, "the contact book already holds {MAX_CONTACTS} contacts")
+            }
+            ContactStoreError::Seam(e) => write!(f, "contact book: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ContactStoreError {}
+
+impl From<SeamError> for ContactStoreError {
+    fn from(e: SeamError) -> Self {
+        ContactStoreError::Seam(e)
+    }
+}
+
+impl From<BookCodecError> for ContactStoreError {
+    fn from(e: BookCodecError) -> Self {
+        ContactStoreError::Unreadable(e)
+    }
+}
+
+/// Why encoding or decoding a stored contact book failed.
+///
+/// Engine-owned rather than a bare [`CodecError`] so a check this format needs
+/// does not extend core's frozen `Malformed` registry, whose names the KAT
+/// manifest pins.
+#[derive(Debug)]
+pub enum BookCodecError {
+    /// The det-CBOR framing was malformed.
+    Codec(CodecError),
+    /// A stored code no longer imports — a tampered or truncated book, never a
+    /// contact to skip past.
+    UnverifiableCode(CodecError),
+    /// Two codes named one identity: no defined authority for that recipient's
+    /// subkey, refused in both directions (AGENTS.md rule 8).
+    DuplicateIdentity,
+    /// A stored code that is not its own canonical re-encoding. This build only
+    /// ever writes canonical codes, so anything else is bytes it did not author
+    /// — refused rather than silently normalised.
+    NonCanonicalCode,
+    /// A book written at a grammar version this build does not read. Never
+    /// treated as empty: the contacts are there, this build cannot read them.
+    UnsupportedVersion {
+        /// The version the stored body declared.
+        version: u64,
+    },
+    /// A collection or field past its frozen bound.
+    TooLong(TooLong),
+}
+
+impl fmt::Display for BookCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BookCodecError::Codec(e) => write!(f, "codec: {e}"),
+            BookCodecError::UnverifiableCode(e) => {
+                write!(f, "holds a code that no longer imports: {}", e.check())
+            }
+            BookCodecError::DuplicateIdentity => f.write_str("names one identity twice"),
+            BookCodecError::NonCanonicalCode => {
+                f.write_str("holds a code that is not its canonical encoding")
+            }
+            BookCodecError::UnsupportedVersion { version } => {
+                write!(f, "is at version {version}, which is not readable")
+            }
+            BookCodecError::TooLong(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for BookCodecError {}
+
+impl From<TooLong> for BookCodecError {
+    fn from(e: TooLong) -> Self {
+        BookCodecError::TooLong(e)
+    }
+}
+
+impl<E: Into<CodecError>> From<E> for BookCodecError {
+    fn from(e: E) -> Self {
+        BookCodecError::Codec(e.into())
+    }
+}
+
+/// Durable persistence for the owner's imported contacts.
+///
+/// [`record`](Self::record) takes the code rather than a [`Contact`] on
+/// purpose: the import *is* the write path, so no caller can persist a pair
+/// whose binding was never checked.
+pub trait ContactStore {
+    /// Import a contact code and durably record it, returning the verified
+    /// contact. A code already recorded for that identity key replaces it —
+    /// both codes carry that identity's own signature, so a re-imported code is
+    /// the contact rotating their own subkey.
+    async fn record(&self, contact_code: &[u8]) -> Result<Contact, ContactStoreError>;
+
+    /// Drop the entry for `identity_pk`. Idempotent: an identity the book does
+    /// not hold succeeds. Without it a book at [`MAX_CONTACTS`] would refuse
+    /// every further import with no way back.
+    async fn forget(
+        &self,
+        identity_pk: &[u8; IDENTITY_PUBLIC_LEN],
+    ) -> Result<(), ContactStoreError>;
+
+    /// Every recorded contact, each re-verified from its stored code.
+    async fn contacts(&self) -> Result<Vec<Contact>, ContactStoreError>;
+}
+
+/// Resolve the recipient a grant names by identity key.
+///
+/// The lookup key is the compressed SEC1 identity key the grant ledger entry
+/// and the mailbox address both use, so a revoke or downgrade resolves the
+/// recipient its grant was minted for.
+pub async fn resolve_recipient<S: ContactStore>(
+    store: &S,
+    identity_pk: &[u8; IDENTITY_PUBLIC_LEN],
+) -> Result<Contact, ContactStoreError> {
+    store
+        .contacts()
+        .await?
+        .into_iter()
+        .find(|contact| contact.identity_pk().to_sec1() == *identity_pk)
+        .ok_or(ContactStoreError::RecipientNotImported)
+}
+
+/// One recorded contact: the verified pair and the canonical self-authenticating
+/// code the book stores it as. Only [`import_recorded`] builds one, so the pair
+/// and the code can never disagree.
+struct Recorded {
+    contact: Contact,
+    code: Vec<u8>,
+}
+
+/// Verify a contact code and return it alongside its canonical re-encoding.
+fn import_recorded(bytes: &[u8]) -> Result<(Contact, Vec<u8>), CodecError> {
+    let code = import_contact_code(bytes)?;
+    Ok((import_contact(bytes)?, code.encode()))
+}
+
+/// The contact book the engine ships over a host's [`StagingStore`], under one
+/// staging key.
+pub struct StagingContactStore<'a, St> {
+    staging: &'a St,
+    staging_key: Vec<u8>,
+}
+
+impl<'a, St: StagingStore> StagingContactStore<'a, St> {
+    /// Wraps a staging store as the contact book for one session.
+    pub fn new(staging: &'a St, enc_secret: &'a X25519Secret) -> Self {
+        Self {
+            staging,
+            staging_key: owner_scoped_key(CONTACTS_PREFIX, enc_secret),
+        }
+    }
+
+    /// The staging key this identity's book occupies.
+    pub fn staging_key(&self) -> &[u8] {
+        &self.staging_key
+    }
+
+    async fn recorded(&self) -> Result<Vec<Recorded>, ContactStoreError> {
+        match self.staging.staged_bytes(self.staging_key()).await? {
+            None => Ok(Vec::new()),
+            Some(bytes) => Ok(decode_book(&bytes)?),
+        }
+    }
+
+    /// Replace the whole book.
+    async fn put(&self, book: &[Recorded]) -> Result<(), ContactStoreError> {
+        let body = encode_book(book)?;
+        self.staging
+            .put_staged_bytes(self.staging_key(), &body)
+            .await?;
+        Ok(())
+    }
+}
+
+impl<St: StagingStore> ContactStore for StagingContactStore<'_, St> {
+    async fn record(&self, contact_code: &[u8]) -> Result<Contact, ContactStoreError> {
+        // Import re-encodes canonically, so what lands is the ~130 frozen bytes
+        // of the three keys — never the caller's spelling, which tolerates
+        // unknown fields and would otherwise be an attacker-chosen byte channel
+        // into the owner's durable store.
+        let (contact, code) = import_recorded(contact_code).map_err(ContactStoreError::Import)?;
+        let mut book = self.recorded().await?;
+        book.retain(|held| held.contact.identity_pk() != contact.identity_pk());
+        if book.len() >= MAX_CONTACTS {
+            return Err(ContactStoreError::Full);
+        }
+        book.push(Recorded { contact, code });
+        self.put(&book).await?;
+        Ok(contact)
+    }
+
+    async fn forget(
+        &self,
+        identity_pk: &[u8; IDENTITY_PUBLIC_LEN],
+    ) -> Result<(), ContactStoreError> {
+        let mut book = self.recorded().await?;
+        let before = book.len();
+        book.retain(|held| held.contact.identity_pk().to_sec1() != *identity_pk);
+        if book.len() == before {
+            return Ok(());
+        }
+        self.put(&book).await
+    }
+
+    async fn contacts(&self) -> Result<Vec<Contact>, ContactStoreError> {
+        Ok(self
+            .recorded()
+            .await?
+            .into_iter()
+            .map(|held| held.contact)
+            .collect())
+    }
+}
+
+/// Encode the durable book to det-CBOR, codes in byte order so one book has one
+/// spelling.
+///
+/// Rejects the bounds and the two-codes-for-one-identity shape [`decode_book`]
+/// hard-rejects, release-active (AGENTS.md rule 8).
+fn encode_book(book: &[Recorded]) -> Result<Vec<u8>, BookCodecError> {
+    within("contacts", book.len(), MAX_CONTACTS)?;
+    let mut sorted: Vec<&Recorded> = book.iter().collect();
+    sorted.sort_by_key(|held| held.contact.identity_pk().to_sec1());
+    if sorted
+        .windows(2)
+        .any(|pair| pair[0].contact.identity_pk() == pair[1].contact.identity_pk())
+    {
+        return Err(BookCodecError::DuplicateIdentity);
+    }
+    for held in &sorted {
+        within("contactCode", held.code.len(), MAX_CONTACT_CODE_BYTES)?;
+    }
+    let mut body = Map::new();
+    body.insert(
+        "contacts",
+        Value::Array(
+            sorted
+                .into_iter()
+                .map(|held| Value::Bytes(held.code.clone()))
+                .collect(),
+        ),
+    );
+    body.insert("v", Value::Unsigned(CONTACT_BOOK_V));
+    Ok(encode_fixed_depth(&Value::Map(body)))
+}
+
+/// Decode a stored book (strict det-CBOR), re-importing every code so the
+/// binding verify runs again on bytes the host handed back.
+///
+/// A missing or mistyped field, an unknown key, an unreadable version, a bound
+/// breach, a code that no longer imports, or two codes for one identity is an
+/// error — never a partial book.
+fn decode_book(bytes: &[u8]) -> Result<Vec<Recorded>, BookCodecError> {
+    let tree = decode(bytes)?;
+    let map = tree.as_map()?;
+    reject_unknown(map, &["contacts", "v"])?;
+    let version = req(map, "v")?.as_unsigned()?;
+    if version != CONTACT_BOOK_V {
+        return Err(BookCodecError::UnsupportedVersion { version });
+    }
+    let raw = req(map, "contacts")?.as_array()?;
+    within("contacts", raw.len(), MAX_CONTACTS)?;
+    let mut book: Vec<Recorded> = Vec::with_capacity(raw.len());
+    for item in raw {
+        let code = item.as_bytes()?;
+        within("contactCode", code.len(), MAX_CONTACT_CODE_BYTES)?;
+        let (contact, canonical) =
+            import_recorded(code).map_err(BookCodecError::UnverifiableCode)?;
+        if canonical != code {
+            return Err(BookCodecError::NonCanonicalCode);
+        }
+        if book
+            .iter()
+            .any(|held| held.contact.identity_pk() == contact.identity_pk())
+        {
+            return Err(BookCodecError::DuplicateIdentity);
+        }
+        book.push(Recorded {
+            contact,
+            code: canonical,
+        });
+    }
+    Ok(book)
+}
+
+#[cfg(test)]
+mod tests {
+    use cipherbox_core::kdf;
+    use cipherbox_core::suite::contact::ContactCode;
+    use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+    use super::*;
+    use crate::testkit::fakes::InMemoryStagingStore;
+    use crate::testkit::{block_on, conformance};
+
+    fn enc(byte: u8) -> X25519Secret {
+        X25519Secret::from_scalar([byte; 32])
+    }
+
+    /// A contact code the peer signed itself, as one arrives out of band.
+    fn code(scalar: u8) -> Vec<u8> {
+        bound_code(scalar, scalar)
+    }
+
+    /// A code binding `scalar`'s identity to `subkey_scalar`'s encryption
+    /// subkey, signed by that same identity — a legitimate rotation.
+    fn bound_code(scalar: u8, subkey_scalar: u8) -> Vec<u8> {
+        let identity = EcdsaSigner::from_scalar(&[scalar; 32]).expect("valid identity scalar");
+        ContactCode::create(&identity, kdf::enc_subkey(&[subkey_scalar; 32]).public()).encode()
+    }
+
+    fn identity_of(scalar: u8) -> [u8; IDENTITY_PUBLIC_LEN] {
+        EcdsaSigner::from_scalar(&[scalar; 32])
+            .expect("valid identity scalar")
+            .verifying_key()
+            .to_sec1()
+    }
+
+    /// A code carrying a subkey the binding signature does not cover — the
+    /// key-substitution shape import exists to refuse.
+    fn substituted_code(scalar: u8, substitute: u8) -> Vec<u8> {
+        let mut bytes = code(scalar);
+        let honest = kdf::enc_subkey(&[scalar; 32]).public().to_bytes();
+        let forged = kdf::enc_subkey(&[substitute; 32]).public().to_bytes();
+        let at = bytes
+            .windows(honest.len())
+            .position(|w| w == honest)
+            .expect("the encoded code carries the subkey it bound");
+        bytes[at..at + forged.len()].copy_from_slice(&forged);
+        bytes
+    }
+
+    /// A book holding exactly `codes`, framed as this build frames one — the
+    /// bytes a hostile host could put back under the key.
+    fn framed(codes: &[Vec<u8>]) -> Vec<u8> {
+        let mut m = Map::new();
+        m.insert(
+            "contacts",
+            Value::Array(codes.iter().cloned().map(Value::Bytes).collect()),
+        );
+        m.insert("v", Value::Unsigned(CONTACT_BOOK_V));
+        encode_fixed_depth(&Value::Map(m))
+    }
+
+    #[test]
+    fn the_staging_store_passes_the_contact_store_kit() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x11);
+        block_on(conformance::contact_store::check(async || {
+            StagingContactStore::new(&staging, &secret)
+        }));
+    }
+
+    /// The gap this store closes: a grant names only the identity key, and the
+    /// subkey it must seal to has to come back from the durable book.
+    #[test]
+    fn a_recorded_contact_resolves_by_identity_key_after_a_restart() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x21);
+        let imported = block_on(StagingContactStore::new(&staging, &secret).record(&code(0x33)))
+            .expect("import");
+
+        let restarted = StagingContactStore::new(&staging, &secret);
+        let resolved =
+            block_on(resolve_recipient(&restarted, &identity_of(0x33))).expect("resolves");
+        assert_eq!(resolved.identity_pk(), imported.identity_pk());
+        assert_eq!(
+            resolved.enc_subkey(),
+            imported.enc_subkey(),
+            "the resolved subkey is the one the import verified"
+        );
+    }
+
+    #[test]
+    fn an_identity_key_no_import_verified_fails_closed() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x31);
+        block_on(StagingContactStore::new(&staging, &secret).record(&code(0x33))).expect("import");
+
+        let store = StagingContactStore::new(&staging, &secret);
+        assert!(
+            matches!(
+                block_on(resolve_recipient(&store, &identity_of(0x44))),
+                Err(ContactStoreError::RecipientNotImported)
+            ),
+            "an un-imported recipient is refused, never resolved from elsewhere"
+        );
+    }
+
+    /// The store's only writer is the import, so a code whose binding does not
+    /// verify persists nothing at all.
+    #[test]
+    fn a_code_whose_binding_fails_is_never_recorded() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x41);
+        let store = StagingContactStore::new(&staging, &secret);
+        assert!(matches!(
+            block_on(store.record(&substituted_code(0x33, 0x44))),
+            Err(ContactStoreError::Import(_))
+        ));
+        assert!(
+            block_on(store.contacts()).expect("load").is_empty(),
+            "a refused import leaves the book empty"
+        );
+        assert!(
+            block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged")
+                .is_none(),
+            "a refused import writes nothing"
+        );
+    }
+
+    /// Why the code is stored rather than the pair: host bytes are re-verified
+    /// on every load, so re-pointing an identity key at a subkey its holder
+    /// never signed is refused rather than served to a grant.
+    #[test]
+    fn a_tampered_book_never_yields_a_contact() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x51);
+        let store = StagingContactStore::new(&staging, &secret);
+        block_on(store.record(&code(0x33))).expect("import");
+        block_on(staging.put_staged_bytes(
+            store.staging_key(),
+            &framed(&[substituted_code(0x33, 0x44)]),
+        ))
+        .expect("clobber");
+
+        assert!(matches!(
+            block_on(resolve_recipient(&store, &identity_of(0x33))),
+            Err(ContactStoreError::Unreadable(
+                BookCodecError::UnverifiableCode(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn a_book_this_build_cannot_read_fails_closed_rather_than_reading_empty() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x61);
+        let store = StagingContactStore::new(&staging, &secret);
+        block_on(store.record(&code(0x33))).expect("import");
+        block_on(staging.put_staged_bytes(store.staging_key(), b"not a contact book"))
+            .expect("clobber");
+
+        assert!(matches!(
+            block_on(store.contacts()),
+            Err(ContactStoreError::Unreadable(_))
+        ));
+    }
+
+    #[test]
+    fn another_identitys_book_is_not_this_sessions_book() {
+        let staging = InMemoryStagingStore::default();
+        let alice = enc(0x71);
+        let bob = enc(0x72);
+        block_on(StagingContactStore::new(&staging, &alice).record(&code(0x33))).expect("import");
+
+        assert!(
+            block_on(StagingContactStore::new(&staging, &bob).contacts())
+                .expect("load")
+                .is_empty(),
+            "one store is shared across accounts; a contact must not cross identities"
+        );
+    }
+
+    /// Rule 8: the decoder refuses two codes for one identity — no defined
+    /// authority for that recipient's subkey — so the encoder must too.
+    #[test]
+    fn two_codes_for_one_identity_are_refused_in_both_directions() {
+        let codes = [code(0x33), bound_code(0x33, 0x99)];
+        let book: Vec<Recorded> = codes
+            .iter()
+            .map(|code| Recorded {
+                contact: import_contact(code).expect("valid code"),
+                code: code.clone(),
+            })
+            .collect();
+        assert!(matches!(
+            encode_book(&book),
+            Err(BookCodecError::DuplicateIdentity)
+        ));
+        assert!(matches!(
+            decode_book(&framed(&codes)),
+            Err(BookCodecError::DuplicateIdentity)
+        ));
+    }
+
+    #[test]
+    fn a_book_at_an_unreadable_version_is_refused() {
+        let mut m = Map::new();
+        m.insert("contacts", Value::Array(vec![]));
+        m.insert("v", Value::Unsigned(CONTACT_BOOK_V + 1));
+        assert!(matches!(
+            decode_book(&encode_fixed_depth(&Value::Map(m))),
+            Err(BookCodecError::UnsupportedVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn a_book_with_an_unknown_key_is_refused() {
+        let mut m = Map::new();
+        m.insert("contacts", Value::Array(vec![]));
+        m.insert("extra", Value::Unsigned(1));
+        m.insert("v", Value::Unsigned(CONTACT_BOOK_V));
+        assert!(decode_book(&encode_fixed_depth(&Value::Map(m))).is_err());
+    }
+
+    /// A contact rotating their own subkey re-signs the binding, so the newer
+    /// code replaces the older one instead of sitting beside it.
+    #[test]
+    fn re_importing_an_identity_replaces_the_subkey_it_resolves_to() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x81);
+        let store = StagingContactStore::new(&staging, &secret);
+        block_on(store.record(&code(0x33))).expect("first import");
+        block_on(store.record(&bound_code(0x33, 0x99))).expect("rotated import");
+
+        assert_eq!(block_on(store.contacts()).expect("load").len(), 1);
+        let resolved = block_on(resolve_recipient(&store, &identity_of(0x33))).expect("resolves");
+        assert_eq!(
+            resolved.enc_subkey(),
+            kdf::enc_subkey(&[0x99; 32]).public(),
+            "the rotated subkey is what a later grant seals to"
+        );
+    }
+
+    /// The book is the only durable home for a recipient's subkey, so a full
+    /// book must name its own remedy rather than read as corruption.
+    #[test]
+    fn a_full_book_reports_as_full_and_a_forget_makes_room() {
+        /// A distinct identity per index, since the bound is past a byte.
+        fn nth_code(i: u16) -> Vec<u8> {
+            let mut seed = [0x11; 32];
+            seed[..2].copy_from_slice(&i.to_be_bytes());
+            let identity = EcdsaSigner::from_scalar(&seed).expect("valid identity scalar");
+            ContactCode::create(&identity, kdf::enc_subkey(&seed).public()).encode()
+        }
+
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0xB1);
+        let store = StagingContactStore::new(&staging, &secret);
+        let book: Vec<Recorded> = (0..MAX_CONTACTS)
+            .map(|i| {
+                let (contact, code) =
+                    import_recorded(&nth_code(u16::try_from(i).expect("in range")))
+                        .expect("valid code");
+                Recorded { contact, code }
+            })
+            .collect();
+        let first = book[0].contact.identity_pk().to_sec1();
+        block_on(store.put(&book)).expect("seed a full book");
+
+        let fresh = nth_code(u16::try_from(MAX_CONTACTS).expect("in range"));
+        assert!(
+            matches!(block_on(store.record(&fresh)), Err(ContactStoreError::Full)),
+            "a full book is refused as full, never as unreadable bytes"
+        );
+
+        block_on(store.forget(&first)).expect("forget");
+        block_on(store.record(&fresh)).expect("a forget makes room");
+    }
+
+    /// A code with an unknown field imports, but only its canonical re-encoding
+    /// is stored — the offered spelling is never an attacker-chosen byte channel
+    /// into the owner's durable store.
+    #[test]
+    fn only_the_canonical_code_reaches_the_book() {
+        use cipherbox_core::codec::{decode as cbor_decode, encode as cbor_encode};
+
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0xC1);
+        let store = StagingContactStore::new(&staging, &secret);
+        let padded = {
+            let mut map = cbor_decode(&code(0x33)).unwrap().as_map().unwrap().clone();
+            map.insert("padding", Value::Bytes(vec![0x5A; 512]));
+            cbor_encode(&Value::Map(map)).unwrap()
+        };
+        block_on(store.record(&padded)).expect("a padded code still imports");
+
+        let stored = block_on(staging.staged_bytes(store.staging_key()))
+            .expect("staged")
+            .expect("the book is stored");
+        assert!(
+            !stored.windows(16).any(|w| w == [0x5A; 16]),
+            "the offered padding never reached the durable book"
+        );
+        assert_eq!(block_on(store.contacts()).expect("load").len(), 1);
+    }
+
+    #[test]
+    fn a_lost_write_never_destroys_the_recorded_book() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x91);
+        let store = StagingContactStore::new(&staging, &secret);
+        block_on(store.record(&code(0x33))).expect("import");
+
+        staging.interrupt_staged_write_after(store.staging_key(), 0);
+        assert!(block_on(store.record(&code(0x44))).is_err());
+        assert_eq!(
+            block_on(store.contacts()).expect("load").len(),
+            1,
+            "the lost replacement left the recorded book intact"
+        );
+    }
+
+    /// The book's real staging key — not just its prefix — is what orphan GC
+    /// must spare, so this pins the key the sweep's prefix table is fed.
+    #[test]
+    fn the_books_staging_key_sits_under_the_swept_prefix() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0xA1);
+        let store = StagingContactStore::new(&staging, &secret);
+        block_on(store.record(&code(0x33))).expect("import");
+
+        assert!(
+            block_on(staging.staged_keys())
+                .expect("keys")
+                .iter()
+                .all(|key| key.starts_with(CONTACTS_PREFIX)),
+            "the book writes nothing outside the prefix orphan GC spares"
+        );
+    }
+}

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -13,6 +13,7 @@
 pub mod accept;
 pub mod child_index;
 pub mod contact;
+pub mod contact_store;
 pub mod create;
 pub mod invite;
 pub mod ledger;
@@ -22,13 +23,17 @@ pub mod revocation;
 
 pub use accept::{
     AcceptError, AcceptOutcome, ReceivedShare, ReceivedShareStore, ReceivedSharesList, SentIndex,
-    SentShare, SharePointer, accept_share,
+    SentShare, SharePointer, TooLong, accept_share,
 };
 pub use child_index::{
     DestIndexVersion, UndoDestAdd, canonicalize, insert_child, move_child, remove_child,
     repair_observed, undo_dest_add_versioned,
 };
-pub use contact::{Contact, import_contact};
+pub use contact::{Contact, MAX_CONTACT_CODE_BYTES, import_contact};
+pub use contact_store::{
+    BookCodecError, CONTACTS_PREFIX, ContactStore, ContactStoreError, MAX_CONTACTS,
+    StagingContactStore, resolve_recipient,
+};
 pub use create::{
     CreateGrantError, CreateGrantOutcome, GrantRecipient, GranteeScopePlan, OwnerGrantKeys,
     ParentScopePlan, create_read_grant,

--- a/crates/engine/src/grants/received_share_store.rs
+++ b/crates/engine/src/grants/received_share_store.rs
@@ -8,40 +8,30 @@
 //! cache, which is contractually a cache of what the network can re-serve.
 
 use core::cell::RefCell;
-use core::cmp::Reverse;
 
 use crate::entropy::{Entropy, fresh_ephemeral};
 use crate::seams::{SeamError, SeamResult, StagingStore};
-use crate::sync::drain::owner_tag;
+use crate::sync::owner_scoped_key;
 use cipherbox_core::seal::{open_received_shares, seal_received_shares};
 use cipherbox_core::suite::x25519::X25519Secret;
 
-use super::accept::{ReceivedShareStore, ReceivedSharesList, StoredList};
+use super::accept::{
+    ReceivedShareStore, ReceivedSharesList, decode_stored_list, encode_stored_list,
+};
 
-/// The staging-key prefix the received-shares slots are stored under.
-///
-/// Scoped by the owner tag every per-identity durable record this device keeps
-/// is scoped by; [`orphan_staging_keys`] treats the whole prefix as referenced,
-/// every identity's slots included.
+/// The staging-key prefix the received-shares list is stored under, scoped per
+/// identity by [`owner_scoped_key`]. `is_bookkeeping` treats the whole prefix as
+/// referenced.
 ///
 /// Kept short: the desktop store spells a staging key as a hex filename, twice
-/// its byte length, inside Windows' whole-path budget.
-///
-/// [`orphan_staging_keys`]: crate::sync::orphan_staging_keys
+/// its byte length, inside Windows' whole-path budget — the bound every prefix
+/// in this space is held to.
 pub const RECEIVED_SHARES_PREFIX: &[u8] = b"cbx/rs/";
 
-/// The two slot suffixes a persist alternates between.
-///
-/// [`StagingStore::put_staged_bytes`] promises the write replaces the previous
-/// bytes, not that the replacement is atomic — a host that truncates before it
-/// writes can be interrupted and leave a partial blob. With one key that is
-/// terminal: the list would never open again, and the mailbox items that
-/// delivered those shares are acked and gone. A persist therefore always writes
-/// the slot with the least to lose ([`TargetPreference`]), so what survives an
-/// interruption is the slot worth keeping.
-const SLOTS: [u8; 2] = [b'a', b'b'];
-
 /// The received-shares store the engine ships over a host's [`StagingStore`].
+///
+/// One staging key holds the whole list; the replacement is failure-atomic at
+/// the seam ([`StagingStore::put_staged_bytes`]).
 ///
 /// The list is sealed HPKE-to-self under the session's `enc-subkey` before it
 /// reaches the host, so the `pointerReadKey` of every bookmarked scope stays
@@ -50,6 +40,7 @@ pub struct StagingReceivedShareStore<'a, St, E> {
     staging: &'a St,
     enc_secret: &'a X25519Secret,
     entropy: &'a RefCell<E>,
+    staging_key: Vec<u8>,
 }
 
 impl<'a, St: StagingStore, E: Entropy> StagingReceivedShareStore<'a, St, E> {
@@ -59,140 +50,44 @@ impl<'a, St: StagingStore, E: Entropy> StagingReceivedShareStore<'a, St, E> {
             staging,
             enc_secret,
             entropy,
+            staging_key: owner_scoped_key(RECEIVED_SHARES_PREFIX, enc_secret),
         }
     }
 
-    /// The staging keys this identity's slots occupy — the entries under
+    /// The staging key this identity's list occupies — the entry under
     /// [`RECEIVED_SHARES_PREFIX`] that orphan GC must treat as referenced.
-    pub fn slot_keys(&self) -> [Vec<u8>; 2] {
-        let tag = owner_tag(self.enc_secret);
-        SLOTS.map(|slot| {
-            let mut key = RECEIVED_SHARES_PREFIX.to_vec();
-            key.extend_from_slice(&tag);
-            key.push(slot);
-            key
-        })
+    pub fn staging_key(&self) -> &[u8] {
+        &self.staging_key
     }
-
-    /// Read one slot. A [`SeamError`] is a host read failure; bytes this build
-    /// cannot open or decode are [`Slot::Unreadable`], which is state to be
-    /// preserved rather than an outage to be retried.
-    async fn read_slot(&self, key: &[u8]) -> SeamResult<Slot> {
-        let Some(blob) = self.staging.staged_bytes(key).await? else {
-            return Ok(Slot::Empty);
-        };
-        let Ok(body) = open_received_shares(self.enc_secret, &blob) else {
-            return Ok(Slot::Unreadable);
-        };
-        Ok(match StoredList::decode(&body) {
-            Ok(stored) => Slot::Held(stored),
-            Err(_) => Slot::Unreadable,
-        })
-    }
-
-    async fn read_slots(&self) -> SeamResult<[Slot; 2]> {
-        let keys = self.slot_keys();
-        Ok([
-            self.read_slot(&keys[0]).await?,
-            self.read_slot(&keys[1]).await?,
-        ])
-    }
-}
-
-/// What one slot holds.
-enum Slot {
-    /// Nothing has been written here.
-    Empty,
-    /// Bytes this session cannot open or decode — a torn write, or another
-    /// identity's. Never treated as empty: overwriting the last readable slot
-    /// on the strength of an unreadable one is how a list is lost.
-    Unreadable,
-    /// A readable list at its revision.
-    Held(StoredList),
-}
-
-impl Slot {
-    fn revision(&self) -> Option<u64> {
-        match self {
-            Slot::Held(stored) => Some(stored.revision),
-            _ => None,
-        }
-    }
-
-    fn target_preference(&self) -> TargetPreference {
-        match self {
-            Slot::Held(stored) => TargetPreference::Held(Reverse(stored.revision)),
-            Slot::Unreadable => TargetPreference::Unreadable,
-            Slot::Empty => TargetPreference::Empty,
-        }
-    }
-}
-
-/// How willing a persist is to overwrite a slot — worst target first, so the
-/// greater of two slots is the one to write.
-///
-/// The order is the whole safety argument of the two-slot layout, and a
-/// revision comparison cannot carry it: `Empty` and `Unreadable` both have no
-/// revision, yet a free slot costs nothing to take while unreadable bytes are
-/// state some build still needs. A write that tears leaves its target
-/// unreadable, so the slot left alone must be the one worth keeping — the
-/// newest readable list above all, then any readable list, then bytes of
-/// unknown value, and last the free slot.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-enum TargetPreference {
-    /// A readable list; [`Reverse`] because the newer list is the worse target.
-    Held(Reverse<u64>),
-    /// Taken only when neither slot is free.
-    Unreadable,
-    /// Nothing to lose.
-    Empty,
 }
 
 impl<St: StagingStore, E: Entropy> ReceivedShareStore for StagingReceivedShareStore<'_, St, E> {
     async fn persist(&self, shares: &ReceivedSharesList) -> SeamResult<()> {
-        let slots = self.read_slots().await?;
-        let newest = slots[0].revision().max(slots[1].revision());
-        // Both unreadable is the one state with no safe target: either write
-        // would drop state this build cannot read.
-        let target = match (&slots[0], &slots[1]) {
-            (Slot::Unreadable, Slot::Unreadable) => {
-                return Err(SeamError::new(
-                    "received-shares: both slots are unreadable, refusing to overwrite either",
-                ));
-            }
-            (a, b) if b.target_preference() > a.target_preference() => 1,
-            _ => 0,
-        };
-
-        let body = StoredList::encode(shares, newest.unwrap_or(0).saturating_add(1))
+        let body = encode_stored_list(shares)
             .map_err(|e| SeamError::new(format!("received-shares encode failed: {e}")))?;
         let ephemeral = fresh_ephemeral(&mut *self.entropy.borrow_mut())
             .map_err(|e| SeamError::new(e.message().to_string()))?;
         let blob = seal_received_shares(self.enc_secret, &ephemeral, &body)
             .map_err(|e| SeamError::new(format!("received-shares seal failed: {e}")))?;
         self.staging
-            .put_staged_bytes(&self.slot_keys()[target], &blob)
+            .put_staged_bytes(self.staging_key(), &blob)
             .await
     }
 
     async fn load(&self) -> SeamResult<ReceivedSharesList> {
-        let slots = self.read_slots().await?;
-        // The higher revision wins; a torn slot beside a readable one loses
-        // rather than bricking the list. Only when nothing is readable and
-        // something is stored does this fail closed — reporting empty there
-        // would let the next persist overwrite bookmarks it never read.
-        match slots {
-            [Slot::Held(a), Slot::Held(b)] => Ok(if a.revision >= b.revision {
-                a.shares
-            } else {
-                b.shares
-            }),
-            [Slot::Held(held), _] | [_, Slot::Held(held)] => Ok(held.shares),
-            [Slot::Unreadable, _] | [_, Slot::Unreadable] => Err(SeamError::new(
-                "received-shares: the stored list did not open",
-            )),
-            [Slot::Empty, Slot::Empty] => Ok(ReceivedSharesList::new()),
-        }
+        let Some(blob) = self.staging.staged_bytes(self.staging_key()).await? else {
+            return Ok(ReceivedSharesList::new());
+        };
+        // Stored bytes this session cannot read are never reported as an empty
+        // list: the next persist would overwrite bookmarks it never saw, and the
+        // mailbox items that delivered them are acked and gone.
+        let body = open_received_shares(self.enc_secret, &blob)
+            .map_err(|_| SeamError::new("received-shares: the stored list did not open"))?;
+        decode_stored_list(&body).map_err(|e| {
+            SeamError::new(format!(
+                "received-shares: the stored list did not decode: {e}"
+            ))
+        })
     }
 }
 
@@ -263,7 +158,7 @@ mod tests {
         let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
         block_on(store.persist(&one_share())).expect("persist");
 
-        let stored = block_on(staging.staged_bytes(&store.slot_keys()[0]))
+        let stored = block_on(staging.staged_bytes(store.staging_key()))
             .expect("staged bytes")
             .expect("the list is stored");
         assert!(
@@ -287,11 +182,32 @@ mod tests {
         block_on(store.persist(&one_share())).expect("persist");
 
         // Same key space, unreadable bytes.
-        block_on(staging.put_staged_bytes(&store.slot_keys()[0], b"not a sealed list"))
+        block_on(staging.put_staged_bytes(store.staging_key(), b"not a sealed list"))
             .expect("clobber");
         assert!(
             block_on(store.load()).is_err(),
             "an unreadable stored list is an error, never an empty list"
+        );
+    }
+
+    /// The other arm of the same rule: bytes that open under this session's key
+    /// but carry a body grammar this build does not read are still state, not an
+    /// empty list.
+    #[test]
+    fn a_stored_list_this_build_cannot_decode_fails_closed_rather_than_reading_empty() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x32);
+        let entropy = RefCell::new(SeededEntropy::new(37));
+        let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
+        block_on(store.persist(&one_share())).expect("persist");
+
+        let ephemeral = fresh_ephemeral(&mut SeededEntropy::new(41)).expect("ephemeral");
+        let sealed = seal_received_shares(&secret, &ephemeral, b"opens, but is not a stored list")
+            .expect("seal");
+        block_on(staging.put_staged_bytes(store.staging_key(), &sealed)).expect("clobber");
+        assert!(
+            block_on(store.load()).is_err(),
+            "a body this build cannot decode is an error, never an empty list"
         );
     }
 
@@ -319,7 +235,7 @@ mod tests {
         let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
         assert!(block_on(store.persist(&one_share())).is_err());
         assert!(
-            block_on(staging.staged_bytes(&store.slot_keys()[0]))
+            block_on(staging.staged_bytes(store.staging_key()))
                 .expect("staged bytes")
                 .is_none(),
             "a refused seal writes nothing"
@@ -345,9 +261,9 @@ mod tests {
         );
     }
 
-    /// The failure the two-slot layout exists for: a host whose write is not
-    /// failure-atomic (the browser seam truncates before it writes, then drops
-    /// the file) must not be able to take the readable list with it.
+    /// The failure a durable whole-set record must survive: the host loses the
+    /// replacement write. `put_staged_bytes` is failure-atomic, so the list the
+    /// store already holds is what the next load must still read.
     #[test]
     fn a_lost_write_never_destroys_the_readable_list() {
         let staging = InMemoryStagingStore::default();
@@ -355,144 +271,24 @@ mod tests {
         let entropy = RefCell::new(SeededEntropy::new(19));
         let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
         block_on(store.persist(&one_share())).expect("first persist");
-        let first_slot = store.slot_keys()[0].clone();
-
-        // The next persist targets the *other* slot, so wiping the slot it
-        // writes leaves the original readable.
-        block_on(store.persist(&ReceivedSharesList::new())).expect("second persist");
-        assert!(block_on(store.load()).expect("load").is_empty());
-        block_on(staging.remove_staged_bytes(&store.slot_keys()[1])).expect("lose the new slot");
-        assert_eq!(
-            block_on(store.load()).expect("load").len(),
-            1,
-            "the surviving slot still holds the older list"
-        );
-        assert!(
-            block_on(staging.staged_bytes(&first_slot))
-                .expect("staged")
-                .is_some(),
-            "the first write was never the target of the second"
-        );
-    }
-
-    /// A torn slot beside a readable one loses; it does not brick the list.
-    #[test]
-    fn a_torn_slot_loses_to_the_readable_one() {
-        let staging = InMemoryStagingStore::default();
-        let secret = enc(0x91);
-        let entropy = RefCell::new(SeededEntropy::new(21));
-        let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
-        block_on(store.persist(&one_share())).expect("persist");
-
-        block_on(staging.put_staged_bytes(&store.slot_keys()[1], b"half a blob")).expect("tear");
-        assert_eq!(
-            block_on(store.load()).expect("load").len(),
-            1,
-            "the readable slot wins over a torn one"
-        );
-        // And the next persist overwrites the torn slot, never the good one.
-        block_on(store.persist(&one_share())).expect("persist over the torn slot");
-        assert_eq!(block_on(store.load()).expect("load").len(), 1);
-    }
-
-    /// The higher revision wins, so restoring a stale slot cannot silently roll
-    /// the bookmark list back.
-    #[test]
-    fn the_higher_revision_wins_a_load() {
-        let staging = InMemoryStagingStore::default();
-        let secret = enc(0xA1);
-        let entropy = RefCell::new(SeededEntropy::new(25));
-        let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
-        block_on(store.persist(&one_share())).expect("revision 1");
-        let stale = block_on(staging.staged_bytes(&store.slot_keys()[0]))
+        let stored = block_on(staging.staged_bytes(store.staging_key()))
             .expect("staged")
-            .expect("slot a holds revision 1");
+            .expect("the list is stored");
 
-        block_on(store.persist(&ReceivedSharesList::new())).expect("revision 2");
-        // Put the older list back in the slot it came from: both slots readable,
-        // and the newer revision must still win.
-        block_on(staging.put_staged_bytes(&store.slot_keys()[0], &stale)).expect("restore");
-        assert!(
-            block_on(store.load()).expect("load").is_empty(),
-            "revision 2 wins over the restored revision 1"
-        );
-    }
-
-    /// A free slot outranks an unreadable one in **both** orientations. Neither
-    /// carries a revision, so a revision comparison alone picks slot `a` twice
-    /// and destroys the unreadable bytes whenever they sit there.
-    #[test]
-    fn a_persist_takes_the_free_slot_over_the_unreadable_one() {
-        const TORN: &[u8] = b"half a sealed list";
-        for unreadable in [0usize, 1] {
-            let staging = InMemoryStagingStore::default();
-            let secret = enc(0xC1);
-            let entropy = RefCell::new(SeededEntropy::new(29));
-            let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
-            let keys = store.slot_keys();
-            block_on(staging.put_staged_bytes(&keys[unreadable], TORN)).expect("tear");
-
-            block_on(store.persist(&one_share())).expect("persist");
-
-            assert_eq!(
-                block_on(staging.staged_bytes(&keys[unreadable]))
-                    .expect("staged")
-                    .as_deref(),
-                Some(TORN),
-                "slot {unreadable}: unreadable bytes survive while a slot is free"
-            );
-            assert_eq!(
-                block_on(store.load()).expect("load").len(),
-                1,
-                "slot {unreadable}: the list landed in the free slot"
-            );
-        }
-    }
-
-    /// With no free slot the unreadable one is the target in both orientations:
-    /// overwriting the readable list would leave nothing to fall back to if
-    /// this write tears as well.
-    #[test]
-    fn a_persist_overwrites_the_unreadable_slot_before_a_readable_one() {
-        for torn in [0usize, 1] {
-            let staging = InMemoryStagingStore::default();
-            let secret = enc(0xD1);
-            let entropy = RefCell::new(SeededEntropy::new(31));
-            let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
-            let keys = store.slot_keys();
-            // Fill both slots, then tear one, so no slot is free.
-            block_on(store.persist(&one_share())).expect("first persist");
-            block_on(store.persist(&one_share())).expect("second persist");
-            block_on(staging.put_staged_bytes(&keys[torn], b"half a blob")).expect("tear");
-            let kept = block_on(staging.staged_bytes(&keys[1 - torn]))
+        staging.interrupt_staged_write_after(store.staging_key(), 0);
+        assert!(block_on(store.persist(&ReceivedSharesList::new())).is_err());
+        assert_eq!(
+            block_on(staging.staged_bytes(store.staging_key()))
                 .expect("staged")
-                .expect("the other slot is readable");
-
-            block_on(store.persist(&ReceivedSharesList::new())).expect("persist");
-
-            assert_eq!(
-                block_on(staging.staged_bytes(&keys[1 - torn]))
-                    .expect("staged")
-                    .as_deref(),
-                Some(kept.as_slice()),
-                "slot {torn} torn: the readable slot is never the target"
-            );
-        }
-    }
-
-    /// Both slots unreadable is the one state with no safe write target: either
-    /// would drop bookmarks this build cannot read.
-    #[test]
-    fn a_persist_refuses_when_neither_slot_is_readable() {
-        let staging = InMemoryStagingStore::default();
-        let secret = enc(0xB1);
-        let entropy = RefCell::new(SeededEntropy::new(27));
-        let store = StagingReceivedShareStore::new(&staging, &secret, &entropy);
-        for key in store.slot_keys() {
-            block_on(staging.put_staged_bytes(&key, b"not a sealed list")).expect("clobber");
-        }
-        assert!(block_on(store.load()).is_err());
-        assert!(block_on(store.persist(&one_share())).is_err());
+                .as_deref(),
+            Some(stored.as_slice()),
+            "the lost replacement left the stored blob byte-identical"
+        );
+        assert_eq!(
+            block_on(store.load()).expect("load").len(),
+            1,
+            "the list the store already held is still the one it serves"
+        );
     }
 
     #[test]

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -95,9 +95,11 @@ pub const DRAINED_OP_MARK_PREFIX: &[u8] = b"cipherbox/drained-op/";
 /// is *for* is [`Drain::mark_published`].
 pub const PUBLISHED_OP_MARK_PREFIX: &[u8] = b"cipherbox/published-op/";
 
-/// One identity's key under `prefix`, scoped by the same owner tag
-/// [`RecordReader`] classifies queue records against — the shape every
-/// per-identity durable record this device keeps takes.
+/// One identity's key under `prefix`: the prefix followed directly by the owner
+/// tag [`RecordReader`] classifies queue records against. Use it only where the
+/// key ends at the tag — a prefix that appends a further suffix has to delimit
+/// the tag itself, as [`StagingRetireLedger`](crate::net::StagingRetireLedger)
+/// does.
 ///
 /// The op-id high-water marks are the load-bearing case. The durable queue is
 /// shared — a `RecordReader` holds another account's records as

--- a/crates/engine/src/sync/drain.rs
+++ b/crates/engine/src/sync/drain.rs
@@ -95,24 +95,25 @@ pub const DRAINED_OP_MARK_PREFIX: &[u8] = b"cipherbox/drained-op/";
 /// is *for* is [`Drain::mark_published`].
 pub const PUBLISHED_OP_MARK_PREFIX: &[u8] = b"cipherbox/published-op/";
 
-/// One identity's op-id high-water key, under the same owner tag
-/// [`RecordReader`] classifies queue records against.
+/// One identity's key under `prefix`, scoped by the same owner tag
+/// [`RecordReader`] classifies queue records against — the shape every
+/// per-identity durable record this device keeps takes.
 ///
-/// **Both marks are per-identity.** The durable queue is shared — a
-/// `RecordReader` holds another account's records as
+/// The op-id high-water marks are the load-bearing case. The durable queue is
+/// shared — a `RecordReader` holds another account's records as
 /// [`Retained`](crate::sync::record::RecordClass::Retained) rather than
 /// deleting them — and `OpId`s are per *store*, not per identity. A device-wide
 /// high-water would therefore let one account's progress discard another's
 /// queued op: as restore residue under the drained mark, or as already
 /// published under the other.
 ///
-/// [`orphan_staging_keys`] treats both prefixes as referenced, including marks
-/// this session cannot read — their owner is exactly the identity that still
-/// needs them.
+/// [`orphan_staging_keys`] treats each such prefix as referenced, including
+/// entries this session cannot read — their owner is exactly the identity that
+/// still needs them.
 ///
 /// [`orphan_staging_keys`]: crate::sync::staging::orphan_staging_keys
 #[must_use]
-pub fn op_mark_key(prefix: &[u8], enc_secret: &X25519Secret) -> Vec<u8> {
+pub fn owner_scoped_key(prefix: &[u8], enc_secret: &X25519Secret) -> Vec<u8> {
     let mut key = prefix.to_vec();
     key.extend_from_slice(&owner_tag(enc_secret));
     key
@@ -2566,8 +2567,11 @@ where
         };
         // Monotonic by construction: the engine is the single writer, and the
         // mark only ever names ops that have already left the queue.
-        self.raise_op_mark(&op_mark_key(DRAINED_OP_MARK_PREFIX, scope.enc_secret), mark)
-            .await
+        self.raise_op_mark(
+            &owner_scoped_key(DRAINED_OP_MARK_PREFIX, scope.enc_secret),
+            mark,
+        )
+        .await
     }
 
     /// Raise this identity's published-op mark over `op_id`
@@ -2587,7 +2591,7 @@ where
     async fn mark_published(&self, scope: &DrainScope<'_>, op_id: OpId) {
         let _ = self
             .raise_op_mark(
-                &op_mark_key(PUBLISHED_OP_MARK_PREFIX, scope.enc_secret),
+                &owner_scoped_key(PUBLISHED_OP_MARK_PREFIX, scope.enc_secret),
                 op_id.0,
             )
             .await;
@@ -2607,7 +2611,7 @@ where
     async fn drained_mark(&self, scope: &DrainScope<'_>) -> Result<Option<u64>, Halt> {
         op_mark(
             self.staging,
-            &op_mark_key(DRAINED_OP_MARK_PREFIX, scope.enc_secret),
+            &owner_scoped_key(DRAINED_OP_MARK_PREFIX, scope.enc_secret),
         )
         .await
         .map_err(seam)
@@ -2780,7 +2784,11 @@ pub(crate) async fn published_op_mark<St: StagingStore>(
     staging: &St,
     enc_secret: &X25519Secret,
 ) -> SeamResult<Option<u64>> {
-    op_mark(staging, &op_mark_key(PUBLISHED_OP_MARK_PREFIX, enc_secret)).await
+    op_mark(
+        staging,
+        &owner_scoped_key(PUBLISHED_OP_MARK_PREFIX, enc_secret),
+    )
+    .await
 }
 
 /// Classify a register-first refusal on the discriminator the registry stamps,

--- a/crates/engine/src/sync/mod.rs
+++ b/crates/engine/src/sync/mod.rs
@@ -34,7 +34,7 @@ pub mod tick;
 pub use boot::{ColdStartError, ColdStartOutcome, ColdStartParams, RootResolve, cold_start};
 pub use drain::{
     BlockedOp, DRAINED_OP_MARK_PREFIX, OP_ATTEMPTS_KEY, PUBLISHED_OP_MARK_PREFIX, UPLOAD_MARK_KEY,
-    op_mark_key,
+    owner_scoped_key,
 };
 pub use model::{Link, NodeMeta, Snapshot, collation_key, suffix_name};
 pub use op::{NewNode, Op, OpDecodeError, OpKind, Replaced, ScopeCrossing, StagedContent};

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -22,7 +22,7 @@ use cipherbox_core::content::verify_cid;
 
 use crate::content::decode_root;
 use crate::facade::WriteHandle;
-use crate::grants::RECEIVED_SHARES_PREFIX;
+use crate::grants::{CONTACTS_PREFIX, RECEIVED_SHARES_PREFIX};
 use crate::net::RETIRE_LEDGER_PREFIX;
 use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
 use crate::sync::drain::{
@@ -33,8 +33,8 @@ use crate::sync::record::{RecordSeal, encode_op_record, record_content_root_cid}
 
 /// Whether `key` is engine bookkeeping rather than upload residue: a
 /// per-identity op-id high-water mark
-/// ([`op_mark_key`](crate::sync::drain::op_mark_key)), a retire-ledger entry, or
-/// a received-shares list. All are per-owner, so their whole prefixes are
+/// ([`owner_scoped_key`](crate::sync::drain::owner_scoped_key)), a retire-ledger entry, a
+/// received-shares list, or a contact book. All are per-owner, so their whole prefixes are
 /// referenced — an entry this session cannot read belongs to the identity that
 /// still needs it.
 fn is_bookkeeping(key: &[u8]) -> bool {
@@ -42,6 +42,7 @@ fn is_bookkeeping(key: &[u8]) -> bool {
         || key.starts_with(PUBLISHED_OP_MARK_PREFIX)
         || key.starts_with(RETIRE_LEDGER_PREFIX)
         || key.starts_with(RECEIVED_SHARES_PREFIX)
+        || key.starts_with(CONTACTS_PREFIX)
 }
 
 /// Journal one op onto the durable queue, returning its id.
@@ -562,6 +563,7 @@ mod tests {
                 PUBLISHED_OP_MARK_PREFIX,
                 RETIRE_LEDGER_PREFIX,
                 RECEIVED_SHARES_PREFIX,
+                CONTACTS_PREFIX,
             ] {
                 store
                     .put_staged_bytes(&foreign(prefix), &7u64.to_be_bytes())

--- a/crates/engine/src/testkit/conformance/contact_store.rs
+++ b/crates/engine/src/testkit/conformance/contact_store.rs
@@ -14,6 +14,21 @@ fn code(scalar: u8, subkey_scalar: u8) -> Vec<u8> {
     ContactCode::create(&identity, kdf::enc_subkey(&[subkey_scalar; 32]).public()).encode()
 }
 
+/// A code whose subkey the binding signature does not cover — the
+/// key-substitution shape import exists to refuse. Same-length substitution, so
+/// the code still decodes and the verify is what rejects it.
+fn substituted_subkey(scalar: u8, substitute: u8) -> Vec<u8> {
+    let mut bytes = code(scalar, scalar);
+    let bound = kdf::enc_subkey(&[scalar; 32]).public().to_bytes();
+    let forged = kdf::enc_subkey(&[substitute; 32]).public().to_bytes();
+    let at = bytes
+        .windows(bound.len())
+        .position(|w| w == bound)
+        .expect("the encoded code carries the subkey it bound");
+    bytes[at..at + forged.len()].copy_from_slice(&forged);
+    bytes
+}
+
 /// The recorded contacts as `(identity, subkey)` byte pairs, sorted so a kit
 /// assertion never depends on an order the contract does not promise.
 async fn held<S: ContactStore>(store: &S) -> Vec<(Vec<u8>, Vec<u8>)> {
@@ -116,17 +131,17 @@ where
     );
 
     // The import is the write path, so a code whose binding does not verify
-    // never reaches the backing.
-    let mut forged = code(0x23, 0x23);
-    let last = forged.len() - 1;
-    forged[last] ^= 0xFF;
-    assert!(
-        matches!(
-            store.record(&forged).await,
-            Err(ContactStoreError::Import(_))
+    // never reaches the backing. The forgery is a decodable code carrying a
+    // subkey the signature does not cover, so the rejection can only come from
+    // the binding verify.
+    match store.record(&substituted_subkey(0x23, 0x24)).await {
+        Err(ContactStoreError::Import(e)) => assert_eq!(
+            e.check(),
+            "subkey-binding-invalid",
+            "the forged code is refused by the binding verify, not by decoding"
         ),
-        "a code that does not import is refused, never recorded"
-    );
+        other => panic!("a code whose binding does not verify must be refused: {other:?}"),
+    }
     assert_eq!(
         held(&open().await).await.len(),
         1,

--- a/crates/engine/src/testkit/conformance/contact_store.rs
+++ b/crates/engine/src/testkit/conformance/contact_store.rs
@@ -1,0 +1,135 @@
+//! Conformance kit: [`ContactStore`] durability, replacement-on-re-import, and
+//! the fail-closed import that is its only write path.
+
+use cipherbox_core::kdf;
+use cipherbox_core::suite::contact::ContactCode;
+use cipherbox_core::suite::ecdsa::EcdsaSigner;
+
+use crate::grants::{ContactStore, ContactStoreError};
+
+/// A contact code binding `scalar`'s identity to `subkey_scalar`'s encryption
+/// subkey, signed by that identity — what an out-of-band exchange hands over.
+fn code(scalar: u8, subkey_scalar: u8) -> Vec<u8> {
+    let identity = EcdsaSigner::from_scalar(&[scalar; 32]).expect("valid identity scalar");
+    ContactCode::create(&identity, kdf::enc_subkey(&[subkey_scalar; 32]).public()).encode()
+}
+
+/// The recorded contacts as `(identity, subkey)` byte pairs, sorted so a kit
+/// assertion never depends on an order the contract does not promise.
+async fn held<S: ContactStore>(store: &S) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut held: Vec<_> = store
+        .contacts()
+        .await
+        .unwrap()
+        .iter()
+        .map(|c| {
+            (
+                c.identity_pk().to_sec1().to_vec(),
+                c.enc_subkey().to_bytes().to_vec(),
+            )
+        })
+        .collect();
+    held.sort();
+    held
+}
+
+/// Runs the `ContactStore` contract against an implementation.
+///
+/// `open` must return a handle over the same durable backing on every call
+/// (reopen semantics); the backing must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S, F>(mut open: F)
+where
+    S: ContactStore,
+    F: AsyncFnMut() -> S,
+{
+    let store = open().await;
+
+    assert!(
+        store.contacts().await.unwrap().is_empty(),
+        "a fresh backing holds no contacts"
+    );
+
+    let alice = code(0x21, 0x21);
+    let bob = code(0x22, 0x22);
+
+    let imported = store.record(&alice).await.unwrap();
+    assert_eq!(
+        held(&store).await,
+        vec![(
+            imported.identity_pk().to_sec1().to_vec(),
+            imported.enc_subkey().to_bytes().to_vec()
+        )],
+        "a recorded contact reads back as the pair the import verified"
+    );
+    assert_eq!(
+        held(&open().await).await,
+        held(&store).await,
+        "contacts survive reopening the backing"
+    );
+
+    store.record(&bob).await.unwrap();
+    assert_eq!(
+        held(&open().await).await.len(),
+        2,
+        "a second contact joins the book rather than replacing it"
+    );
+
+    // Re-importing an identity replaces its entry: both codes carry that
+    // identity's own signature, so the later one is the contact rotating.
+    let rotated = store.record(&code(0x21, 0x77)).await.unwrap();
+    let after = held(&open().await).await;
+    assert_eq!(after.len(), 2, "a rotation does not grow the book");
+    assert!(
+        after.contains(&(
+            rotated.identity_pk().to_sec1().to_vec(),
+            rotated.enc_subkey().to_bytes().to_vec()
+        )),
+        "the rotated subkey is what the book now holds"
+    );
+
+    // A re-import of an unchanged code is idempotent.
+    store.record(&bob).await.unwrap();
+    assert_eq!(
+        held(&open().await).await,
+        after,
+        "re-recording an unchanged code changes nothing"
+    );
+
+    let bob_identity = EcdsaSigner::from_scalar(&[0x22; 32])
+        .expect("valid identity scalar")
+        .verifying_key()
+        .to_sec1();
+    store.forget(&bob_identity).await.unwrap();
+    assert_eq!(
+        held(&open().await).await.len(),
+        1,
+        "a forgotten contact does not survive"
+    );
+    store.forget(&bob_identity).await.unwrap();
+    assert_eq!(
+        held(&open().await).await.len(),
+        1,
+        "forgetting an identity the book does not hold is a no-op, not an error"
+    );
+
+    // The import is the write path, so a code whose binding does not verify
+    // never reaches the backing.
+    let mut forged = code(0x23, 0x23);
+    let last = forged.len() - 1;
+    forged[last] ^= 0xFF;
+    assert!(
+        matches!(
+            store.record(&forged).await,
+            Err(ContactStoreError::Import(_))
+        ),
+        "a code that does not import is refused, never recorded"
+    );
+    assert_eq!(
+        held(&open().await).await.len(),
+        1,
+        "a refused import leaves the book exactly as it was"
+    );
+}

--- a/crates/engine/src/testkit/conformance/mod.rs
+++ b/crates/engine/src/testkit/conformance/mod.rs
@@ -21,6 +21,7 @@
 //! (host-driven events, no seam-local semantics; losing hints costs only
 //! staleness).
 
+pub mod contact_store;
 pub mod credential_store;
 pub mod floor_store;
 pub mod mailbox;

--- a/crates/engine/src/testkit/fakes/received_share_store.rs
+++ b/crates/engine/src/testkit/fakes/received_share_store.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use zeroize::Zeroizing;
 
-use crate::grants::accept::StoredList;
+use crate::grants::accept::{decode_stored_list, encode_stored_list};
 use crate::grants::{ReceivedShareStore, ReceivedSharesList};
 use crate::seams::{SeamError, SeamResult};
 
@@ -18,8 +18,7 @@ struct Inner {
     /// happened (or did not) around a self-healing re-accept.
     persists: u32,
     /// The persisted list as encoded bytes, so a reopen goes through the same
-    /// codec a real backing does. Revision-free: a fake has one slot and no
-    /// torn-write window to arbitrate.
+    /// codec a real backing does.
     stored: Option<Zeroizing<Vec<u8>>>,
 }
 
@@ -44,7 +43,7 @@ impl InMemoryReceivedShareStore {
 
 impl ReceivedShareStore for InMemoryReceivedShareStore {
     async fn persist(&self, shares: &ReceivedSharesList) -> SeamResult<()> {
-        let encoded = StoredList::encode(shares, 1)
+        let encoded = encode_stored_list(shares)
             .map_err(|e| SeamError::new(format!("received-shares encode failed: {e}")))?;
         let mut inner = self.inner.lock().expect("lock");
         if inner.failing {
@@ -59,8 +58,7 @@ impl ReceivedShareStore for InMemoryReceivedShareStore {
         let stored = self.inner.lock().expect("lock").stored.clone();
         match stored {
             None => Ok(ReceivedSharesList::new()),
-            Some(bytes) => StoredList::decode(&bytes)
-                .map(|stored| stored.shares)
+            Some(bytes) => decode_stored_list(&bytes)
                 .map_err(|e| SeamError::new(format!("received-shares decode failed: {e}"))),
         }
     }

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -4,6 +4,7 @@
 use cipherbox_core::kdf;
 use cipherbox_core::suite::contact::ContactCode;
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
+use cipherbox_engine::grants::{ContactStore, StagingContactStore, resolve_recipient};
 use cipherbox_engine::net::RE_PUT_INTERVAL;
 use cipherbox_engine::seams::{HttpResponse, Scheduler, UnixMillis};
 use cipherbox_engine::testkit::{FakeDevice, FakeSeamTypes, FakeWorld, SeededEntropy, block_on};
@@ -191,6 +192,66 @@ fn importing_a_contact_returns_the_bound_public_keys() {
     let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
     assert_eq!(contact.identity_pk(), identity.verifying_key());
     assert_eq!(contact.enc_subkey(), kdf::enc_subkey(&scalar).public());
+}
+
+/// An import that only lived in the command's return value would leave a later
+/// grant with an identity key and no subkey to seal to, so the contact must come
+/// back from the durable book on the next session.
+#[test]
+fn an_imported_contact_survives_a_session_restart() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+    let scalar = [3u8; 32];
+    block_on(engine.command(Command::ImportContact {
+        contact_code: contact_code(scalar),
+    }))
+    .expect("the code imports");
+    drop(engine);
+
+    let enc_subkey = kdf::enc_subkey(&[7u8; 32]);
+    let book = StagingContactStore::new(&device.staging_store, &enc_subkey);
+    let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
+    let resolved = block_on(resolve_recipient(
+        &book,
+        &identity.verifying_key().to_sec1(),
+    ))
+    .expect("the recorded contact resolves by identity key");
+    assert_eq!(
+        resolved.enc_subkey(),
+        kdf::enc_subkey(&scalar).public(),
+        "the subkey a later grant seals to is the one the import verified"
+    );
+}
+
+/// A durable book that cannot take the write must fail the command: a host told
+/// the contact imported would offer it as a grant recipient the next session
+/// cannot resolve.
+#[test]
+fn an_import_the_book_cannot_take_is_not_reported_as_imported() {
+    let world = FakeWorld::new();
+    let device = world.device(b"alice-pk");
+    let (mut engine, _events) = new_engine(&device);
+    block_on(engine.start(secret())).unwrap();
+
+    let enc_subkey = kdf::enc_subkey(&[7u8; 32]);
+    let book = StagingContactStore::new(&device.staging_store, &enc_subkey);
+    device
+        .staging_store
+        .interrupt_staged_write_after(book.staging_key(), 0);
+
+    let result = block_on(engine.command(Command::ImportContact {
+        contact_code: contact_code([3u8; 32]),
+    }));
+    assert!(
+        matches!(result, Err(EngineError::Seam { .. })),
+        "a lost durable write fails the import: {result:?}"
+    );
+    assert!(
+        block_on(book.contacts()).expect("load").is_empty(),
+        "nothing was recorded"
+    );
 }
 
 /// The binding signature is the only thing tying the encryption subkey to the

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -26,8 +26,13 @@ fn new_engine(device: &FakeDevice) -> (Engine<FakeSeamTypes>, EventStream) {
     )
 }
 
+/// The login secret every test in this file starts the engine with. The staging
+/// stores the tests reach into directly derive their keys from it, so the two
+/// stay in step.
+const SECRET: [u8; 32] = [7u8; 32];
+
 fn secret() -> LoginSecret {
-    LoginSecret::new(vec![7u8; 32])
+    LoginSecret::new(SECRET.to_vec())
 }
 
 /// Commands whose pipeline slice has not landed: the still-unimplemented
@@ -210,7 +215,7 @@ fn an_imported_contact_survives_a_session_restart() {
     .expect("the code imports");
     drop(engine);
 
-    let enc_subkey = kdf::enc_subkey(&[7u8; 32]);
+    let enc_subkey = kdf::enc_subkey(&SECRET);
     let book = StagingContactStore::new(&device.staging_store, &enc_subkey);
     let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
     let resolved = block_on(resolve_recipient(
@@ -235,7 +240,7 @@ fn an_import_the_book_cannot_take_is_not_reported_as_imported() {
     let (mut engine, _events) = new_engine(&device);
     block_on(engine.start(secret())).unwrap();
 
-    let enc_subkey = kdf::enc_subkey(&[7u8; 32]);
+    let enc_subkey = kdf::enc_subkey(&SECRET);
     let book = StagingContactStore::new(&device.staging_store, &enc_subkey);
     device
         .staging_store

--- a/crates/engine/tests/grants_mailbox.rs
+++ b/crates/engine/tests/grants_mailbox.rs
@@ -1637,7 +1637,7 @@ fn a_recovered_persist_lands_in_the_durable_list() {
     // it acks: nothing is acked and no floor moves.
     recipient
         .staging_store
-        .interrupt_staged_write_after(&store.slot_keys()[0], 0);
+        .interrupt_staged_write_after(store.staging_key(), 0);
     let mut received = block_on(store.load()).expect("cold load");
     let err = block_on(accept_share(
         &recipient.floor_store,

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -43,8 +43,8 @@ use cipherbox_engine::settings::{
 };
 use cipherbox_engine::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
 use cipherbox_engine::sync::{
-    DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX, StagedContent, UPLOAD_MARK_KEY, op_mark_key,
-    record_content_root_cid,
+    DRAINED_OP_MARK_PREFIX, PUBLISHED_OP_MARK_PREFIX, StagedContent, UPLOAD_MARK_KEY,
+    owner_scoped_key, record_content_root_cid,
 };
 use cipherbox_engine::testkit::fakes::InMemoryRecordStore;
 use cipherbox_engine::testkit::{
@@ -4521,12 +4521,12 @@ fn a_cancel_after_the_version_published_is_refused() {
 /// This account's published-op mark key. The mark is per-identity, so a store
 /// shared with another account keeps one mark each.
 fn mark_key() -> Vec<u8> {
-    op_mark_key(PUBLISHED_OP_MARK_PREFIX, &kdf::enc_subkey(&SECRET))
+    owner_scoped_key(PUBLISHED_OP_MARK_PREFIX, &kdf::enc_subkey(&SECRET))
 }
 
 /// This account's drained-op mark key.
 fn drained_key() -> Vec<u8> {
-    op_mark_key(DRAINED_OP_MARK_PREFIX, &kdf::enc_subkey(&SECRET))
+    owner_scoped_key(DRAINED_OP_MARK_PREFIX, &kdf::enc_subkey(&SECRET))
 }
 
 /// Plant a published-op mark over `op_id` under `enc_secret`'s identity,
@@ -4534,7 +4534,7 @@ fn drained_key() -> Vec<u8> {
 /// removal from the queue.
 fn plant_published_mark_for(device: &FakeDevice, enc_secret: &X25519Secret, op_id: OpId) {
     block_on(device.staging_store.put_staged_bytes(
-        &op_mark_key(PUBLISHED_OP_MARK_PREFIX, enc_secret),
+        &owner_scoped_key(PUBLISHED_OP_MARK_PREFIX, enc_secret),
         &op_id.0.to_be_bytes(),
     ))
     .unwrap();
@@ -5038,7 +5038,7 @@ fn another_identitys_drained_mark_never_discards_this_ones_queued_op() {
 
     let stranger = kdf::enc_subkey(&[9u8; 32]);
     block_on(alice.staging_store.put_staged_bytes(
-        &op_mark_key(DRAINED_OP_MARK_PREFIX, &stranger),
+        &owner_scoped_key(DRAINED_OP_MARK_PREFIX, &stranger),
         &(op_id.0 + 100).to_be_bytes(),
     ))
     .unwrap();


### PR DESCRIPTION
Wave 8 batch A. Two commits: the single-key collapse that #1194's failure-atomic `put_staged_bytes` made possible, and the owner's contact book on top of it.

No new host seam. `SeamSet` stays at nine fields — the store rides the existing `StagingStore` seam at the grants layer, on the `RetireLedger` precedent named at `crates/engine/src/seams/mod.rs:5-10`. No `crates/core` file changes, so no structure tag and no KAT vector moves.

**The invite-record store for #1165 is not in this PR.** See "What is missing" below — the review gates found that landing it unsealed would be a latent forgery, and sealing it needs a frozen core structure tag that is out of scope here.

## 1 — collapse the received-shares store onto a single staging key

`put_staged_bytes` is failure-atomic at the seam, so the two-slot layout with its monotonic `revision` no longer buys anything. It was also a liability: when one slot was unreadable it was usually the *newer* one, so the load served the older list and silently dropped what the newer session had bookmarked.

One key now holds the whole list. Stored bytes this build cannot open or decode fail closed rather than reading as an empty list. `Slot`, `TargetPreference`, `slot_keys`, `read_slots` and `StoredList.revision` are gone; the stored body is `encode_stored_list`/`decode_stored_list` over `{shares, v}`, and the at-rest byte vector that pins the format is re-frozen.

Five slot-arbitration tests were removed as meaningless under one key — torn-slot-loses, higher-revision-wins, free-slot-over-unreadable, unreadable-before-readable, and refuse-when-neither-slot-is-readable. Everything they protected that still exists is covered: `a_lost_write_never_destroys_the_readable_list` is reworked onto the seam's atomicity, and the fail-closed load is covered in both arms — bytes that do not open, and bytes that open but do not decode.

`op_mark_key` becomes `owner_scoped_key`: the prefix-plus-owner-tag shape it already implemented is what every per-identity durable record uses, and the store now derives its key through it once at construction rather than on every call. `TooLong`, `within` and `reject_unknown` are shared across the grants layer's stored-body codecs instead of recopied.

## 2 — the owner's contact book

A grant command names its recipient by identity key alone, but the grant blob and the blinded tag both need that recipient's X25519 encryption subkey, and nothing kept the `Contact` an import produced.

`StagingContactStore` persists the self-authenticating **contact code**, not the imported pair. `record` is itself the fail-closed import, and every load re-runs that binding verify, so host bytes never construct a `Contact` and a tampered backing can never re-point an identity key at a subkey its holder did not sign. Only the canonical re-encoding is stored, so the offered spelling — which tolerates unknown fields — is not a byte channel into the owner's durable store.

`resolve_recipient` looks a contact up by the same compressed SEC1 identity key the ledger entry and the mailbox address use; an identity key no import verified is `RecipientNotImported`. A book at `MAX_CONTACTS` reports `Full` with `forget` as the remedy rather than reading as corruption.

`Command::ImportContact` writes through the book before it reports the contact, so an import the durable book could not take is not reported as imported, and a stored book this build cannot read surfaces as a trust violation rather than a retryable seam error.

### Residuals, stated in the module header

The book carries no owner attestation and a contact code carries no counter, so a tamperer can still insert a validly signed third-party code, roll an identity back to a subkey its holder signed once but has since rotated away from, or delete an entry and turn a later revoke into `RecipientNotImported`. It is also plaintext at rest, which discloses the owner's contact graph to a local reader — the grant ledger that would otherwise carry those identity keys is sealed under the scope's write key, so this is a new disclosure rather than a restatement of a published one. Closing all four wants the book sealed HPKE-to-self under a frozen structure tag of its own.

## What is missing

`#1165`'s invite-record store is built and reviewed but held back. `RecordedInvite.ephemeral_identity_pk` is bound by nothing: the tag re-derivation in `convert_invite_claim` covers only `ephemeral_enc_pk`, and the commitment carries `(tag, permission, pseudonymPk)`. A durable store therefore hands an attacker who can write host storage a way to pair a real grantee's `enc_pk` — which re-derives to that grantee's committed tag — with an identity key they hold, and convert a claim into an owner-signed grant at that grantee's permission.

Embedding the ephemeral half as a contact code does not close it: a contact code proves "identity A asserts enc E", which the attacker can sign for any E. The authority has to be the owner's, so the record set must be sealed or MAC'd under the session enc-subkey — a new frozen structure tag plus its KAT vectors, which is a larger and separately reviewable change than #1165 describes. #1165 stays open; the work is preserved and the mechanism is written up on the issue.

Closes #1164
Closes #1189


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist imported contacts and collapse received-shares storage to a single key
> - Introduces `StagingContactStore` in [contact_store.rs](https://github.com/FSM1/cipher-box/pull/1196/files#diff-108775664640364cb3ba554dbee6877279344d8e5ad83139e7ac3a132f7a2e53) with a `ContactStore` trait (`record`, `forget`, `contacts`) backed by a single owner-scoped staging key under the `cbx/cb/` prefix; contacts are encoded as versioned det-CBOR with duplicate/bounds enforcement and full re-verification on read.
> - Wires `ImportContact` in [facade.rs](https://github.com/FSM1/cipher-box/pull/1196/files#diff-76615117c8cac0cf4673ee8bdad7503af14a9f6988afc51f66d3f31b82325238) to use `StagingContactStore.record()`, adding structured error mapping for `contact-book-full`, seam failures, and trust violations.
> - Collapses the received-shares store from a two-slot alternating scheme to a single owner-scoped key; removes revision tracking and slot selection logic from [received_share_store.rs](https://github.com/FSM1/cipher-box/pull/1196/files#diff-6e04f73a125c9340168917dce01cd8e831d5fa6f98b336e1001e07eb20afec34) and [accept.rs](https://github.com/FSM1/cipher-box/pull/1196/files#diff-64490c735faf9bdfa24fdeb175093548c22e75b73c69cf943e704ae45c01a05e).
> - Renames `op_mark_key` to `owner_scoped_key` in [drain.rs](https://github.com/FSM1/cipher-box/pull/1196/files#diff-2dbe80269b4dfac050f51bbaedb9a173236f92de78f9951dd049c549f45f08a5) and updates all call sites.
> - Risk: `decode_stored_list` now hard-fails on unreadable or undecodable blobs rather than falling back to an alternate slot; existing stored blobs containing a `revision` field will be rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac5f9b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable contact storage with listing, replacement, removal, and identity-based resolution.
  * Imported contacts are encrypted, persisted, and restored after restarting.
  * Added validation and size limits for contact codes, with fail-closed handling of invalid or tampered data.

* **Bug Fixes**
  * Failed contact persistence no longer reports success or leaves partial contact records.
  * Contact records are preserved during staging cleanup.

* **Refactor**
  * Simplified received-share and staged-record storage for more reliable persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->