### PR TITLE
feat: rebuild the sweep as an interior-node lazy wave over the real seams

### DIFF
--- a/blueprint/engine.md
+++ b/blueprint/engine.md
@@ -450,9 +450,16 @@ Idempotent lazy-wave advancement over a scope's **interior nodes** — not its
 descendant scope roots, which the cascade rotates eagerly (FSM1/cipher-box-next#26 D2,
 [ADR 0003](https://github.com/FSM1/cipher-box-next/blob/main/decisions/0003-sweep-population-and-below-floor-scope-roots.md)).
 The work-list is the epoch-lag predicate: an interior node whose envelope epoch
-is behind its scope's current epoch. Runnable by any write-capable client;
-ordinary writes advance it for free. It also converges a subtree before a grant
-(the epoch-converged requirement) and self-heals the direct-child-scope index —
+is behind its scope's current epoch. Reading one is the single path that runs
+the sequence floor without the read-epoch floor — a lagging node sits below that
+floor by construction, and carries no seed, grant blob or commitment for the
+stage to protect; its body opens under the seed the scope's history-link ratchet
+walks back to. A node the retained window no longer reaches is readable by
+nobody: it is reported unreachable and neither swept nor descended into, never
+treated as a trust violation of its own record. Runnable by any write-capable
+client; ordinary writes advance it for free. It also converges the granted folder's own
+subtree before a grant (the epoch-converged requirement, FSM1/cipher-box-next#26 D2 — the folder's
+subtree, not the whole scope it sits in) and self-heals the direct-child-scope index —
 a scope root encountered but missing from its parent's index is repaired and
 flagged (FSM1/cipher-box-next#38 D6), a walk-time repair that runs whether or not any node is being
 re-sealed. Only a name the walk resolved current may be written to an index: a
@@ -625,8 +632,10 @@ the republish it already does.
   `writeScopeSeed` sealed to the owner's own enc subkey, beside that write-body
   (`reseal_scope_root`, so every root/interior write-scope cut, rotation, and
   cascade carries one) — the owner's recovery source for `write_name_signer`.
-  The sweep authors none: it re-seals interior nodes, which publish no
-  write-body for a blob to sit beside (FSM1/cipher-box-next#27 D6). This slice authors and
+  The sweep's interior re-seals author none — an interior node publishes no
+  write-body for a blob to sit beside (FSM1/cipher-box-next#27 D6) — while its
+  index self-heal, which republishes the scope root, authors one like any other
+  root re-seal. This slice authors and
   gate-verifies the blob; the owner read/consume that opens it into
   `HeldMaterial.write_scope_seed` rides a later facade slice.
 

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -1174,13 +1174,21 @@ impl SweepResolver for LocalNet {
         Ok(None)
     }
 
-    async fn resolve_child(&self, _child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+    async fn resolve_child(
+        &self,
+        _scope: &ChildScopeRef,
+        _child: &NodeRef,
+    ) -> Result<SweptChild, SweepResolveFailure> {
         Err(SweepResolveFailure::Rejected)
     }
 }
 
 impl SweepPublisher for LocalNet {
-    async fn publish_node(&self, _node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+    async fn publish_node(
+        &self,
+        _scope: &ChildScopeRef,
+        _node: &LaggingNode<'_>,
+    ) -> Result<(), ScopeRootPublishError> {
         Ok(())
     }
 

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -19,7 +19,7 @@ use cipherbox_contract::{
 };
 use cipherbox_core::content::{CONTENT_CID_CODEC, compute_cid, encode_content_cid_str};
 use cipherbox_core::seal::{
-    ChildScopeRef, GrantSetCommitment, Permission, PreservedFields, sign_grant_set,
+    ChildScopeRef, GrantSetCommitment, Permission, PreservedFields, ReadBody, sign_grant_set,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -38,8 +38,8 @@ use cipherbox_engine::net::REGISTRY_BATCH_MAX;
 use cipherbox_engine::rotation::{
     CascadeResealResolver, CascadeTarget, LaggingNode, NodeRef, PrevEpochSeed, ResealSeeds,
     ResealedScopeRoot, ResolveFailure, ScopeRootIdentity, ScopeRootPublishError,
-    ScopeRootPublisher, SweepPublisher, SweepResolveFailure, SweepResolver, SweptChild, SweptScope,
-    WriteHistory,
+    ScopeRootPublisher, SweepPublisher, SweepResolveFailure, SweepResolver, SweptChild, SweptNode,
+    SweptScope, WriteHistory,
 };
 use cipherbox_engine::seams::{
     CredentialStore, Http, HttpCredentials, HttpMethod, HttpRequest, Mailbox,
@@ -1151,9 +1151,13 @@ impl Mailbox for ApiMailbox {
 }
 
 /// The grant's whole net arm, kept local: this leg asserts the *delivery* the
-/// grant path emits, not IPNS. The swept parent scope is empty, so the
-/// convergence gate passes with nothing to advance.
+/// grant path emits, not IPNS. The convergence gate measures the granted node
+/// and finds it already at the scope epoch, so it advances nothing.
 struct LocalNet;
+
+/// The parent scope's read epoch, shared by the scope root and the granted node
+/// so the node measures as converged.
+const LOCAL_NET_READ_EPOCH: u64 = 3;
 
 impl SweepResolver for LocalNet {
     async fn resolve_scope(
@@ -1161,7 +1165,7 @@ impl SweepResolver for LocalNet {
         _scope: &ChildScopeRef,
     ) -> Result<SweptScope, SweepResolveFailure> {
         Ok(SweptScope {
-            current_read_epoch: 3,
+            current_read_epoch: LOCAL_NET_READ_EPOCH,
             children: Vec::new(),
             direct_child_scope_index: Vec::new(),
         })
@@ -1179,7 +1183,18 @@ impl SweepResolver for LocalNet {
         _scope: &ChildScopeRef,
         _child: &NodeRef,
     ) -> Result<SweptChild, SweepResolveFailure> {
-        Err(SweepResolveFailure::Rejected)
+        Ok(SweptChild::Interior(SweptNode {
+            current_read_epoch: LOCAL_NET_READ_EPOCH,
+            sequence: 1,
+            read_body: ReadBody::Folder {
+                created_at: 0,
+                modified_at: 0,
+                children: Vec::new(),
+                unknown: PreservedFields::new(),
+            },
+            carried_unknown: PreservedFields::new(),
+            carried_epoch_tag_unknown: PreservedFields::new(),
+        }))
     }
 }
 

--- a/crates/contract/tests/contract.rs
+++ b/crates/contract/tests/contract.rs
@@ -36,15 +36,16 @@ use cipherbox_engine::grants::{
 use cipherbox_engine::mailbox::poll_verified;
 use cipherbox_engine::net::REGISTRY_BATCH_MAX;
 use cipherbox_engine::rotation::{
-    PrevEpochSeed, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
-    ScopeRootPublishError, ScopeRootPublisher, SweepResolver, SweepTarget, WriteHistory,
+    CascadeResealResolver, CascadeTarget, LaggingNode, NodeRef, PrevEpochSeed, ResealSeeds,
+    ResealedScopeRoot, ResolveFailure, ScopeRootIdentity, ScopeRootPublishError,
+    ScopeRootPublisher, SweepPublisher, SweepResolveFailure, SweepResolver, SweptChild, SweptScope,
+    WriteHistory,
 };
 use cipherbox_engine::seams::{
     CredentialStore, Http, HttpCredentials, HttpMethod, HttpRequest, Mailbox,
     MailboxItem as SealedMailboxItem, SeamError, SeamResult,
 };
 use cipherbox_engine::testkit::SeededEntropy;
-use cipherbox_engine::testkit::fakes::InMemoryFloorStore;
 
 type Client = ApiClient<ReqwestHttp, MemoryCredentialStore>;
 
@@ -1149,12 +1150,51 @@ impl Mailbox for ApiMailbox {
     }
 }
 
-/// A `SweepResolver` + `ScopeRootPublisher` that keeps the grant's network side
-/// local: this leg asserts the *delivery* the grant path emits, not IPNS.
+/// The grant's whole net arm, kept local: this leg asserts the *delivery* the
+/// grant path emits, not IPNS. The swept parent scope is empty, so the
+/// convergence gate passes with nothing to advance.
 struct LocalNet;
 
 impl SweepResolver for LocalNet {
-    async fn resolve(&self, _scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure> {
+    async fn resolve_scope(
+        &self,
+        _scope: &ChildScopeRef,
+    ) -> Result<SweptScope, SweepResolveFailure> {
+        Ok(SweptScope {
+            current_read_epoch: 3,
+            children: Vec::new(),
+            direct_child_scope_index: Vec::new(),
+        })
+    }
+
+    async fn consult_pointer(
+        &self,
+        _scope_id: &[u8; 16],
+    ) -> Result<Option<Vec<u8>>, SweepResolveFailure> {
+        Ok(None)
+    }
+
+    async fn resolve_child(&self, _child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+        Err(SweepResolveFailure::Rejected)
+    }
+}
+
+impl SweepPublisher for LocalNet {
+    async fn publish_node(&self, _node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+        Ok(())
+    }
+
+    async fn repair_child_scope_index(
+        &self,
+        _scope: &ChildScopeRef,
+        _index: &[ChildScopeRef],
+    ) -> Result<(), ScopeRootPublishError> {
+        Ok(())
+    }
+}
+
+impl CascadeResealResolver for LocalNet {
+    async fn resolve(&self, _scope: &ChildScopeRef) -> Result<CascadeTarget, ResolveFailure> {
         Err(ResolveFailure::Rejected)
     }
 }
@@ -1209,7 +1249,6 @@ async fn a_read_grant_delivers_its_share_pointer_through_the_live_mailbox() {
         .to_compact();
 
     let mut entropy = SeededEntropy::new(954);
-    let floors = InMemoryFloorStore::default();
     let net = LocalNet;
     let mailbox = ApiMailbox {
         client: owner_client,
@@ -1217,7 +1256,6 @@ async fn a_read_grant_delivers_its_share_pointer_through_the_live_mailbox() {
 
     create_read_grant(
         &mut entropy,
-        &floors,
         &net,
         &net,
         &mailbox,

--- a/crates/engine/src/gate/floor.rs
+++ b/crates/engine/src/gate/floor.rs
@@ -158,6 +158,37 @@ pub enum Strictness {
     /// last-known-good): only exact equality is admitted — lower is a
     /// fail-closed replay, higher is a record that never passed an adopt.
     AtFloor,
+    /// The replay bar alone: the floor or anything above it. The one read that
+    /// takes it ([`crate::rotation::sweep`]'s interior nodes) must reach records
+    /// the **epoch** stage refuses, so it runs [`check_sequence`] rather than
+    /// [`check`] — and its bar is named here, beside the rest of the floor law,
+    /// rather than hand-rolled at the call site.
+    AtOrAboveFloor,
+}
+
+/// The per-name sequence floor alone — gate stage 4, per `strictness`.
+pub async fn check_sequence<F: FloorStore>(
+    floors: &F,
+    ipns_name: &[u8],
+    sequence: u64,
+    strictness: Strictness,
+) -> Result<(), GateError> {
+    let floor = sequence_floor(floors, ipns_name)
+        .await
+        .map_err(GateError::Seam)?
+        .unwrap_or(0);
+    let replayed = match strictness {
+        Strictness::StrictlyNewer => sequence <= floor,
+        Strictness::AtFloor => sequence != floor,
+        Strictness::AtOrAboveFloor => sequence < floor,
+    };
+    if replayed {
+        return Err(GateError::Rejected(GateRejection {
+            stage: GateStage::Sequence,
+            reason: RejectionReason::SequenceNotNewer { floor, sequence },
+        }));
+    }
+    Ok(())
 }
 
 /// The durable floor checks — gate stages 4/5: the per-name sequence floor
@@ -171,20 +202,7 @@ pub async fn check<F: FloorStore>(
     epoch: u64,
     strictness: Strictness,
 ) -> Result<(), GateError> {
-    let floor = sequence_floor(floors, ipns_name)
-        .await
-        .map_err(GateError::Seam)?
-        .unwrap_or(0);
-    let replayed = match strictness {
-        Strictness::StrictlyNewer => sequence <= floor,
-        Strictness::AtFloor => sequence != floor,
-    };
-    if replayed {
-        return Err(GateError::Rejected(GateRejection {
-            stage: GateStage::Sequence,
-            reason: RejectionReason::SequenceNotNewer { floor, sequence },
-        }));
-    }
+    check_sequence(floors, ipns_name, sequence, strictness).await?;
     let epoch_floor = read_epoch_floor(floors, scope_id)
         .await
         .map_err(GateError::Seam)?

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -12,9 +12,8 @@
 //! # Simulation boundary
 //!
 //! Deterministic-simulation slice: entropy is the injected [`Entropy`] seam and
-//! the read/floor/publish/mailbox effects are faked in tests. The publisher this
-//! composes over has a production implementation in [`crate::net::rotation`]; the
-//! sweep resolver does not.
+//! the read/floor/publish/mailbox effects are faked in tests. Every seam this
+//! composes over has a production implementation in [`crate::net::rotation`].
 //!
 //! # Not implemented here
 //!
@@ -45,11 +44,11 @@ use crate::grants::child_index::{canonicalize, insert_child, remove_child};
 use crate::grants::mint_grant_row;
 use crate::mailbox::post_sealed;
 use crate::rotation::{
-    CommittedSet, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure, ScopeRootIdentity,
-    ScopeRootPublishError, ScopeRootPublisher, SweepError, SweepResolver, WriteHistory,
-    derive_write_name, reseal_scope_root, sweep_pass,
+    CascadeResealResolver, CommittedSet, ResealError, ResealSeeds, ResealedScopeRoot,
+    ResolveFailure, ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, SweepError,
+    SweepPublisher, SweepResolver, WriteHistory, derive_write_name, reseal_scope_root, sweep_pass,
 };
-use crate::seams::{FloorStore, Mailbox, SeamError};
+use crate::seams::{Mailbox, SeamError};
 use cipherbox_core::hex::lower as hex_lower;
 
 /// The fresh grantee scope minted at the granted folder. `scope_id` is the
@@ -165,7 +164,7 @@ pub enum CreateGrantError {
     /// dropped on a lost CAS race, so the grant is refused rather than minted
     /// over a possibly-lagging subtree.
     SubtreeNotConverged {
-        /// Scope roots left unproven this pass.
+        /// The interior nodes left unproven this pass.
         unconverged: Vec<[u8; 16]>,
     },
     /// The recipient encryption key is non-contributory (degenerate ECDH).
@@ -256,10 +255,9 @@ impl std::error::Error for CreateGrantError {}
 /// 5); past that point the sequence is not atomic — see [`CreateGrantError`] for
 /// what each post-publish variant leaves committed.
 #[allow(clippy::too_many_arguments)]
-pub async fn create_read_grant<E, F, R, P, M>(
+pub async fn create_read_grant<E, R, P, M>(
     entropy: &mut E,
-    floors: &F,
-    sweep_resolver: &R,
+    resolver: &R,
     publisher: &P,
     mailbox: &M,
     grantee: &GranteeScopePlan<'_>,
@@ -269,24 +267,19 @@ pub async fn create_read_grant<E, F, R, P, M>(
 ) -> Result<CreateGrantOutcome, CreateGrantError>
 where
     E: Entropy,
-    F: FloorStore,
-    R: SweepResolver,
-    P: ScopeRootPublisher,
+    R: SweepResolver + CascadeResealResolver,
+    P: ScopeRootPublisher + SweepPublisher,
     M: Mailbox,
 {
-    // 1) Convergence gate — run the sweep over the granted subtree. A dropped
-    // lost race means convergence is unproven: refuse rather than share a
-    // possibly-lagging subtree (the grant-creation convergence requirement).
-    let swept = sweep_pass(
-        entropy,
-        floors,
-        sweep_resolver,
-        publisher,
-        grantee.scope_id,
-        grantee.subtree_child_index,
-    )
-    .await
-    .map_err(CreateGrantError::Converge)?;
+    // 1) Convergence gate — sweep the scope the granted folder still lives in,
+    // so no interior node under it lags that scope's epoch. A dropped lost race
+    // means convergence is unproven: refuse rather than share a possibly-lagging
+    // subtree (CONTEXT.md "Epoch-converged").
+    let parent_scope =
+        ChildScopeRef::new(parent.identity.scope_id, parent.identity.ipns_name.to_vec());
+    let swept = sweep_pass(resolver, publisher, &parent_scope)
+        .await
+        .map_err(CreateGrantError::Converge)?;
     if !swept.dropped_lost_race.is_empty() {
         return Err(CreateGrantError::SubtreeNotConverged {
             unconverged: swept.dropped_lost_race,
@@ -389,7 +382,7 @@ where
     // (rotation/cascade.rs). Register-first: the grantee root published above
     // already lists these descendants, so each points back at a parent that exists.
     for descendant in grantee.subtree_child_index {
-        let target = sweep_resolver.resolve(descendant).await.map_err(|reason| {
+        let target = resolver.resolve(descendant).await.map_err(|reason| {
             CreateGrantError::DescendantResolve {
                 scope_id: descendant.scope_id,
                 reason,
@@ -544,12 +537,15 @@ mod tests {
     use crate::grants::recipient_blinded_tag;
     use crate::grants::{GrantRow, PublishedGrantBlob};
     use crate::mailbox::poll_verified;
-    use crate::rotation::{PrevEpochSeed, ResolveFailure, SweepTarget};
-    use crate::testkit::fakes::{InMemoryFloorStore, InMemoryMailboxHub};
+    use crate::rotation::{
+        CascadeTarget, LaggingNode, NodeRef, PrevEpochSeed, ResolveFailure, SweepResolveFailure,
+        SweptChild, SweptNode, SweptScope,
+    };
+    use crate::testkit::fakes::InMemoryMailboxHub;
     use crate::testkit::{SeededEntropy, block_on};
     use cipherbox_core::seal::{
-        AadContext, AscentLink, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, open_ascent_link,
-        open_grant_blob,
+        AadContext, AscentLink, ReadBody, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB,
+        open_ascent_link, open_grant_blob,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -566,6 +562,15 @@ mod tests {
     const PARENT_NAME: &[u8] = b"parent-scope-root-name";
     const DESCENDANT_SCOPE: [u8; 16] = [0xdd; 16];
     const DESCENDANT_NAME: &[u8] = b"descendant-scope-root-name";
+    /// The read epoch every `ParentScopePlan` below re-seals at — the epoch the
+    /// convergence sweep measures the parent scope's interior nodes against.
+    const PARENT_EPOCH: u64 = 3;
+    /// An interior node of the parent scope, inside the granted folder.
+    const INTERIOR_NODE: [u8; 16] = [0xa1; 16];
+    const INTERIOR_NAME: &[u8] = b"interior-node-name";
+
+    /// One interior node of the parent scope: its id and its published epoch.
+    type InteriorNodeState = ([u8; 16], u64);
 
     /// The grantee scope root's ipnsName, derived exactly as the primitive does
     /// (from the folder's write material) so assertions bind the real name.
@@ -594,11 +599,15 @@ mod tests {
             .verifying_key()
     }
 
-    /// A combined `SweepResolver` + `ScopeRootPublisher` fake: it records every
-    /// committed publish and can force a lost race to model an unconvergeable
-    /// subtree. `resolve` builds a valid, lagging descendant `SweepTarget` for
-    /// `DESCENDANT_SCOPE` (whose re-seal succeeds, so the convergence outcome is
-    /// decided by the publish result).
+    /// The whole net arm the primitive composes over: the convergence sweep's
+    /// two seams, the cascade re-seal resolve step 5b runs, and the scope-root
+    /// publisher. It records every committed publish and can force a lost race
+    /// to model an unconvergeable subtree.
+    ///
+    /// The parent scope sits at [`PARENT_EPOCH`] and carries whatever interior
+    /// nodes `interior` lists, so a test decides whether the granted subtree
+    /// holds a lagging node. `resolve` builds a valid descendant `CascadeTarget`
+    /// for `DESCENDANT_SCOPE`.
     ///
     /// `fail_after` fails the Nth+ `publish_scope_root` call so a test can let
     /// the grantee publish succeed and then fail the parent publish — the
@@ -610,6 +619,13 @@ mod tests {
         publish_result: Result<(), ScopeRootPublishError>,
         publish_calls: Rc<RefCell<usize>>,
         fail_after: Option<(usize, ScopeRootPublishError)>,
+        /// The parent scope's interior nodes: id → published read epoch.
+        interior: Rc<RefCell<Vec<InteriorNodeState>>>,
+        /// What an interior-node re-seal publish returns.
+        node_publish_result: Result<(), ScopeRootPublishError>,
+        node_publishes: Rc<RefCell<Vec<[u8; 16]>>>,
+        /// A node the sweep cannot resolve at all.
+        unresolvable: Option<[u8; 16]>,
     }
 
     impl FakeNet {
@@ -619,6 +635,10 @@ mod tests {
                 publish_result,
                 publish_calls: Rc::new(RefCell::new(0)),
                 fail_after: None,
+                interior: Rc::new(RefCell::new(Vec::new())),
+                node_publish_result: Ok(()),
+                node_publishes: Rc::new(RefCell::new(Vec::new())),
+                unresolvable: None,
             }
         }
 
@@ -631,10 +651,102 @@ mod tests {
                 ..Self::new(Ok(()))
             }
         }
+
+        /// Put one interior node in the parent scope at `epoch`.
+        fn with_interior(self, node_id: [u8; 16], epoch: u64) -> Self {
+            self.interior.borrow_mut().push((node_id, epoch));
+            self
+        }
+
+        fn node_publish(mut self, result: Result<(), ScopeRootPublishError>) -> Self {
+            self.node_publish_result = result;
+            self
+        }
+
+        fn unresolvable(mut self, node_id: [u8; 16]) -> Self {
+            self.unresolvable = Some(node_id);
+            self
+        }
     }
 
     impl SweepResolver for FakeNet {
-        async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure> {
+        async fn resolve_scope(
+            &self,
+            scope: &ChildScopeRef,
+        ) -> Result<SweptScope, SweepResolveFailure> {
+            if scope.scope_id != PARENT_SCOPE {
+                return Err(SweepResolveFailure::Rejected);
+            }
+            Ok(SweptScope {
+                current_read_epoch: PARENT_EPOCH,
+                children: self
+                    .interior
+                    .borrow()
+                    .iter()
+                    .map(|(node_id, _)| NodeRef {
+                        node_id: *node_id,
+                        ipns_name: INTERIOR_NAME.to_vec(),
+                    })
+                    .collect(),
+                direct_child_scope_index: Vec::new(),
+            })
+        }
+
+        async fn consult_pointer(
+            &self,
+            _scope_id: &[u8; 16],
+        ) -> Result<Option<Vec<u8>>, SweepResolveFailure> {
+            Ok(None)
+        }
+
+        async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+            if self.unresolvable == Some(child.node_id) {
+                return Err(SweepResolveFailure::Unavailable);
+            }
+            let epoch = self
+                .interior
+                .borrow()
+                .iter()
+                .find(|(node_id, _)| *node_id == child.node_id)
+                .map(|(_, epoch)| *epoch)
+                .ok_or(SweepResolveFailure::Unavailable)?;
+            Ok(SweptChild::Interior(SweptNode {
+                current_read_epoch: epoch,
+                read_body: ReadBody::Folder {
+                    created_at: 0,
+                    modified_at: 0,
+                    children: Vec::new(),
+                    unknown: PreservedFields::new(),
+                },
+                carried_unknown: PreservedFields::new(),
+                carried_epoch_tag_unknown: PreservedFields::new(),
+            }))
+        }
+    }
+
+    impl SweepPublisher for FakeNet {
+        async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+            self.node_publishes.borrow_mut().push(node.node_id);
+            self.node_publish_result.clone()?;
+            for (node_id, epoch) in self.interior.borrow_mut().iter_mut() {
+                if *node_id == node.node_id {
+                    *epoch = node.read_epoch;
+                }
+            }
+            Ok(())
+        }
+
+        async fn repair_child_scope_index(
+            &self,
+            _scope: &ChildScopeRef,
+            _index: &[ChildScopeRef],
+        ) -> Result<(), ScopeRootPublishError> {
+            Ok(())
+        }
+    }
+
+    impl CascadeResealResolver for FakeNet {
+        async fn resolve(&self, scope: &ChildScopeRef) -> Result<CascadeTarget, ResolveFailure> {
             if scope.scope_id != DESCENDANT_SCOPE {
                 return Err(ResolveFailure::Rejected);
             }
@@ -648,11 +760,10 @@ mod tests {
             let commitment_sig = sign_grant_set(&owner_identity(), &commitment)
                 .unwrap()
                 .to_compact();
-            Ok(SweepTarget {
+            Ok(CascadeTarget {
                 v: V,
                 current_read_epoch: 1,
                 owner_enc_pub: owner_enc().public(),
-                parent_node_seed: None,
                 pseudonym_signer: pseudonym,
                 override_seed: Zeroizing::new([0x71; SECRET_LEN]),
                 write_scope_seed: Zeroizing::new([0x72; SECRET_LEN]),
@@ -733,7 +844,6 @@ mod tests {
     /// grantee folder (empty subtree, converged, publishing OK), with the
     /// grant's blinded tag alongside it.
     fn delivery_for(entropy_seed: u64, recipient_enc: &X25519Secret) -> (PostedDelivery, [u8; 32]) {
-        let floors = InMemoryFloorStore::default();
         let net = FakeNet::new(Ok(()));
         let recorder = RecordingMailbox::default();
 
@@ -807,7 +917,6 @@ mod tests {
         };
         let outcome = block_on(create_read_grant(
             &mut entropy,
-            &floors,
             &net,
             &net,
             &recorder,
@@ -830,7 +939,6 @@ mod tests {
     fn run(
         entropy_seed: u64,
         subtree: &[ChildScopeRef],
-        floor: Option<([u8; 16], u64)>,
         net: FakeNet,
         parent_grants: &[GrantRow],
     ) -> (
@@ -838,10 +946,6 @@ mod tests {
         Vec<ResealedScopeRoot>,
         InMemoryMailboxHub,
     ) {
-        let floors = InMemoryFloorStore::default();
-        if let Some((scope, epoch)) = floor {
-            block_on(floors.raise_epoch_floor(&scope, epoch)).unwrap();
-        }
         let hub = InMemoryMailboxHub::default();
         let mailbox = hub.mailbox_for(&recipient_identity().to_sec1());
 
@@ -925,7 +1029,6 @@ mod tests {
             };
             block_on(create_read_grant(
                 &mut entropy,
-                &floors,
                 &net,
                 &net,
                 &mailbox,
@@ -941,7 +1044,7 @@ mod tests {
 
     #[test]
     fn converged_subtree_mints_publishes_and_posts_the_share_pointer() {
-        let (outcome, published, hub) = run(7, &[], None, FakeNet::new(Ok(())), &[]);
+        let (outcome, published, hub) = run(7, &[], FakeNet::new(Ok(())), &[]);
         let outcome = outcome.expect("grant creation succeeds over a converged subtree");
 
         // Two records, grantee first (register-first / never-orphan / dest-first).
@@ -1004,25 +1107,19 @@ mod tests {
     }
 
     #[test]
-    fn non_converged_subtree_is_rejected_fail_closed() {
-        // A descendant that lags (floor 2 > epoch 1) whose convergence publish
-        // loses the CAS race: the subtree cannot be proven converged, so the
-        // grant is refused — nothing minted, nothing posted.
-        let subtree = vec![ChildScopeRef::new(
-            DESCENDANT_SCOPE,
-            DESCENDANT_NAME.to_vec(),
-        )];
-        let (outcome, published, hub) = run(
-            7,
-            &subtree,
-            Some((DESCENDANT_SCOPE, 2)),
-            FakeNet::new(Err(ScopeRootPublishError::LostRace)),
-            &[],
-        );
+    fn a_lagging_interior_node_that_cannot_converge_refuses_the_grant() {
+        // An interior node of the parent scope lags (epoch 1 < PARENT_EPOCH) and
+        // its convergence publish loses the CAS race, so the subtree cannot be
+        // proven epoch-converged: the grant is refused — nothing minted, nothing
+        // posted.
+        let net = FakeNet::new(Ok(()))
+            .with_interior(INTERIOR_NODE, 1)
+            .node_publish(Err(ScopeRootPublishError::LostRace));
+        let (outcome, published, hub) = run(7, &[], net, &[]);
 
         match outcome {
             Err(CreateGrantError::SubtreeNotConverged { unconverged }) => {
-                assert_eq!(unconverged, vec![DESCENDANT_SCOPE]);
+                assert_eq!(unconverged, vec![INTERIOR_NODE]);
             }
             other => panic!("expected SubtreeNotConverged, got {other:?}"),
         }
@@ -1034,11 +1131,39 @@ mod tests {
     }
 
     #[test]
-    fn unresolvable_subtree_is_rejected_fail_closed() {
-        // A subtree scope root that will not resolve is a fail-closed convergence
-        // abort, never a silent partial share.
-        let subtree = vec![ChildScopeRef::new([0x99; 16], b"unresolvable".to_vec())];
-        let (outcome, published, _hub) = run(7, &subtree, None, FakeNet::new(Ok(())), &[]);
+    fn the_same_lagging_node_lets_the_grant_through_once_it_converges() {
+        // The negative direction of the same gate: identical subtree, and the
+        // node's convergence publish now lands, so the grant proceeds.
+        let net = FakeNet::new(Ok(())).with_interior(INTERIOR_NODE, 1);
+        let publishes = Rc::clone(&net.node_publishes);
+        let (outcome, published, _hub) = run(7, &[], net, &[]);
+
+        outcome.expect("a converged subtree grants");
+        assert_eq!(
+            *publishes.borrow(),
+            vec![INTERIOR_NODE],
+            "the lagging node was advanced before the mint"
+        );
+        assert_eq!(published.len(), 2, "grantee root and parent index");
+    }
+
+    #[test]
+    fn an_already_converged_subtree_needs_no_convergence_publish() {
+        let net = FakeNet::new(Ok(())).with_interior(INTERIOR_NODE, PARENT_EPOCH);
+        let publishes = Rc::clone(&net.node_publishes);
+        let (outcome, _published, _hub) = run(7, &[], net, &[]);
+        outcome.expect("grant creation succeeds");
+        assert!(publishes.borrow().is_empty(), "nothing lagged");
+    }
+
+    #[test]
+    fn an_unresolvable_interior_node_is_rejected_fail_closed() {
+        // A node the sweep cannot resolve is a fail-closed convergence abort,
+        // never a silent partial share.
+        let net = FakeNet::new(Ok(()))
+            .with_interior(INTERIOR_NODE, 1)
+            .unresolvable(INTERIOR_NODE);
+        let (outcome, published, _hub) = run(7, &[], net, &[]);
         assert_eq!(outcome.unwrap_err().check(), "converge-failed");
         assert!(published.is_empty());
     }
@@ -1053,7 +1178,6 @@ mod tests {
         let (outcome, published, hub) = run(
             7,
             &[],
-            None,
             FakeNet::new_fail_after(1, ScopeRootPublishError::LostRace),
             &[],
         );
@@ -1087,7 +1211,6 @@ mod tests {
         let (outcome, published, hub) = run(
             7,
             &subtree,
-            None,
             FakeNet::new_fail_after(1, ScopeRootPublishError::LostRace),
             &[],
         );
@@ -1120,8 +1243,8 @@ mod tests {
             DESCENDANT_SCOPE,
             DESCENDANT_NAME.to_vec(),
         )];
-        let (a_outcome, a_pub, _) = run(42, &subtree, None, FakeNet::new(Ok(())), &[]);
-        let (b_outcome, b_pub, _) = run(42, &subtree, None, FakeNet::new(Ok(())), &[]);
+        let (a_outcome, a_pub, _) = run(42, &subtree, FakeNet::new(Ok(())), &[]);
+        let (b_outcome, b_pub, _) = run(42, &subtree, FakeNet::new(Ok(())), &[]);
         assert_eq!(a_outcome.unwrap(), b_outcome.unwrap());
         assert_eq!(a_pub, b_pub, "same seed → byte-identical published records");
     }
@@ -1174,7 +1297,7 @@ mod tests {
             DESCENDANT_SCOPE,
             DESCENDANT_NAME.to_vec(),
         )];
-        let (outcome, published, _hub) = run(7, &subtree, None, FakeNet::new(Ok(())), &[]);
+        let (outcome, published, _hub) = run(7, &subtree, FakeNet::new(Ok(())), &[]);
         outcome.expect("grant creation succeeds over a converged subtree");
 
         // The grantee opens its grant blob to recover the fresh override seed.
@@ -1256,7 +1379,7 @@ mod tests {
             DESCENDANT_SCOPE,
             DESCENDANT_NAME.to_vec(),
         )];
-        let (outcome, published, _hub) = run(7, &subtree, None, FakeNet::new(Ok(())), &[]);
+        let (outcome, published, _hub) = run(7, &subtree, FakeNet::new(Ok(())), &[]);
         outcome.expect("grant creation succeeds over a converged subtree");
 
         let descendant_record = published
@@ -1297,7 +1420,7 @@ mod tests {
         .expect("a contributory recipient key");
         row.ledger_entry.recipient_enc_pk = attacker.public().to_bytes();
 
-        let (outcome, published, _hub) = run(7, &[], None, FakeNet::new(Ok(())), &[row]);
+        let (outcome, published, _hub) = run(7, &[], FakeNet::new(Ok(())), &[row]);
 
         assert_eq!(
             outcome.expect_err("the parent re-seal refuses the swapped key"),

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -44,9 +44,10 @@ use crate::grants::child_index::{canonicalize, insert_child, remove_child};
 use crate::grants::mint_grant_row;
 use crate::mailbox::post_sealed;
 use crate::rotation::{
-    CascadeResealResolver, CommittedSet, ResealError, ResealSeeds, ResealedScopeRoot,
+    CascadeResealResolver, CommittedSet, NodeRef, ResealError, ResealSeeds, ResealedScopeRoot,
     ResolveFailure, ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, SweepError,
-    SweepPublisher, SweepResolver, WriteHistory, derive_write_name, reseal_scope_root, sweep_pass,
+    SweepPublisher, SweepResolver, WriteHistory, converge_subtree, derive_write_name,
+    reseal_scope_root,
 };
 use crate::seams::{Mailbox, SeamError};
 use cipherbox_core::hex::lower as hex_lower;
@@ -164,7 +165,8 @@ pub enum CreateGrantError {
     /// dropped on a lost CAS race, so the grant is refused rather than minted
     /// over a possibly-lagging subtree.
     SubtreeNotConverged {
-        /// The interior nodes left unproven this pass.
+        /// The interior nodes left unproven this pass — dropped on a lost CAS
+        /// race, or unreadable at the epoch their record claims.
         unconverged: Vec<[u8; 16]>,
     },
     /// The recipient encryption key is non-contributory (degenerate ECDH).
@@ -271,29 +273,41 @@ where
     P: ScopeRootPublisher + SweepPublisher,
     M: Mailbox,
 {
-    // 1) Convergence gate — sweep the scope the granted folder still lives in,
-    // so no interior node under it lags that scope's epoch. A dropped lost race
-    // means convergence is unproven: refuse rather than share a possibly-lagging
-    // subtree (CONTEXT.md "Epoch-converged").
-    let parent_scope =
-        ChildScopeRef::new(parent.identity.scope_id, parent.identity.ipns_name.to_vec());
-    let swept = sweep_pass(resolver, publisher, &parent_scope)
-        .await
-        .map_err(CreateGrantError::Converge)?;
-    if !swept.dropped_lost_race.is_empty() {
-        return Err(CreateGrantError::SubtreeNotConverged {
-            unconverged: swept.dropped_lost_race,
-        });
-    }
-
-    // 2) Derive the scope root's ipnsName from the folder's write material — the
+    // 1) Derive the scope root's ipnsName from the folder's write material — the
     // sole gated identity edge (blueprint/engine.md: the name binds the record
     // via the Ed25519 key it encodes). The tag and commitment below bind this
     // name, and the recipient re-derives the same name from the record it
     // resolves; deriving here (never trusting a passed name) keeps that binding
-    // fail-closed at the mint.
+    // fail-closed at the mint. A read grant cuts no write scope, so this is also
+    // the name the folder already answers at inside the parent scope.
     let ipns_name = derive_write_name(grantee.write_scope_seed, &grantee.scope_id);
     let name_bytes = ipns_name.as_str().as_bytes();
+
+    // 2) Convergence gate — converge the granted folder's own subtree inside the
+    // scope it still lives in, so no interior node the grantee will read lags
+    // that scope's epoch. A dropped lost race means convergence is unproven:
+    // refuse rather than share a possibly-lagging subtree (CONTEXT.md
+    // "Epoch-converged").
+    let swept = converge_subtree(
+        resolver,
+        publisher,
+        &ChildScopeRef::new(parent.identity.scope_id, parent.identity.ipns_name.to_vec()),
+        &NodeRef {
+            node_id: grantee.scope_id,
+            ipns_name: name_bytes.to_vec(),
+        },
+    )
+    .await
+    .map_err(CreateGrantError::Converge)?;
+    // A node the pass could not read is as unproven as one whose convergence
+    // publish lost the race: either way the grantee could descend into a node
+    // still sealed at an epoch its fresh seed does not reach.
+    if !swept.dropped_lost_race.is_empty() || !swept.unreachable.is_empty() {
+        let mut unconverged = swept.dropped_lost_race;
+        unconverged.extend(swept.unreachable);
+        unconverged.sort_unstable();
+        return Err(CreateGrantError::SubtreeNotConverged { unconverged });
+    }
 
     // 3) Build the committed set for the recipient — the same pairwise mint an
     // invite link goes through, keyed off the name derived above.
@@ -544,8 +558,8 @@ mod tests {
     use crate::testkit::fakes::InMemoryMailboxHub;
     use crate::testkit::{SeededEntropy, block_on};
     use cipherbox_core::seal::{
-        AadContext, AscentLink, ReadBody, STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB,
-        open_ascent_link, open_grant_blob,
+        AadContext, AscentLink, ChildRef, NodeKind, ReadBody, STRUCT_TAG_ASCENT_LINK,
+        STRUCT_TAG_GRANT_BLOB, open_ascent_link, open_grant_blob,
     };
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
     use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -567,7 +581,11 @@ mod tests {
     const PARENT_EPOCH: u64 = 3;
     /// An interior node of the parent scope, inside the granted folder.
     const INTERIOR_NODE: [u8; 16] = [0xa1; 16];
-    const INTERIOR_NAME: &[u8] = b"interior-node-name";
+
+    /// One interior node's simulated name inside the parent scope.
+    fn interior_name(node_id: [u8; 16]) -> Vec<u8> {
+        format!("interior-{:02x}", node_id[0]).into_bytes()
+    }
 
     /// One interior node of the parent scope: its id and its published epoch.
     type InteriorNodeState = ([u8; 16], u64);
@@ -619,13 +637,17 @@ mod tests {
         publish_result: Result<(), ScopeRootPublishError>,
         publish_calls: Rc<RefCell<usize>>,
         fail_after: Option<(usize, ScopeRootPublishError)>,
-        /// The parent scope's interior nodes: id → published read epoch.
+        /// Interior nodes **inside** the granted folder: id → published epoch.
         interior: Rc<RefCell<Vec<InteriorNodeState>>>,
+        /// Interior nodes of the same scope but **outside** the granted folder.
+        outside: Rc<RefCell<Vec<InteriorNodeState>>>,
         /// What an interior-node re-seal publish returns.
         node_publish_result: Result<(), ScopeRootPublishError>,
         node_publishes: Rc<RefCell<Vec<[u8; 16]>>>,
         /// A node the sweep cannot resolve at all.
         unresolvable: Option<[u8; 16]>,
+        /// A node the scope's ratchet cannot open.
+        unreadable: Option<[u8; 16]>,
     }
 
     impl FakeNet {
@@ -636,9 +658,11 @@ mod tests {
                 publish_calls: Rc::new(RefCell::new(0)),
                 fail_after: None,
                 interior: Rc::new(RefCell::new(Vec::new())),
+                outside: Rc::new(RefCell::new(Vec::new())),
                 node_publish_result: Ok(()),
                 node_publishes: Rc::new(RefCell::new(Vec::new())),
                 unresolvable: None,
+                unreadable: None,
             }
         }
 
@@ -652,9 +676,16 @@ mod tests {
             }
         }
 
-        /// Put one interior node in the parent scope at `epoch`.
+        /// Put one interior node inside the granted folder at `epoch`.
         fn with_interior(self, node_id: [u8; 16], epoch: u64) -> Self {
             self.interior.borrow_mut().push((node_id, epoch));
+            self
+        }
+
+        /// Put one interior node in the same scope but outside the granted
+        /// folder, at `epoch`.
+        fn with_outside(self, node_id: [u8; 16], epoch: u64) -> Self {
+            self.outside.borrow_mut().push((node_id, epoch));
             self
         }
 
@@ -667,6 +698,12 @@ mod tests {
             self.unresolvable = Some(node_id);
             self
         }
+
+        /// A node whose body no seed on the scope's ratchet opens.
+        fn unreadable(mut self, node_id: [u8; 16]) -> Self {
+            self.unreadable = Some(node_id);
+            self
+        }
     }
 
     impl SweepResolver for FakeNet {
@@ -677,17 +714,17 @@ mod tests {
             if scope.scope_id != PARENT_SCOPE {
                 return Err(SweepResolveFailure::Rejected);
             }
+            let mut children = vec![NodeRef {
+                node_id: GRANTEE_SCOPE,
+                ipns_name: grantee_name(),
+            }];
+            children.extend(self.outside.borrow().iter().map(|(node_id, _)| NodeRef {
+                node_id: *node_id,
+                ipns_name: interior_name(*node_id),
+            }));
             Ok(SweptScope {
                 current_read_epoch: PARENT_EPOCH,
-                children: self
-                    .interior
-                    .borrow()
-                    .iter()
-                    .map(|(node_id, _)| NodeRef {
-                        node_id: *node_id,
-                        ipns_name: INTERIOR_NAME.to_vec(),
-                    })
-                    .collect(),
+                children,
                 direct_child_scope_index: Vec::new(),
             })
         }
@@ -699,23 +736,54 @@ mod tests {
             Ok(None)
         }
 
-        async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+        async fn resolve_child(
+            &self,
+            _scope: &ChildScopeRef,
+            child: &NodeRef,
+        ) -> Result<SweptChild, SweepResolveFailure> {
             if self.unresolvable == Some(child.node_id) {
                 return Err(SweepResolveFailure::Unavailable);
             }
-            let epoch = self
-                .interior
-                .borrow()
-                .iter()
-                .find(|(node_id, _)| *node_id == child.node_id)
-                .map(|(_, epoch)| *epoch)
-                .ok_or(SweepResolveFailure::Unavailable)?;
+            if self.unreadable == Some(child.node_id) {
+                return Err(SweepResolveFailure::Unreadable);
+            }
+            // The granted folder is itself an interior node of the parent scope
+            // until the mint publishes its scope root; its body names the nodes
+            // the convergence gate must reach.
+            let (epoch, children) = if child.node_id == GRANTEE_SCOPE {
+                (
+                    PARENT_EPOCH,
+                    self.interior
+                        .borrow()
+                        .iter()
+                        .map(|(node_id, _)| ChildRef {
+                            id: *node_id,
+                            name: "n".into(),
+                            ipns_name: interior_name(*node_id),
+                            kind: NodeKind::Folder,
+                            link_counter: 1,
+                            unknown: PreservedFields::new(),
+                        })
+                        .collect(),
+                )
+            } else {
+                let epoch = self
+                    .interior
+                    .borrow()
+                    .iter()
+                    .chain(self.outside.borrow().iter())
+                    .find(|(node_id, _)| *node_id == child.node_id)
+                    .map(|(_, epoch)| *epoch)
+                    .ok_or(SweepResolveFailure::Unavailable)?;
+                (epoch, Vec::new())
+            };
             Ok(SweptChild::Interior(SweptNode {
                 current_read_epoch: epoch,
+                sequence: 1,
                 read_body: ReadBody::Folder {
                     created_at: 0,
                     modified_at: 0,
-                    children: Vec::new(),
+                    children,
                     unknown: PreservedFields::new(),
                 },
                 carried_unknown: PreservedFields::new(),
@@ -725,10 +793,19 @@ mod tests {
     }
 
     impl SweepPublisher for FakeNet {
-        async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+        async fn publish_node(
+            &self,
+            _scope: &ChildScopeRef,
+            node: &LaggingNode<'_>,
+        ) -> Result<(), ScopeRootPublishError> {
             self.node_publishes.borrow_mut().push(node.node_id);
             self.node_publish_result.clone()?;
-            for (node_id, epoch) in self.interior.borrow_mut().iter_mut() {
+            for (node_id, epoch) in self
+                .interior
+                .borrow_mut()
+                .iter_mut()
+                .chain(self.outside.borrow_mut().iter_mut())
+            {
                 if *node_id == node.node_id {
                     *epoch = node.read_epoch;
                 }
@@ -1154,6 +1231,39 @@ mod tests {
         let (outcome, _published, _hub) = run(7, &[], net, &[]);
         outcome.expect("grant creation succeeds");
         assert!(publishes.borrow().is_empty(), "nothing lagged");
+    }
+
+    #[test]
+    fn a_node_lagging_outside_the_granted_folder_does_not_block_the_grant() {
+        // The gate owes the epoch-converged guarantee over the folder being
+        // shared, not over every sibling in the scope it happens to sit in.
+        const OUTSIDE_NODE: [u8; 16] = [0xb2; 16];
+        let net = FakeNet::new(Ok(())).with_outside(OUTSIDE_NODE, 1);
+        let publishes = Rc::clone(&net.node_publishes);
+        let (outcome, _published, _hub) = run(7, &[], net, &[]);
+
+        outcome.expect("a lagging sibling is none of this grant's business");
+        assert!(
+            publishes.borrow().is_empty(),
+            "the sibling subtree was never walked, let alone re-sealed"
+        );
+    }
+
+    #[test]
+    fn an_unreachable_node_in_the_granted_folder_refuses_the_grant() {
+        // A node this device cannot read is as unproven as one whose publish
+        // lost the race: the grantee could descend into it.
+        let net = FakeNet::new(Ok(()))
+            .with_interior(INTERIOR_NODE, 1)
+            .unreadable(INTERIOR_NODE);
+        let (outcome, published, _hub) = run(7, &[], net, &[]);
+        match outcome {
+            Err(CreateGrantError::SubtreeNotConverged { unconverged }) => {
+                assert_eq!(unconverged, vec![INTERIOR_NODE]);
+            }
+            other => panic!("expected SubtreeNotConverged, got {other:?}"),
+        }
+        assert!(published.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/grants/create.rs
+++ b/crates/engine/src/grants/create.rs
@@ -1209,7 +1209,7 @@ mod tests {
 
     #[test]
     fn the_same_lagging_node_lets_the_grant_through_once_it_converges() {
-        // The negative direction of the same gate: identical subtree, and the
+        // The passing direction of the same gate: identical subtree, and the
         // node's convergence publish now lands, so the grant proceeds.
         let net = FakeNet::new(Ok(())).with_interior(INTERIOR_NODE, 1);
         let publishes = Rc::clone(&net.node_publishes);

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -21,15 +21,16 @@ use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildScopeRef, Envelope, GrantLedgerEntry, GrantSection, GrantSetCommitment,
     GrantSetEntry, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY,
-    WriteBody, decode_write_body, open_owner_blob, sign_grant_set, unseal,
+    SignedSealed, WriteBody, decode_write_body, has_grant_section, open_owner_blob, open_read_body,
+    sign_grant_set, unseal,
 };
-use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier};
+use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier, SIGNATURE_LEN as ECDSA_SIG_LEN};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 use zeroize::Zeroizing;
 
-use super::adopter::{RootAdopter, open_write_scope_seed_at};
+use super::adopter::{RootAdopter, assemble_head_envelope, open_write_scope_seed_at};
 use super::author::{
     AuthorError, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
     author_scope_root_with_section,
@@ -50,11 +51,12 @@ use crate::net::fanout_get_verify;
 use crate::net::resolve::Adopter;
 use crate::profile::SyncTimingProfile;
 use crate::rotation::{
-    CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, PrevEpochSeed,
-    RepointChannel, RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot, ResolveFailure,
-    ResumedWriteWave, ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher, WriteHistory,
-    WritePublishError, WriteScopeNode, WriteSubtreeResolver, WriteWavePublisher, derive_write_name,
-    reseal_scope_root,
+    CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, LaggingNode, NodeRef,
+    PrevEpochSeed, RepointChannel, RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot,
+    ResolveFailure, ResumedWriteWave, ScopeRootIdentity, ScopeRootPublishError, ScopeRootPublisher,
+    SweepPublisher, SweepResolveFailure, SweepResolver, SweptChild, SweptNode, SweptScope,
+    WriteHistory, WritePublishError, WriteScopeNode, WriteSubtreeResolver, WriteWavePublisher,
+    derive_write_name, reseal_scope_root, seed_at_epoch,
 };
 use crate::seams::{CredentialStore, FloorStore, Http, RecordTransport, Scheduler};
 use crate::session::SessionIdentity;
@@ -112,9 +114,17 @@ pub struct OwnerRotationNet<'a, T, H: Http, C: CredentialStore, F, Sch, E> {
     pub keys: OwnerRotationKeys<'a>,
     /// The ancestor seeds every interior scope root's gated read needs.
     pub ancestry: RotationAncestry,
+    /// Derives the scope pointer's name for the sweep's consult (owner-only
+    /// material, never published).
+    pub owner_pointer_seed: &'a [u8; SECRET_LEN],
+    /// The pointer-payload envelope version a consulted re-point is read under.
+    pub payload_version: u64,
     /// The record a re-key is about to replace, handed from the resolve that
     /// gated it to the publish (see [`GatedRoots`]). One rotation pass per net.
     pub gated: GatedRoots,
+    /// The scope the sweep is walking, held from the scope-root read that
+    /// proved it (see [`SweptScopeState`]). One sweep pass per net.
+    pub swept: SweptScopeState,
 }
 
 /// The one scope root this pass gated and has not yet republished.
@@ -359,6 +369,38 @@ fn nonce<E: Entropy>(entropy: &RefCell<E>) -> Result<[u8; 24], ScopeRootPublishE
     Ok(nonce)
 }
 
+/// A rotation root read's verdict, carrying ADR 0003 D2's below-floor split: a
+/// scope root under its own read-epoch floor is a **superseded name**, not a
+/// trust rejection — rotations publish before they raise the floor, so the
+/// condition cannot mean the root lags. Only the sweep routes that verdict
+/// (through the pointer consult); every other arm folds it back into a
+/// fail-closed rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootGateVerdict {
+    Rejected,
+    Unavailable,
+    Superseded,
+}
+
+impl From<RootGateVerdict> for ResolveFailure {
+    fn from(verdict: RootGateVerdict) -> Self {
+        match verdict {
+            RootGateVerdict::Unavailable => Self::Unavailable,
+            RootGateVerdict::Rejected | RootGateVerdict::Superseded => Self::Rejected,
+        }
+    }
+}
+
+impl From<RootGateVerdict> for SweepResolveFailure {
+    fn from(verdict: RootGateVerdict) -> Self {
+        match verdict {
+            RootGateVerdict::Unavailable => Self::Unavailable,
+            RootGateVerdict::Rejected => Self::Rejected,
+            RootGateVerdict::Superseded => Self::Superseded,
+        }
+    }
+}
+
 /// The rejection arm of a rotation's gated read, recovered at the durable
 /// sequence floor.
 ///
@@ -373,19 +415,19 @@ async fn reread_at_floor<H: Http, F: FloorStore>(
     name: &IpnsName,
     record_bytes: &[u8],
     reason: &RejectionReason,
-) -> Result<GatedScopeRoot, ResolveFailure> {
+) -> Result<GatedScopeRoot, RootGateVerdict> {
     if !matches!(
         reason,
         RejectionReason::SequenceNotNewer { floor, sequence } if sequence == floor
     ) {
-        return Err(ResolveFailure::Rejected);
+        return Err(RootGateVerdict::Rejected);
     }
     let recovered = adopter
         .recover_own_scope_root(name, record_bytes)
         .await
-        .map_err(|_| ResolveFailure::Unavailable)?
+        .map_err(|_| RootGateVerdict::Unavailable)?
         // The recovery is fail-open; the rotation keeps the gate's own verdict.
-        .ok_or(ResolveFailure::Rejected)?;
+        .ok_or(RootGateVerdict::Rejected)?;
     Ok(GatedScopeRoot {
         envelope: recovered.envelope,
         section: recovered.grant_section,
@@ -402,16 +444,23 @@ async fn gated_scope_root<H: Http, F: FloorStore>(
     adopter: &RootAdopter<'_, H, F>,
     name: &IpnsName,
     record_bytes: &[u8],
-) -> Result<GatedScopeRoot, ResolveFailure> {
+) -> Result<GatedScopeRoot, RootGateVerdict> {
     match adopter.adopt_root(name, record_bytes).await {
         Ok((candidate, outcome)) => Ok(GatedScopeRoot {
             envelope: candidate.envelope,
             section: candidate.grant_section,
             read_body: outcome.adopted.read_body,
-            read_scope_seed: outcome.read_scope_seed.ok_or(ResolveFailure::Unavailable)?,
+            read_scope_seed: outcome
+                .read_scope_seed
+                .ok_or(RootGateVerdict::Unavailable)?,
             write_scope_seed: outcome.write_scope_seed,
         }),
-        Err(GateError::Seam(_)) => Err(ResolveFailure::Unavailable),
+        Err(GateError::Seam(_)) => Err(RootGateVerdict::Unavailable),
+        Err(GateError::Rejected(rejection))
+            if matches!(rejection.reason, RejectionReason::EpochBelowFloor { .. }) =>
+        {
+            Err(RootGateVerdict::Superseded)
+        }
         Err(GateError::Rejected(rejection)) => {
             reread_at_floor(adopter, name, record_bytes, &rejection.reason).await
         }
@@ -433,9 +482,9 @@ where
         &self,
         scope_id: [u8; 16],
         name: &IpnsName,
-    ) -> Result<GatedScopeRoot, ResolveFailure> {
+    ) -> Result<GatedScopeRoot, RootGateVerdict> {
         let Some((_, record_bytes)) = fanout_get_verify(self.transport, name).await else {
-            return Err(ResolveFailure::Unavailable);
+            return Err(RootGateVerdict::Unavailable);
         };
         let mut adopter = RootAdopter::new(
             self.gateway,
@@ -490,7 +539,10 @@ where
         scope: &ChildScopeRef,
     ) -> Result<GatedWritePlane, ResolveFailure> {
         let name = scope_name(&scope.ipns_name)?;
-        let root = self.gated_root(scope.scope_id, &name).await?;
+        let root = self
+            .gated_root(scope.scope_id, &name)
+            .await
+            .map_err(ResolveFailure::from)?;
         let (write_body, write_epoch) = self.write_body(&root, scope.scope_id).await?;
         self.ancestry.record(
             scope.scope_id,
@@ -636,7 +688,7 @@ where
             None => RepublishBase::from(
                 self.gated_root(record.scope_id, &name)
                     .await
-                    .map_err(publish_verdict)?,
+                    .map_err(|verdict| publish_verdict(verdict.into()))?,
             ),
         };
         self.check_publishable(record).await?;
@@ -699,6 +751,419 @@ where
             // re-publishing is idempotent-in-sequence.
             PublishOutcome::Unconfirmed { .. } => Err(ScopeRootPublishError::NotPublished),
         }
+    }
+}
+
+/// The scope a sweep pass is walking, held from the scope-root read that proved
+/// it to the node reads and publishes that ride on it.
+///
+/// An interior node carries no seed of its own: its read key derives from the
+/// scope's, and the epoch its record was sealed at derives from the scope's
+/// history-link ratchet. Pinning that one gated read is what lets the pass read
+/// and re-seal every node under material a single adoption proved, rather than
+/// re-gating the root per node.
+#[derive(Default)]
+pub struct SweptScopeState {
+    inner: RefCell<Option<SweptScopeSource>>,
+}
+
+/// Everything the sweep's node reads and publishes need from the scope root.
+/// Terminal owner of the two seeds: they zeroize when the state is replaced or
+/// dropped.
+#[derive(Clone)]
+struct SweptScopeSource {
+    scope_id: [u8; 16],
+    name: IpnsName,
+    v: u64,
+    read_epoch: u64,
+    write_epoch: u64,
+    read_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
+    write_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
+    parent_node_seed: Option<Zeroizing<[u8; SECRET_LEN]>>,
+    commitment: GrantSetCommitment,
+    commitment_sig: [u8; ECDSA_SIG_LEN],
+    history_links: Vec<SignedSealed>,
+    grant_ledger: Vec<GrantLedgerEntry>,
+    write_history_link: Vec<u8>,
+}
+
+impl SweptScopeState {
+    fn park(&self, source: SweptScopeSource) {
+        *self.inner.borrow_mut() = Some(source);
+    }
+
+    /// The parked scope, cloned so no borrow is held across a suspend point.
+    fn source(&self) -> Option<SweptScopeSource> {
+        self.inner.borrow().clone()
+    }
+}
+
+/// Carry a re-seal refusal into the sweep's publish arm on rule 6's axis: every
+/// variant but entropy is this build's own fail-closed verdict on material the
+/// pass already gated, so re-sealing the same inputs reaches it again.
+fn reseal_publish_verdict(error: ResealError) -> ScopeRootPublishError {
+    match error {
+        ResealError::Entropy(_) => ScopeRootPublishError::NotPublished,
+        _ => ScopeRootPublishError::Rejected,
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport,
+    F: FloorStore,
+{
+    /// The parked scope. A node read or publish issued before the scope root was
+    /// gated has no material to run under — an internal ordering break, and
+    /// fail-closed rather than a re-gate under an unproven label.
+    fn swept_scope(&self) -> Result<SweptScopeSource, SweepResolveFailure> {
+        self.swept.source().ok_or(SweepResolveFailure::Rejected)
+    }
+
+    /// Prove a walked child really is a descendant scope root, and report the
+    /// name it gated current at.
+    ///
+    /// The read body names children, not scope boundaries, so a child carrying a
+    /// grant section is only a scope root if its **owner-signed** commitment
+    /// binds this name and its ascent link opens under the seed this scope
+    /// derives for it. Anything less would let a committed writer plant a marker
+    /// that carves a node out of the sweep.
+    async fn gated_child_scope_root(
+        &self,
+        source: &SweptScopeSource,
+        child: &NodeRef,
+        name: &IpnsName,
+        record_bytes: &[u8],
+    ) -> Result<SweptChild, SweepResolveFailure> {
+        let parent_node_seed = kdf::node_seed(&source.read_scope_seed, &child.node_id);
+        let adopter = RootAdopter::new(
+            self.gateway,
+            self.http,
+            self.floors,
+            self.keys.enc_secret,
+            self.keys.identity,
+            child.node_id,
+        )
+        .under_parent_node_seed(Zeroizing::new(*parent_node_seed.as_bytes()));
+        // The gate binds `envelope.scope` to the label above; a scope root's node
+        // id is its scope id, and only this binds it.
+        let gated = gated_scope_root(&adopter, name, record_bytes)
+            .await
+            .map_err(SweepResolveFailure::from)?;
+        if gated.envelope.id != child.node_id {
+            return Err(SweepResolveFailure::Rejected);
+        }
+        Ok(SweptChild::ScopeRoot(ChildScopeRef::new(
+            child.node_id,
+            name.as_str().as_bytes().to_vec(),
+        )))
+    }
+
+    /// Open one interior node's record at the epoch it was sealed at.
+    ///
+    /// This is the one read that deliberately does **not** run the scope's
+    /// read-epoch floor: a lagging interior node is below that floor by
+    /// construction, and it is exactly the record the sweep exists to advance.
+    /// It is safe where admitting a below-floor *scope root* is not, because an
+    /// interior record carries no seed, no grant blob and no commitment — every
+    /// key here comes from the scope root this pass already gated, so nothing
+    /// the record claims can hand a revoked reader anything. The per-name
+    /// sequence floor still applies, so a replayed older record is refused.
+    async fn interior_node(
+        &self,
+        source: &SweptScopeSource,
+        child: &NodeRef,
+        name: &IpnsName,
+        sequence: u64,
+        envelope: Envelope,
+    ) -> Result<SweptChild, SweepResolveFailure> {
+        if envelope.v != ENVELOPE_V
+            || envelope.id != child.node_id
+            || envelope.scope != source.scope_id
+        {
+            return Err(SweepResolveFailure::Rejected);
+        }
+        let floor = floor::sequence_floor(self.floors, name.as_str().as_bytes())
+            .await
+            .map_err(|_| SweepResolveFailure::Unavailable)?
+            .unwrap_or(0);
+        if sequence < floor {
+            return Err(SweepResolveFailure::Rejected);
+        }
+        // A node above the scope root's epoch means this pass's view of the root
+        // is stale, not that the node is forged: re-read it next pass.
+        if envelope.epoch > source.read_epoch {
+            return Err(SweepResolveFailure::Unavailable);
+        }
+        let seed = seed_at_epoch(
+            envelope.v,
+            source.scope_id,
+            &source.read_scope_seed,
+            source.read_epoch,
+            &source.history_links,
+            envelope.epoch,
+        )
+        .ok_or(SweepResolveFailure::Rejected)?;
+        let read_key = read_key_for(&seed, &envelope.id);
+        let read_body =
+            open_read_body(&envelope, &read_key).map_err(|_| SweepResolveFailure::Rejected)?;
+        Ok(SweptChild::Interior(SweptNode {
+            current_read_epoch: envelope.epoch,
+            read_body,
+            carried_unknown: envelope.unknown,
+            carried_epoch_tag_unknown: envelope.epoch_tag_unknown,
+        }))
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> SweepResolver
+    for OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport,
+    F: FloorStore,
+{
+    async fn resolve_scope(
+        &self,
+        scope: &ChildScopeRef,
+    ) -> Result<SweptScope, SweepResolveFailure> {
+        let name = scope_name(&scope.ipns_name).map_err(SweepResolveFailure::from)?;
+        let root = self
+            .gated_root(scope.scope_id, &name)
+            .await
+            .map_err(SweepResolveFailure::from)?;
+        if root.envelope.v != ENVELOPE_V {
+            return Err(SweepResolveFailure::Rejected);
+        }
+        let (write_body, write_epoch) = self
+            .write_body(&root, scope.scope_id)
+            .await
+            .map_err(SweepResolveFailure::from)?;
+        let write_scope_seed = root
+            .write_scope_seed
+            .clone()
+            .ok_or(SweepResolveFailure::Unavailable)?;
+        let children = read_body_children(&root.read_body);
+        self.swept.park(SweptScopeSource {
+            scope_id: scope.scope_id,
+            name: name.clone(),
+            v: root.envelope.v,
+            read_epoch: root.envelope.epoch,
+            write_epoch,
+            read_scope_seed: root.read_scope_seed.clone(),
+            write_scope_seed: write_scope_seed.clone(),
+            parent_node_seed: self.ancestry.parent_node_seed(&scope.scope_id),
+            commitment: root.section.commitment.clone(),
+            commitment_sig: root.section.commitment_sig,
+            history_links: root.section.history_links.clone(),
+            grant_ledger: write_body.grant_ledger,
+            write_history_link: write_body.write_history_link,
+        });
+        // The index repair republishes this root, and runs off this read rather
+        // than gating the same record twice ([`GatedRoots`]).
+        self.gated.park(
+            name,
+            RepublishBase {
+                read_body: root.read_body,
+                unknown: root.envelope.unknown,
+                epoch_tag_unknown: root.envelope.epoch_tag_unknown,
+                write_scope_seed: Some(write_scope_seed),
+            },
+        );
+        Ok(SweptScope {
+            current_read_epoch: root.envelope.epoch,
+            children,
+            direct_child_scope_index: write_body.direct_child_scope_index,
+        })
+    }
+
+    async fn consult_pointer(
+        &self,
+        scope_id: &[u8; 16],
+    ) -> Result<Option<Vec<u8>>, SweepResolveFailure> {
+        let pointer = scope_pointer_name(self.owner_pointer_seed, scope_id);
+        let block = match RecordPointerFetch::new(self.transport)
+            .fetch(&pointer)
+            .await
+        {
+            Ok(Some(block)) => block,
+            // No pointer record: this scope has never been re-pointed, so there
+            // is no fresher name to re-resolve at.
+            Ok(None) => return Ok(None),
+            Err(_) => return Err(SweepResolveFailure::Unavailable),
+        };
+        let pointer_read_key = self.keys.scope_keys.pointer_read_key(scope_id);
+        let repoint = open_repoint(
+            &pointer_read_key,
+            self.payload_version,
+            scope_id,
+            self.keys.identity,
+            &block,
+        )
+        .map_err(|_| SweepResolveFailure::Rejected)?;
+        Ok(Some(repoint.current_root.as_str().as_bytes().to_vec()))
+    }
+
+    async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+        let source = self.swept_scope()?;
+        let name = scope_name(&child.ipns_name).map_err(SweepResolveFailure::from)?;
+        let Some((_, record_bytes)) = fanout_get_verify(self.transport, &name).await else {
+            return Err(SweepResolveFailure::Unavailable);
+        };
+        let (sequence, envelope) =
+            assemble_head_envelope(self.gateway, self.http, &name, &record_bytes, None)
+                .await
+                .map_err(|error| match error {
+                    GateError::Seam(_) => SweepResolveFailure::Unavailable,
+                    GateError::Rejected(_) => SweepResolveFailure::Rejected,
+                })?;
+        if has_grant_section(&envelope) {
+            return self
+                .gated_child_scope_root(&source, child, &name, &record_bytes)
+                .await;
+        }
+        self.interior_node(&source, child, &name, sequence, envelope)
+            .await
+    }
+}
+
+impl<T, H: Http, C: CredentialStore, F, Sch, E> SweepPublisher
+    for OwnerRotationNet<'_, T, H, C, F, Sch, E>
+where
+    T: RecordTransport + Clone + 'static,
+    F: FloorStore,
+    Sch: Scheduler + Clone + 'static,
+    E: Entropy,
+{
+    async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+        let source = self
+            .swept_scope()
+            .map_err(|_| ScopeRootPublishError::Rejected)?;
+        let name = scope_name(node.ipns_name).map_err(publish_verdict)?;
+        // Release-active mirror of the gate reject this build would itself make
+        // on the record about to be signed: a record cannot be unpublished
+        // (security rule 8).
+        let read_floor = floor::read_epoch_floor(self.floors, &source.scope_id)
+            .await
+            .map_err(|_| ScopeRootPublishError::NotPublished)?
+            .unwrap_or(0);
+        if node.read_epoch < read_floor {
+            return Err(ScopeRootPublishError::Rejected);
+        }
+        let read_key = read_key_for(&source.read_scope_seed, &node.node_id);
+        let nonce = nonce(self.entropy)?;
+        let head = author_child_envelope(EnvelopeAuthoring {
+            node_id: node.node_id,
+            scope_id: source.scope_id,
+            epoch: node.read_epoch,
+            read_key: &read_key,
+            nonce: &nonce,
+            body: node.read_body,
+            carried_unknown: node.carried_unknown.clone(),
+            carried_epoch_tag_unknown: node.carried_epoch_tag_unknown.clone(),
+        })
+        .map_err(author_verdict)?;
+
+        let binding = HeadBinding {
+            node_id: node.node_id,
+            scope_id: source.scope_id,
+            epoch: node.read_epoch,
+        };
+        let preflighted = preflight(&binding, &read_key, &head)
+            .map_err(|_| ScopeRootPublishError::NotPublished)?;
+        let signer = SessionIdentity::write_name_signer(&source.write_scope_seed, &node.node_id);
+        let receipt = publish_record(
+            self.transport,
+            self.api,
+            self.floors,
+            self.scheduler,
+            self.profile,
+            &RecordPublishRequest {
+                name: &name,
+                signer: &signer,
+                head: &preflighted,
+                content_cids: Vec::new(),
+                min_current_sequence: None,
+            },
+        )
+        .await
+        .map_err(|_| ScopeRootPublishError::NotPublished)?;
+
+        match receipt.outcome {
+            PublishOutcome::Published { .. } => Ok(()),
+            PublishOutcome::LostRace { .. } => Err(ScopeRootPublishError::LostRace),
+            PublishOutcome::Unconfirmed { .. } => Err(ScopeRootPublishError::NotPublished),
+        }
+    }
+
+    async fn repair_child_scope_index(
+        &self,
+        scope: &ChildScopeRef,
+        index: &[ChildScopeRef],
+    ) -> Result<(), ScopeRootPublishError> {
+        let source = self
+            .swept_scope()
+            .map_err(|_| ScopeRootPublishError::Rejected)?;
+        // The repair republishes the root this pass gated, at the name it gated
+        // it under — never a name the walk did not resolve current.
+        if scope.scope_id != source.scope_id || scope.ipns_name != source.name.as_str().as_bytes() {
+            return Err(ScopeRootPublishError::Rejected);
+        }
+        let owner_enc_pub = self.keys.enc_secret.public();
+        let pseudonym_signer = self.keys.scope_keys.writer_pseudonym(&source.scope_id);
+        let pointer_read_key = self.keys.scope_keys.pointer_read_key(&source.scope_id);
+        let section = reseal_scope_root(
+            &mut *self.entropy.borrow_mut(),
+            &ScopeRootIdentity {
+                v: source.v,
+                scope_id: source.scope_id,
+                ipns_name: &scope.ipns_name,
+                owner_enc_pub: &owner_enc_pub,
+                owner_enc_secret: Some(self.keys.enc_secret),
+                parent_node_seed: source.parent_node_seed.as_deref(),
+                pseudonym_signer: &pseudonym_signer,
+            },
+            &ResealSeeds {
+                override_seed: &source.read_scope_seed,
+                read_epoch: source.read_epoch,
+                // Metadata only: the same seed at the same epoch mints no
+                // history link.
+                prev: None,
+                write_scope_seed: &source.write_scope_seed,
+                write_epoch: source.write_epoch,
+                write_history: WriteHistory::Carried(&source.write_history_link),
+                pointer_read_key: &pointer_read_key,
+            },
+            &CommittedSet {
+                commitment: &source.commitment,
+                commitment_sig: &source.commitment_sig,
+                grant_ledger: &source.grant_ledger,
+                direct_child_scope_index: index,
+            },
+            &source.history_links,
+        )
+        .map_err(reseal_publish_verdict)?;
+        self.publish_scope_root(&ResealedScopeRoot {
+            scope_id: source.scope_id,
+            ipns_name: scope.ipns_name.clone(),
+            read_epoch: source.read_epoch,
+            write_epoch: source.write_epoch,
+            section,
+        })
+        .await
+    }
+}
+
+/// The in-scope children a gated read body names.
+fn read_body_children(body: &ReadBody) -> Vec<NodeRef> {
+    match body {
+        ReadBody::Folder { children, .. } => children
+            .iter()
+            .map(|child| NodeRef {
+                node_id: child.id,
+                ipns_name: child.ipns_name.clone(),
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -1063,7 +1528,7 @@ where
         let identity = self.owner.verifying_key();
         let gated = gated_scope_root(&self.root_adopter(&identity), name, record_bytes)
             .await
-            .map_err(wave_read_verdict)?;
+            .map_err(|verdict| wave_read_verdict(verdict.into()))?;
         let envelope = gated.envelope;
         // The root gate binds `envelope.scope` but not `envelope.id`, and every
         // AAD this republish authors binds the id — so a root whose record claims
@@ -1135,7 +1600,8 @@ where
             // The gate binds `envelope.scope` to the label above; a scope root's
             // node id is its scope id, and only this binds it.
             if gated_scope_root(&adopter, &name, &record_bytes)
-                .await?
+                .await
+                .map_err(ResolveFailure::from)?
                 .envelope
                 .id
                 != child.scope_id
@@ -1615,7 +2081,8 @@ where
             &repoint.current_root,
             &record_bytes,
         )
-        .await?;
+        .await
+        .map_err(ResolveFailure::from)?;
         if gated.envelope.v != ENVELOPE_V || gated.envelope.id != self.scope_id {
             return Err(ResolveFailure::Rejected);
         }
@@ -1731,6 +2198,7 @@ mod tests {
     use cipherbox_core::codec::Value;
     use cipherbox_core::error::{CodecError, Malformed};
     use cipherbox_core::ipns::{IpnsRecord, VerifiedRecord};
+    use cipherbox_core::payload::RepointObject;
     use cipherbox_core::seal::{
         AscentLink, ChildRef, GrantBlobPayload, GrantSetCommitment, NodeKind, Permission,
         STRUCT_TAG_ASCENT_LINK, STRUCT_TAG_GRANT_BLOB, STRUCT_TAG_HISTORY_LINK,
@@ -1745,14 +2213,15 @@ mod tests {
 
     use super::*;
     use crate::content::GatewaySource;
+    use crate::rotation::sweep::sim;
     use crate::rotation::{
         CascadeError, CascadeOutcome, CommittedSet, PrevEpochSeed, ResealSeeds, RotateScopePlan,
         RotateScopeWritePlan, ScopeRootIdentity, WriteRotateError, cascade_rotate_scope,
         derive_write_name, enumerate_eager_set, reseal_scope_root, rotate_scope,
-        rotate_scope_write,
+        rotate_scope_write, sweep_pass,
     };
     use crate::seams::{EndpointId, HttpResponse, SeamError, SeamResult};
-    use crate::sync::pointer::open_repoint;
+    use crate::sync::pointer::{SessionRole, open_repoint, seal_repoint};
     use crate::testkit::fakes::{
         InMemoryCredentialStore, InMemoryFloorStore, InMemoryRecordStore, ScriptedHttp,
         VirtualScheduler,
@@ -1770,6 +2239,9 @@ mod tests {
     const POINTER_READ_KEY: [u8; 32] = [0x5a; 32];
     const OWNER_ROOT_SECRET: [u8; 32] = [0x6b; 32];
     const OWNER_POINTER_SEED: [u8; 32] = [0x7c; 32];
+    /// The pointer-payload envelope version every re-point in this suite is
+    /// sealed and read under.
+    const PAYLOAD_VERSION: u64 = 1;
 
     /// The owner's derivation arm: the two per-scope edges the rotation needs,
     /// off this test owner's root secret and pointer seed.
@@ -2021,7 +2493,10 @@ mod tests {
                     scope_keys: &OwnerSeeds,
                 },
                 ancestry,
+                owner_pointer_seed: &OWNER_POINTER_SEED,
+                payload_version: PAYLOAD_VERSION,
                 gated: GatedRoots::default(),
+                swept: SweptScopeState::default(),
             }
         }
     }
@@ -2581,11 +3056,14 @@ mod tests {
             read_epoch,
             parent_node_seed,
             children,
+            Vec::new(),
+            None,
         )
     }
 
     /// [`owner_scope_root`] at a chosen envelope version — every AAD in the
     /// record, section included, binds `v`.
+    #[allow(clippy::too_many_arguments)]
     fn owner_scope_root_at(
         v: u64,
         scope_id: [u8; 16],
@@ -2593,6 +3071,8 @@ mod tests {
         read_epoch: u64,
         parent_node_seed: Option<&[u8; 32]>,
         children: &[ChildScopeRef],
+        body_children: Vec<ChildRef>,
+        prev: Option<PrevEpochSeed<'_>>,
     ) -> OwnerRootFixture {
         let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, &scope_id);
         let name =
@@ -2624,7 +3104,7 @@ mod tests {
             &ResealSeeds {
                 override_seed,
                 read_epoch,
-                prev: None,
+                prev,
                 write_scope_seed: &OWNER_ROOT_WRITE_SCOPE_SEED,
                 write_epoch: OWNER_ROOT_EPOCH,
                 write_history: WriteHistory::Carried(&[]),
@@ -2645,7 +3125,7 @@ mod tests {
         let body = ReadBody::Folder {
             created_at: 0,
             modified_at: 0,
-            children: Vec::new(),
+            children: body_children,
             unknown: PreservedFields::new(),
         };
         // Authored through the seal primitives rather than
@@ -2897,6 +3377,8 @@ mod tests {
             OWNER_ROOT_EPOCH,
             Some(&parent_node_seed),
             &[],
+            Vec::new(),
+            None,
         );
         let child_ref = child_ref(CHILD_SCOPE, &child);
         let harness = Harness::plain();
@@ -4900,5 +5382,485 @@ mod tests {
             .collect();
 
         assert_eq!(before, after);
+    }
+
+    // --- The interior-node lazy wave ---
+
+    /// The read epoch `SCOPE` sits at after one read rotation, and the seed that
+    /// cut minted. Records authored before it carry `OWNER_ROOT_SCOPE_SEED`, so a
+    /// node still at [`OWNER_ROOT_EPOCH`] only opens through the history link the
+    /// cut left behind.
+    const SWEPT_EPOCH: u64 = OWNER_ROOT_EPOCH + 1;
+    const SWEPT_SEED: [u8; 32] = [0xa5; 32];
+
+    /// The scope read seed records at `epoch` were sealed under.
+    fn seed_at(epoch: u64) -> [u8; 32] {
+        if epoch >= SWEPT_EPOCH {
+            SWEPT_SEED
+        } else {
+            OWNER_ROOT_SCOPE_SEED
+        }
+    }
+
+    /// One interior node's record: an ordinary child envelope sealed under the
+    /// scope's `epoch`-era read key, at the write name its own write seed derives.
+    fn interior_record(
+        node_id: [u8; 16],
+        epoch: u64,
+        children: Vec<ChildRef>,
+    ) -> (IpnsName, Vec<u8>) {
+        let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, &node_id);
+        let name =
+            IpnsName::from_public_key(&kdf::ipns_keypair(write_seed.as_bytes()).verifying_key());
+        let read_key = read_key_for(&seed_at(epoch), &node_id);
+        let body = ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children,
+            unknown: PreservedFields::new(),
+        };
+        let envelope = seal_read_body(
+            &read_key,
+            &[0x4d; 24],
+            ENVELOPE_V,
+            node_id,
+            SCOPE,
+            epoch,
+            &body,
+        )
+        .expect("seal the interior body");
+        (
+            name,
+            encode_envelope(&envelope).expect("encode the envelope"),
+        )
+    }
+
+    /// The parent ref a folder body carries for `node_id` at `name`.
+    fn body_ref(node_id: [u8; 16], name: &IpnsName) -> ChildRef {
+        ChildRef {
+            id: node_id,
+            name: format!("n{:02x}", node_id[0]),
+            ipns_name: name.as_str().as_bytes().to_vec(),
+            kind: NodeKind::Folder,
+            link_counter: 1,
+            unknown: PreservedFields::new(),
+        }
+    }
+
+    /// `SCOPE`'s root as the sweep meets it: post-rotation at [`SWEPT_EPOCH`]
+    /// under [`SWEPT_SEED`], carrying the one history link back to the
+    /// pre-rotation seed, with `body_children` in its read body and
+    /// `child_scope_index` as its committed boundary set.
+    fn swept_root(
+        body_children: Vec<ChildRef>,
+        child_scope_index: &[ChildScopeRef],
+    ) -> OwnerRootFixture {
+        owner_scope_root_at(
+            ENVELOPE_V,
+            SCOPE,
+            &SWEPT_SEED,
+            SWEPT_EPOCH,
+            None,
+            child_scope_index,
+            body_children,
+            Some(PrevEpochSeed {
+                seed: &OWNER_ROOT_SCOPE_SEED,
+                epoch: OWNER_ROOT_EPOCH,
+            }),
+        )
+    }
+
+    impl<T: RecordTransport + Clone> Harness<T> {
+        /// Stage a head block and a signed record for `node_id` at `name`.
+        fn stage_node(&self, node_id: [u8; 16], name: &IpnsName, block: &[u8]) {
+            let cid = root_block_cid(block);
+            self.blocks
+                .lock()
+                .expect("lock")
+                .insert(cid.clone(), block.to_vec());
+            let record = record_for(&node_id, &cid, 1);
+            for endpoint in self.store.endpoints() {
+                self.store
+                    .seed_record(&endpoint, name.as_str(), record.clone());
+            }
+        }
+    }
+
+    /// A staged one-node scope: `SCOPE`'s root at [`SWEPT_EPOCH`] naming one
+    /// interior node published at `node_epoch`.
+    fn staged_swept_scope(
+        node_epoch: u64,
+    ) -> (Harness<InMemoryRecordStore>, ChildScopeRef, [u8; 16]) {
+        let node_id = [0x01; 16];
+        let (node_name, node_block) = interior_record(node_id, node_epoch, Vec::new());
+        let root = swept_root(vec![body_ref(node_id, &node_name)], &[]);
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage_node(node_id, &node_name, &node_block);
+        (harness, child_ref(SCOPE, &root), node_id)
+    }
+
+    #[test]
+    fn a_lagging_interior_node_opens_through_the_history_link_ratchet() {
+        let (harness, scope, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let net = harness.net(&[]);
+
+        let swept = block_on(net.resolve_scope(&scope)).expect("the scope root gates");
+        assert_eq!(swept.current_read_epoch, SWEPT_EPOCH);
+        assert_eq!(swept.children.len(), 1, "the read body is the frontier");
+
+        let found = block_on(net.resolve_child(&swept.children[0])).expect("the node opens");
+        let SweptChild::Interior(node) = found else {
+            panic!("an ordinary node is not a scope-root boundary");
+        };
+        assert_eq!(
+            node.current_read_epoch, OWNER_ROOT_EPOCH,
+            "the node is behind its scope, and read anyway",
+        );
+        assert_eq!(node.read_body, interior_body());
+    }
+
+    /// The body [`interior_record`] sealed for a childless node.
+    fn interior_body() -> ReadBody {
+        ReadBody::Folder {
+            created_at: 0,
+            modified_at: 0,
+            children: Vec::new(),
+            unknown: PreservedFields::new(),
+        }
+    }
+
+    #[test]
+    fn a_node_whose_epoch_the_ratchet_cannot_reach_is_refused() {
+        // A record claiming an epoch no history link walks back to is a forgery
+        // this scope's own ratchet cannot authenticate.
+        let node_id = [0x01; 16];
+        let (node_name, node_block) = interior_record(node_id, OWNER_ROOT_EPOCH, Vec::new());
+        // A root with no history links at all: nothing walks back from SWEPT_EPOCH.
+        let root = owner_scope_root_at(
+            ENVELOPE_V,
+            SCOPE,
+            &SWEPT_SEED,
+            SWEPT_EPOCH,
+            None,
+            &[],
+            vec![body_ref(node_id, &node_name)],
+            None,
+        );
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage_node(node_id, &node_name, &node_block);
+        let net = harness.net(&[]);
+        let swept = block_on(net.resolve_scope(&child_ref(SCOPE, &root))).expect("gates");
+
+        assert_eq!(
+            block_on(net.resolve_child(&swept.children[0])),
+            Err(SweepResolveFailure::Rejected),
+        );
+    }
+
+    #[test]
+    fn an_interior_record_below_its_names_sequence_floor_is_refused() {
+        // The sweep reads past the read-epoch floor by design, so the per-name
+        // sequence floor is what stops a rolled-back record being carried
+        // forward as the node's current body.
+        let (harness, scope, node_id) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let (node_name, _) = interior_record(node_id, OWNER_ROOT_EPOCH, Vec::new());
+        block_on(
+            harness
+                .floors
+                .raise_sequence_floor(node_name.as_str().as_bytes(), 5),
+        )
+        .expect("raise the sequence floor past the staged record");
+        let net = harness.net(&[]);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
+
+        assert_eq!(
+            block_on(net.resolve_child(&swept.children[0])),
+            Err(SweepResolveFailure::Rejected),
+        );
+    }
+
+    #[test]
+    fn an_interior_record_claiming_another_node_is_refused() {
+        let (harness, scope, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let net = harness.net(&[]);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
+        let mislabelled = NodeRef {
+            node_id: [0x9e; 16],
+            ipns_name: swept.children[0].ipns_name.clone(),
+        };
+        assert_eq!(
+            block_on(net.resolve_child(&mislabelled)),
+            Err(SweepResolveFailure::Rejected),
+        );
+    }
+
+    #[test]
+    fn a_child_carrying_a_grant_section_is_a_scope_root_boundary() {
+        let boundary = [0x0a; 16];
+        let parent_node_seed = *kdf::node_seed(&SWEPT_SEED, &boundary).as_bytes();
+        let descendant = owner_scope_root(
+            boundary,
+            &OWNER_ROOT_SCOPE_SEED,
+            OWNER_ROOT_EPOCH,
+            Some(&parent_node_seed),
+            &[],
+        );
+        let root = swept_root(vec![body_ref(boundary, &descendant.name)], &[]);
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage(boundary, &descendant, Some(OWNER_ROOT_EPOCH));
+        let net = harness.net(&[]);
+        let swept = block_on(net.resolve_scope(&child_ref(SCOPE, &root))).expect("gates");
+
+        assert_eq!(
+            block_on(net.resolve_child(&swept.children[0])),
+            Ok(SweptChild::ScopeRoot(ChildScopeRef::new(
+                boundary,
+                descendant.name.as_str().as_bytes().to_vec(),
+            ))),
+            "a grant section makes it the cascade's, and names it for the index",
+        );
+    }
+
+    #[test]
+    fn a_swept_node_republishes_at_the_scopes_epoch_under_the_current_seed() {
+        let (harness, scope, node_id) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        // One net per pass: the publisher runs off the resolve that gated it.
+        let net = harness.net(&[]);
+        let outcome = block_on(sweep_pass(&net, &net, &scope)).expect("the pass converges");
+        assert_eq!(outcome.converged, vec![node_id]);
+        drop(outcome);
+
+        let (node_name, _) = interior_record(node_id, OWNER_ROOT_EPOCH, Vec::new());
+        let (_, envelope) = published_head(&harness, &node_name);
+        assert_eq!(envelope.epoch, SWEPT_EPOCH, "advanced to the scope's epoch");
+        assert!(
+            !has_grant_section(&envelope),
+            "an interior node never gains a scope-root marker",
+        );
+        let read_key = read_key_for(&SWEPT_SEED, &node_id);
+        assert_eq!(
+            open_read_body(&envelope, &read_key).expect("reopens under the current seed"),
+            interior_body(),
+            "the body is carried forward verbatim",
+        );
+    }
+
+    #[test]
+    fn a_scope_root_below_its_own_floor_is_superseded_not_rejected() {
+        let (harness, scope, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        block_on(harness.floors.raise_epoch_floor(&SCOPE, SWEPT_EPOCH + 3))
+            .expect("raise the floor past the record");
+
+        assert_eq!(
+            block_on(harness.net(&[]).resolve_scope(&scope)),
+            Err(SweepResolveFailure::Superseded),
+            "a rotation publishes before it raises the floor, so this is a stale name",
+        );
+    }
+
+    #[test]
+    fn a_forged_below_floor_record_stays_a_trust_rejection() {
+        // A record whose commitment another identity signed is refused at gate
+        // stage 2, which runs before the floor stages — so a forgery is never
+        // reclassified as a stale name and no consult path is offered one.
+        let (harness, scope, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let impostor = owner_root_fixture(OwnerRootSpec {
+            owner_identity: &EcdsaSigner::from_scalar(&[0x4d; 32]).expect("valid scalar"),
+            owner_enc: &owner_enc().public(),
+            scope_id: SCOPE,
+            root_id: SCOPE,
+            children: Vec::new(),
+            child_scope_index: Vec::new(),
+            parent_node_seed: None,
+            owner_write_blob_epoch: Some(OWNER_ROOT_EPOCH),
+            write_history_link: Vec::new(),
+            grants: Vec::new(),
+        });
+        harness.stage(SCOPE, &impostor, Some(OWNER_ROOT_EPOCH));
+        block_on(harness.floors.raise_epoch_floor(&SCOPE, SWEPT_EPOCH + 3))
+            .expect("raise the floor past the forged record");
+
+        assert_eq!(
+            block_on(harness.net(&[]).resolve_scope(&scope)),
+            Err(SweepResolveFailure::Rejected),
+        );
+    }
+
+    #[test]
+    fn the_consult_reports_the_owner_signed_current_root_name() {
+        let (harness, _, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let current_root = vault_root([0xb0; 16], Vec::new()).name;
+        let repoint = RepointObject {
+            scope_id: SCOPE,
+            current_root: current_root.clone(),
+            write_epoch: OWNER_ROOT_EPOCH,
+            min_read_epoch: SWEPT_EPOCH,
+            prev_root: None,
+        };
+        stage_scope_pointer(&harness, &owner_identity(), &repoint);
+
+        assert_eq!(
+            block_on(harness.net(&[]).consult_pointer(&SCOPE)),
+            Ok(Some(current_root.as_str().as_bytes().to_vec())),
+        );
+    }
+
+    #[test]
+    fn a_scope_pointer_another_identity_signed_admits_nothing() {
+        let (harness, _, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let repoint = RepointObject {
+            scope_id: SCOPE,
+            current_root: vault_root([0xb0; 16], Vec::new()).name,
+            write_epoch: OWNER_ROOT_EPOCH,
+            min_read_epoch: SWEPT_EPOCH,
+            prev_root: None,
+        };
+        let impostor = EcdsaSigner::from_scalar(&[0x4d; 32]).expect("valid scalar");
+        stage_scope_pointer(&harness, &impostor, &repoint);
+
+        assert_eq!(
+            block_on(harness.net(&[]).consult_pointer(&SCOPE)),
+            Err(SweepResolveFailure::Rejected),
+        );
+    }
+
+    #[test]
+    fn a_scope_that_was_never_re_pointed_has_no_fresher_name() {
+        let (harness, _, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        assert_eq!(block_on(harness.net(&[]).consult_pointer(&SCOPE)), Ok(None));
+    }
+
+    /// Publish `repoint` at `SCOPE`'s scope-pointer name, sealed under the same
+    /// pointer read key the net re-derives and signed by `owner`.
+    fn stage_scope_pointer<T: RecordTransport + Clone>(
+        harness: &Harness<T>,
+        owner: &EcdsaSigner,
+        repoint: &RepointObject,
+    ) {
+        let pointer = scope_pointer_name(&OWNER_POINTER_SEED, &SCOPE);
+        let read_key = OwnerSeeds.pointer_read_key(&SCOPE);
+        let mut entropy = SeededEntropy::new(5);
+        let block = seal_repoint(
+            SessionRole::Owner,
+            &mut entropy,
+            &read_key,
+            PAYLOAD_VERSION,
+            owner,
+            repoint,
+        )
+        .expect("owner seals the re-point");
+        let signer = scope_pointer_signer(&OWNER_POINTER_SEED, &SCOPE);
+        let record = IpnsRecord::create_v2(&signer, &block, 1, TTL_NANOS, EOL).marshal();
+        for endpoint in harness.store.endpoints() {
+            harness
+                .store
+                .seed_record(&endpoint, pointer.as_str(), record.clone());
+        }
+    }
+
+    #[test]
+    fn an_omitted_scope_root_is_repaired_into_the_published_index() {
+        let boundary = [0x0a; 16];
+        let parent_node_seed = *kdf::node_seed(&SWEPT_SEED, &boundary).as_bytes();
+        let descendant = owner_scope_root(
+            boundary,
+            &OWNER_ROOT_SCOPE_SEED,
+            OWNER_ROOT_EPOCH,
+            Some(&parent_node_seed),
+            &[],
+        );
+        // The body names it; the committed index does not — the #38 D6 gap.
+        let root = swept_root(vec![body_ref(boundary, &descendant.name)], &[]);
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage(boundary, &descendant, Some(OWNER_ROOT_EPOCH));
+        let net = harness.net(&[]);
+
+        let outcome =
+            block_on(sweep_pass(&net, &net, &child_ref(SCOPE, &root))).expect("the pass runs");
+        assert_eq!(outcome.flagged_indexes, vec![boundary]);
+        assert!(
+            outcome.converged.is_empty(),
+            "the self-heal did not ride an epoch-lag re-seal",
+        );
+
+        // The republished root's own write body now names it.
+        let regated = harness.net(&[]);
+        let swept = block_on(regated.resolve_scope(&child_ref(SCOPE, &root)))
+            .expect("the repaired root re-gates");
+        assert_eq!(
+            swept.direct_child_scope_index,
+            vec![ChildScopeRef::new(
+                boundary,
+                descendant.name.as_str().as_bytes().to_vec(),
+            )],
+        );
+    }
+
+    /// Stage `scenario`'s scope on the record plane and return the scope root's
+    /// ref, so the same description drives both the simulation and the real
+    /// seams.
+    fn stage_scenario(
+        harness: &Harness<InMemoryRecordStore>,
+        scenario: &sim::Scenario,
+    ) -> ChildScopeRef {
+        let mut names: BTreeMap<[u8; 16], IpnsName> = BTreeMap::new();
+        let mut index: Vec<ChildScopeRef> = Vec::new();
+        for (byte, epoch) in scenario.nodes {
+            let node_id = sim::id(*byte);
+            let (name, block) = interior_record(node_id, *epoch, Vec::new());
+            harness.stage_node(node_id, &name, &block);
+            names.insert(node_id, name);
+        }
+        for (byte, indexed) in scenario.scope_roots {
+            let scope_id = sim::id(*byte);
+            let parent_node_seed = *kdf::node_seed(&SWEPT_SEED, &scope_id).as_bytes();
+            let descendant = owner_scope_root(
+                scope_id,
+                &OWNER_ROOT_SCOPE_SEED,
+                OWNER_ROOT_EPOCH,
+                Some(&parent_node_seed),
+                &[],
+            );
+            harness.stage(scope_id, &descendant, Some(OWNER_ROOT_EPOCH));
+            if *indexed {
+                index.push(child_ref(scope_id, &descendant));
+            }
+            names.insert(scope_id, descendant.name.clone());
+        }
+        let body: Vec<ChildRef> = scenario
+            .children
+            .iter()
+            .map(|byte| {
+                let node_id = sim::id(*byte);
+                body_ref(node_id, names.get(&node_id).expect("a staged child"))
+            })
+            .collect();
+        let root = swept_root(body, &index);
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        child_ref(SCOPE, &root)
+    }
+
+    /// The fake-vs-concrete equivalence check: every scenario runs the one pure
+    /// [`sweep_pass`] over the simulation network and over the production seams,
+    /// and the two outcomes must agree. A fake that drifts from its production
+    /// counterpart is a suite proving nothing, so the divergence fails this gate
+    /// rather than being found by reading.
+    #[test]
+    fn the_sweep_simulation_and_the_production_seams_agree() {
+        for scenario in sim::SCENARIOS {
+            let fake = scenario.fake();
+            let simulated = block_on(sweep_pass(&fake, &fake, &sim::scope_ref(0x00)));
+
+            let harness = Harness::plain();
+            let scope = stage_scenario(&harness, scenario);
+            let net = harness.net(&[]);
+            let real = block_on(sweep_pass(&net, &net, &scope));
+
+            assert_eq!(simulated, real, "scenario {:?} diverged", scenario.label);
+        }
     }
 }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -5475,9 +5475,7 @@ mod tests {
         epoch: u64,
         children: Vec<ChildRef>,
     ) -> (IpnsName, Vec<u8>) {
-        let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, &node_id);
-        let name =
-            IpnsName::from_public_key(&kdf::ipns_keypair(write_seed.as_bytes()).verifying_key());
+        let name = interior_name(node_id);
         let read_key = read_key_for(&seed_at(epoch), &node_id);
         let body = ReadBody::Folder {
             created_at: 0,
@@ -5499,6 +5497,13 @@ mod tests {
             name,
             encode_envelope(&envelope).expect("encode the envelope"),
         )
+    }
+
+    /// The write name an interior node's own write seed derives. A pure function
+    /// of the node id, so a parent body can cite a child staged after it.
+    fn interior_name(node_id: [u8; 16]) -> IpnsName {
+        let write_seed = kdf::write_seed(&OWNER_ROOT_WRITE_SCOPE_SEED, &node_id);
+        IpnsName::from_public_key(&kdf::ipns_keypair(write_seed.as_bytes()).verifying_key())
     }
 
     /// The parent ref a folder body carries for `node_id` at `name`.
@@ -5990,11 +5995,9 @@ mod tests {
     ) -> ChildScopeRef {
         let mut names: BTreeMap<[u8; 16], IpnsName> = BTreeMap::new();
         let mut index: Vec<ChildScopeRef> = Vec::new();
-        for (byte, epoch) in scenario.nodes {
+        for (byte, _, _) in scenario.nodes {
             let node_id = sim::id(*byte);
-            let (name, block) = interior_record(node_id, *epoch, Vec::new());
-            harness.stage_node(node_id, &name, &block);
-            names.insert(node_id, name);
+            names.insert(node_id, interior_name(node_id));
         }
         for (byte, indexed) in scenario.scope_roots {
             let scope_id = sim::id(*byte);
@@ -6011,6 +6014,20 @@ mod tests {
                 index.push(child_ref(scope_id, &descendant));
             }
             names.insert(scope_id, descendant.name.clone());
+        }
+        // Every name is bound above, so a node's body can cite a child whose
+        // own record is staged later in this loop.
+        for (byte, epoch, children) in scenario.nodes {
+            let node_id = sim::id(*byte);
+            let body: Vec<ChildRef> = children
+                .iter()
+                .map(|child| {
+                    let child_id = sim::id(*child);
+                    body_ref(child_id, names.get(&child_id).expect("a staged child"))
+                })
+                .collect();
+            let (name, block) = interior_record(node_id, *epoch, body);
+            harness.stage_node(node_id, &name, &block);
         }
         let body: Vec<ChildRef> = scenario
             .children
@@ -6046,6 +6063,30 @@ mod tests {
                 .unwrap_or_else(|e| panic!("real {:?}: {e}", scenario.label));
 
             assert_eq!(simulated, real, "scenario {:?} diverged", scenario.label);
+
+            // Both sides must have walked the whole subtree the scenario
+            // describes, not just the root's own body: a scenario set that
+            // flattened back to one level would otherwise agree trivially.
+            let mut reached: Vec<[u8; 16]> = simulated
+                .converged
+                .iter()
+                .chain(&simulated.already_converged)
+                .chain(&simulated.skipped_scope_roots)
+                .copied()
+                .collect();
+            reached.sort_unstable();
+            let mut described: Vec<[u8; 16]> = scenario
+                .nodes
+                .iter()
+                .map(|(byte, _, _)| sim::id(*byte))
+                .chain(scenario.scope_roots.iter().map(|(byte, _)| sim::id(*byte)))
+                .collect();
+            described.sort_unstable();
+            assert_eq!(
+                reached, described,
+                "scenario {:?} left part of its subtree unwalked",
+                scenario.label
+            );
         }
     }
 }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -15,14 +15,15 @@
 use core::cell::RefCell;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 
 use cipherbox_core::ipns::IpnsName;
 use cipherbox_core::kdf;
 use cipherbox_core::seal::{
     AadContext, ChildScopeRef, Envelope, GrantLedgerEntry, GrantSection, GrantSetCommitment,
     GrantSetEntry, PreservedFields, ReadBody, STRUCT_TAG_OWNER_BLOB, STRUCT_TAG_WRITE_BODY,
-    SignedSealed, WriteBody, decode_write_body, has_grant_section, open_owner_blob, open_read_body,
-    sign_grant_set, unseal,
+    SignedSealed, WriteBody, decode_envelope, decode_write_body, has_grant_section,
+    open_owner_blob, open_read_body, sign_grant_set, unseal,
 };
 use cipherbox_core::suite::ecdsa::{EcdsaSigner, EcdsaVerifier, SIGNATURE_LEN as ECDSA_SIG_LEN};
 use cipherbox_core::suite::ed25519::Ed25519Signer;
@@ -30,7 +31,7 @@ use cipherbox_core::suite::secret::{SECRET_LEN, SecretBytes};
 use cipherbox_core::suite::x25519::{X25519Public, X25519Secret};
 use zeroize::Zeroizing;
 
-use super::adopter::{RootAdopter, assemble_head_envelope, open_write_scope_seed_at};
+use super::adopter::{LocalHead, RootAdopter, fetch_head_block, open_write_scope_seed_at};
 use super::author::{
     AuthorError, ENVELOPE_V, EnvelopeAuthoring, author_child_envelope,
     author_scope_root_with_section,
@@ -44,12 +45,14 @@ use super::record_publish::{
 use super::retire::{retire, root_retire_ready};
 use crate::api::ApiClient;
 use crate::content::Gateway;
+use crate::content::root_block_cid;
 use crate::entropy::Entropy;
 use crate::gate::{GateError, RejectionReason, floor};
 use crate::grants::{enforce_committed_ledger, entry_tag_is_bound, mint_grant_row};
 use crate::net::fanout_get_verify;
 use crate::net::resolve::Adopter;
 use crate::profile::SyncTimingProfile;
+use crate::rotation::sweep::body_children;
 use crate::rotation::{
     CascadeResealResolver, CascadeTarget, ChildIndexResolver, CommittedSet, LaggingNode, NodeRef,
     PrevEpochSeed, RepointChannel, RepublishedNode, ResealError, ResealSeeds, ResealedScopeRoot,
@@ -760,21 +763,22 @@ where
 /// An interior node carries no seed of its own: its read key derives from the
 /// scope's, and the epoch its record was sealed at derives from the scope's
 /// history-link ratchet. Pinning that one gated read is what lets the pass read
-/// and re-seal every node under material a single adoption proved, rather than
-/// re-gating the root per node.
+/// and re-seal every node under material a single adoption proved.
+///
+/// Keyed on the scope root's own name, as [`GatedRoots`] is: a caller asking
+/// under a different label gets nothing rather than aliasing onto this scope's
+/// keys.
 #[derive(Default)]
 pub struct SweptScopeState {
-    inner: RefCell<Option<SweptScopeSource>>,
+    inner: RefCell<Option<Rc<SweptScopeSource>>>,
 }
 
 /// Everything the sweep's node reads and publishes need from the scope root.
-/// Terminal owner of the two seeds: they zeroize when the state is replaced or
-/// dropped.
-#[derive(Clone)]
+/// Shared behind an [`Rc`] rather than copied per node, so the two seeds have
+/// one live copy that zeroizes when the state is replaced or dropped.
 struct SweptScopeSource {
     scope_id: [u8; 16],
     name: IpnsName,
-    v: u64,
     read_epoch: u64,
     write_epoch: u64,
     read_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
@@ -789,12 +793,29 @@ struct SweptScopeSource {
 
 impl SweptScopeState {
     fn park(&self, source: SweptScopeSource) {
-        *self.inner.borrow_mut() = Some(source);
+        *self.inner.borrow_mut() = Some(Rc::new(source));
     }
 
-    /// The parked scope, cloned so no borrow is held across a suspend point.
-    fn source(&self) -> Option<SweptScopeSource> {
-        self.inner.borrow().clone()
+    /// The parked scope when it is the one `scope` names. The `Rc` is cloned so
+    /// no borrow is held across a suspend point.
+    fn source(&self, scope: &ChildScopeRef) -> Option<Rc<SweptScopeSource>> {
+        self.inner
+            .borrow()
+            .as_ref()
+            .filter(|source| {
+                source.scope_id == scope.scope_id
+                    && source.name.as_str().as_bytes() == scope.ipns_name
+            })
+            .map(Rc::clone)
+    }
+}
+
+/// Carry a gate error into the sweep's read arm on rule 6's axis: a rejection
+/// is a fail-closed trust violation, a seam failure is availability.
+fn read_verdict(error: GateError) -> SweepResolveFailure {
+    match error {
+        GateError::Seam(_) => SweepResolveFailure::Unavailable,
+        GateError::Rejected(_) => SweepResolveFailure::Rejected,
     }
 }
 
@@ -813,27 +834,36 @@ where
     T: RecordTransport,
     F: FloorStore,
 {
-    /// The parked scope. A node read or publish issued before the scope root was
-    /// gated has no material to run under — an internal ordering break, and
-    /// fail-closed rather than a re-gate under an unproven label.
-    fn swept_scope(&self) -> Result<SweptScopeSource, SweepResolveFailure> {
-        self.swept.source().ok_or(SweepResolveFailure::Rejected)
+    /// The scope `scope` names, as this pass gated it. A node read or publish
+    /// issued for a scope this net never gated has no material to run under —
+    /// fail-closed rather than a read under an unproven label.
+    fn swept_scope(
+        &self,
+        scope: &ChildScopeRef,
+    ) -> Result<Rc<SweptScopeSource>, SweepResolveFailure> {
+        self.swept
+            .source(scope)
+            .ok_or(SweepResolveFailure::Rejected)
     }
 
-    /// Prove a walked child really is a descendant scope root, and report the
-    /// name it gated current at.
+    /// Prove a walked child really is a descendant scope root **of this scope**,
+    /// and report the name it gated current at.
     ///
-    /// The read body names children, not scope boundaries, so a child carrying a
-    /// grant section is only a scope root if its **owner-signed** commitment
-    /// binds this name and its ascent link opens under the seed this scope
-    /// derives for it. Anything less would let a committed writer plant a marker
-    /// that carves a node out of the sweep.
+    /// The read body is authored by any committed writer, so the `ChildRef` that
+    /// led here proves nothing. Two bindings do: the owner-signed commitment
+    /// binds the name, and the **ascent link** — required here, release-active —
+    /// binds the record to `nodeSeed(this scope's read seed, child)`. The gate
+    /// verifies an ascent link only when the record carries one, and a vault root
+    /// carries none; without this the owner's own vault root, planted as a
+    /// `ChildRef`, would gate cleanly and be repaired into this scope's committed
+    /// index, where a later cascade would re-key it under this scope's seed.
     async fn gated_child_scope_root(
         &self,
         source: &SweptScopeSource,
         child: &NodeRef,
         name: &IpnsName,
         record_bytes: &[u8],
+        head: LocalHead,
     ) -> Result<SweptChild, SweepResolveFailure> {
         let parent_node_seed = kdf::node_seed(&source.read_scope_seed, &child.node_id);
         let adopter = RootAdopter::new(
@@ -845,12 +875,11 @@ where
             child.node_id,
         )
         .under_parent_node_seed(Zeroizing::new(*parent_node_seed.as_bytes()));
-        // The gate binds `envelope.scope` to the label above; a scope root's node
-        // id is its scope id, and only this binds it.
+        adopter.hold_local_head(head);
         let gated = gated_scope_root(&adopter, name, record_bytes)
             .await
             .map_err(SweepResolveFailure::from)?;
-        if gated.envelope.id != child.node_id {
+        if gated.envelope.id != child.node_id || gated.section.ascent_link.is_none() {
             return Err(SweepResolveFailure::Rejected);
         }
         Ok(SweptChild::ScopeRoot(ChildScopeRef::new(
@@ -863,12 +892,20 @@ where
     ///
     /// This is the one read that deliberately does **not** run the scope's
     /// read-epoch floor: a lagging interior node is below that floor by
-    /// construction, and it is exactly the record the sweep exists to advance.
-    /// It is safe where admitting a below-floor *scope root* is not, because an
-    /// interior record carries no seed, no grant blob and no commitment — every
-    /// key here comes from the scope root this pass already gated, so nothing
-    /// the record claims can hand a revoked reader anything. The per-name
-    /// sequence floor still applies, so a replayed older record is refused.
+    /// construction, and it is exactly the record the sweep exists to advance
+    /// (ADR 0003 D1). It is safe where admitting a below-floor *scope root* is
+    /// not, because an interior record carries no seed, no grant blob and no
+    /// commitment — every key here comes from the scope root this pass already
+    /// gated, so nothing the record claims hands a revoked reader anything.
+    ///
+    /// What the skipped stage did carry is **authorship**: an interior body is
+    /// authenticated only by the AEAD under the epoch's read key, so a party who
+    /// held that epoch's seed and still holds the node's write key can author a
+    /// body this pass promotes to the current epoch. That is the write plane's
+    /// residual forgery window (CONTEXT.md "Forgery window"), closed by
+    /// `rotateScopeWrite`, not by this read. The per-name sequence floor is what
+    /// bars a rolled-back record, and it advances here on every confirmed
+    /// unseal so it stops being 0 for an unbrowsed node.
     async fn interior_node(
         &self,
         source: &SweptScopeSource,
@@ -883,17 +920,24 @@ where
         {
             return Err(SweepResolveFailure::Rejected);
         }
-        let floor = floor::sequence_floor(self.floors, name.as_str().as_bytes())
-            .await
-            .map_err(|_| SweepResolveFailure::Unavailable)?
-            .unwrap_or(0);
-        if sequence < floor {
-            return Err(SweepResolveFailure::Rejected);
-        }
-        // A node above the scope root's epoch means this pass's view of the root
-        // is stale, not that the node is forged: re-read it next pass.
+        floor::check_sequence(
+            self.floors,
+            name.as_str().as_bytes(),
+            sequence,
+            floor::Strictness::AtOrAboveFloor,
+        )
+        .await
+        .map_err(|error| match error {
+            GateError::Seam(_) => SweepResolveFailure::Unavailable,
+            GateError::Rejected(_) => SweepResolveFailure::Rejected,
+        })?;
+        // A record above the scope root's epoch is not lagging, and this scope's
+        // ratchet only walks backward, so there is no seed here that opens it —
+        // an honest race with a fresher root, or an epoch label a committed
+        // writer chose freely (the epoch is only AAD). Either way it is this
+        // pass's read that fails, not the record's trust.
         if envelope.epoch > source.read_epoch {
-            return Err(SweepResolveFailure::Unavailable);
+            return Err(SweepResolveFailure::Unreadable);
         }
         let seed = seed_at_epoch(
             envelope.v,
@@ -903,12 +947,20 @@ where
             &source.history_links,
             envelope.epoch,
         )
-        .ok_or(SweepResolveFailure::Rejected)?;
+        .ok_or(SweepResolveFailure::Unreadable)?;
         let read_key = read_key_for(&seed, &envelope.id);
         let read_body =
             open_read_body(&envelope, &read_key).map_err(|_| SweepResolveFailure::Rejected)?;
+        // The floor law's child arm: the per-name sequence floor advances only
+        // after an AAD-confirmed unseal (`net/child.rs`), and nothing else on
+        // this path raises it — so without this a rolled-back record stays
+        // admissible for as long as the node goes unbrowsed.
+        floor::advance_sequence_on_unseal(self.floors, name.as_str().as_bytes(), sequence)
+            .await
+            .map_err(|_| SweepResolveFailure::Unavailable)?;
         Ok(SweptChild::Interior(SweptNode {
             current_read_epoch: envelope.epoch,
+            sequence,
             read_body,
             carried_unknown: envelope.unknown,
             carried_epoch_tag_unknown: envelope.epoch_tag_unknown,
@@ -938,23 +990,27 @@ where
             .write_body(&root, scope.scope_id)
             .await
             .map_err(SweepResolveFailure::from)?;
-        let write_scope_seed = root
-            .write_scope_seed
-            .clone()
-            .ok_or(SweepResolveFailure::Unavailable)?;
-        let children = read_body_children(&root.read_body);
+        let GatedScopeRoot {
+            envelope,
+            section,
+            read_body,
+            read_scope_seed,
+            write_scope_seed,
+        } = root;
+        let write_scope_seed = write_scope_seed.ok_or(SweepResolveFailure::Unavailable)?;
+        let children = body_children(&read_body);
+        let read_epoch = envelope.epoch;
         self.swept.park(SweptScopeSource {
             scope_id: scope.scope_id,
             name: name.clone(),
-            v: root.envelope.v,
-            read_epoch: root.envelope.epoch,
+            read_epoch,
             write_epoch,
-            read_scope_seed: root.read_scope_seed.clone(),
+            read_scope_seed,
             write_scope_seed: write_scope_seed.clone(),
             parent_node_seed: self.ancestry.parent_node_seed(&scope.scope_id),
-            commitment: root.section.commitment.clone(),
-            commitment_sig: root.section.commitment_sig,
-            history_links: root.section.history_links.clone(),
+            commitment: section.commitment,
+            commitment_sig: section.commitment_sig,
+            history_links: section.history_links,
             grant_ledger: write_body.grant_ledger,
             write_history_link: write_body.write_history_link,
         });
@@ -963,14 +1019,14 @@ where
         self.gated.park(
             name,
             RepublishBase {
-                read_body: root.read_body,
-                unknown: root.envelope.unknown,
-                epoch_tag_unknown: root.envelope.epoch_tag_unknown,
+                read_body,
+                unknown: envelope.unknown,
+                epoch_tag_unknown: envelope.epoch_tag_unknown,
                 write_scope_seed: Some(write_scope_seed),
             },
         );
         Ok(SweptScope {
-            current_read_epoch: root.envelope.epoch,
+            current_read_epoch: read_epoch,
             children,
             direct_child_scope_index: write_body.direct_child_scope_index,
         })
@@ -986,8 +1042,6 @@ where
             .await
         {
             Ok(Some(block)) => block,
-            // No pointer record: this scope has never been re-pointed, so there
-            // is no fresher name to re-resolve at.
             Ok(None) => return Ok(None),
             Err(_) => return Err(SweepResolveFailure::Unavailable),
         };
@@ -1003,22 +1057,35 @@ where
         Ok(Some(repoint.current_root.as_str().as_bytes().to_vec()))
     }
 
-    async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
-        let source = self.swept_scope()?;
+    async fn resolve_child(
+        &self,
+        scope: &ChildScopeRef,
+        child: &NodeRef,
+    ) -> Result<SweptChild, SweepResolveFailure> {
+        let source = self.swept_scope(scope)?;
         let name = scope_name(&child.ipns_name).map_err(SweepResolveFailure::from)?;
         let Some((_, record_bytes)) = fanout_get_verify(self.transport, &name).await else {
             return Err(SweepResolveFailure::Unavailable);
         };
-        let (sequence, envelope) =
-            assemble_head_envelope(self.gateway, self.http, &name, &record_bytes, None)
+        let (sequence, block) =
+            fetch_head_block(self.gateway, self.http, &name, &record_bytes, None)
                 .await
-                .map_err(|error| match error {
-                    GateError::Seam(_) => SweepResolveFailure::Unavailable,
-                    GateError::Rejected(_) => SweepResolveFailure::Rejected,
-                })?;
+                .map_err(read_verdict)?;
+        let envelope = decode_envelope(&block).map_err(|_| SweepResolveFailure::Rejected)?;
         if has_grant_section(&envelope) {
+            // The root gate re-assembles the head; hand it the block this read
+            // already paid for.
             return self
-                .gated_child_scope_root(&source, child, &name, &record_bytes)
+                .gated_child_scope_root(
+                    &source,
+                    child,
+                    &name,
+                    &record_bytes,
+                    LocalHead {
+                        cid: root_block_cid(&block),
+                        block,
+                    },
+                )
                 .await;
         }
         self.interior_node(&source, child, &name, sequence, envelope)
@@ -1034,14 +1101,24 @@ where
     Sch: Scheduler + Clone + 'static,
     E: Entropy,
 {
-    async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+    async fn publish_node(
+        &self,
+        scope: &ChildScopeRef,
+        node: &LaggingNode<'_>,
+    ) -> Result<(), ScopeRootPublishError> {
         let source = self
-            .swept_scope()
+            .swept_scope(scope)
             .map_err(|_| ScopeRootPublishError::Rejected)?;
         let name = scope_name(node.ipns_name).map_err(publish_verdict)?;
-        // Release-active mirror of the gate reject this build would itself make
-        // on the record about to be signed: a record cannot be unpublished
-        // (security rule 8).
+        // Release-active (security rule 8), both halves. The seam's own
+        // invariant: a node is only ever sealed at the epoch of the scope root
+        // this pass gated, since any other value signs under a key no reader
+        // re-derives. And the durable mirror: a concurrent cascade can raise the
+        // read-epoch floor after that gated read, and a record cannot be
+        // unpublished — so re-read the floor rather than trusting the snapshot.
+        if node.read_epoch != source.read_epoch {
+            return Err(ScopeRootPublishError::Rejected);
+        }
         let read_floor = floor::read_epoch_floor(self.floors, &source.scope_id)
             .await
             .map_err(|_| ScopeRootPublishError::NotPublished)?
@@ -1082,7 +1159,12 @@ where
                 signer: &signer,
                 head: &preflighted,
                 content_cids: Vec::new(),
-                min_current_sequence: None,
+                // Nothing on the sweep's read path adopts an interior record, so
+                // no gate ever raises this name's durable sequence floor to what
+                // the network already holds: the record the pass read is the CAS
+                // lower bound, exactly as the pointer publish and revival treat
+                // their own ungated names.
+                min_current_sequence: Some(node.sequence),
             },
         )
         .await
@@ -1100,21 +1182,19 @@ where
         scope: &ChildScopeRef,
         index: &[ChildScopeRef],
     ) -> Result<(), ScopeRootPublishError> {
+        // Keyed on `scope`, so the repair can only ever republish the root this
+        // pass gated, at the name it gated it under — never a name the walk did
+        // not resolve current.
         let source = self
-            .swept_scope()
+            .swept_scope(scope)
             .map_err(|_| ScopeRootPublishError::Rejected)?;
-        // The repair republishes the root this pass gated, at the name it gated
-        // it under — never a name the walk did not resolve current.
-        if scope.scope_id != source.scope_id || scope.ipns_name != source.name.as_str().as_bytes() {
-            return Err(ScopeRootPublishError::Rejected);
-        }
         let owner_enc_pub = self.keys.enc_secret.public();
         let pseudonym_signer = self.keys.scope_keys.writer_pseudonym(&source.scope_id);
         let pointer_read_key = self.keys.scope_keys.pointer_read_key(&source.scope_id);
         let section = reseal_scope_root(
             &mut *self.entropy.borrow_mut(),
             &ScopeRootIdentity {
-                v: source.v,
+                v: ENVELOPE_V,
                 scope_id: source.scope_id,
                 ipns_name: &scope.ipns_name,
                 owner_enc_pub: &owner_enc_pub,
@@ -1150,20 +1230,6 @@ where
             section,
         })
         .await
-    }
-}
-
-/// The in-scope children a gated read body names.
-fn read_body_children(body: &ReadBody) -> Vec<NodeRef> {
-    match body {
-        ReadBody::Folder { children, .. } => children
-            .iter()
-            .map(|child| NodeRef {
-                node_id: child.id,
-                ipns_name: child.ipns_name.clone(),
-            })
-            .collect(),
-        _ => Vec::new(),
     }
 }
 
@@ -5473,12 +5539,17 @@ mod tests {
     impl<T: RecordTransport + Clone> Harness<T> {
         /// Stage a head block and a signed record for `node_id` at `name`.
         fn stage_node(&self, node_id: [u8; 16], name: &IpnsName, block: &[u8]) {
+            self.stage_node_at(node_id, name, block, 1);
+        }
+
+        /// [`Self::stage_node`] at a chosen record sequence.
+        fn stage_node_at(&self, node_id: [u8; 16], name: &IpnsName, block: &[u8], sequence: u64) {
             let cid = root_block_cid(block);
             self.blocks
                 .lock()
                 .expect("lock")
                 .insert(cid.clone(), block.to_vec());
-            let record = record_for(&node_id, &cid, 1);
+            let record = record_for(&node_id, &cid, sequence);
             for endpoint in self.store.endpoints() {
                 self.store
                     .seed_record(&endpoint, name.as_str(), record.clone());
@@ -5509,7 +5580,8 @@ mod tests {
         assert_eq!(swept.current_read_epoch, SWEPT_EPOCH);
         assert_eq!(swept.children.len(), 1, "the read body is the frontier");
 
-        let found = block_on(net.resolve_child(&swept.children[0])).expect("the node opens");
+        let found =
+            block_on(net.resolve_child(&scope, &swept.children[0])).expect("the node opens");
         let SweptChild::Interior(node) = found else {
             panic!("an ordinary node is not a scope-root boundary");
         };
@@ -5531,9 +5603,10 @@ mod tests {
     }
 
     #[test]
-    fn a_node_whose_epoch_the_ratchet_cannot_reach_is_refused() {
-        // A record claiming an epoch no history link walks back to is a forgery
-        // this scope's own ratchet cannot authenticate.
+    fn a_node_whose_epoch_the_ratchet_cannot_reach_is_unreadable() {
+        // A record claiming an epoch no history link walks back to opens under
+        // no seed this scope can derive — unreadable to every reader, so the
+        // pass isolates the node rather than calling the record forged.
         let node_id = [0x01; 16];
         let (node_name, node_block) = interior_record(node_id, OWNER_ROOT_EPOCH, Vec::new());
         // A root with no history links at all: nothing walks back from SWEPT_EPOCH.
@@ -5551,10 +5624,26 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
         harness.stage_node(node_id, &node_name, &node_block);
         let net = harness.net(&[]);
-        let swept = block_on(net.resolve_scope(&child_ref(SCOPE, &root))).expect("gates");
+        let scope = child_ref(SCOPE, &root);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
 
         assert_eq!(
-            block_on(net.resolve_child(&swept.children[0])),
+            block_on(net.resolve_child(&scope, &swept.children[0])),
+            Err(SweepResolveFailure::Unreadable),
+        );
+    }
+
+    #[test]
+    fn a_node_read_under_a_scope_this_net_never_gated_is_refused() {
+        // The parked read is keyed on the scope root's own name, so a caller
+        // asking under another label gets nothing rather than this scope's keys.
+        let (harness, scope, _) = staged_swept_scope(OWNER_ROOT_EPOCH);
+        let net = harness.net(&[]);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
+        let foreign = ChildScopeRef::new([0x9e; 16], scope.ipns_name.clone());
+
+        assert_eq!(
+            block_on(net.resolve_child(&foreign, &swept.children[0])),
             Err(SweepResolveFailure::Rejected),
         );
     }
@@ -5576,7 +5665,7 @@ mod tests {
         let swept = block_on(net.resolve_scope(&scope)).expect("gates");
 
         assert_eq!(
-            block_on(net.resolve_child(&swept.children[0])),
+            block_on(net.resolve_child(&scope, &swept.children[0])),
             Err(SweepResolveFailure::Rejected),
         );
     }
@@ -5591,7 +5680,7 @@ mod tests {
             ipns_name: swept.children[0].ipns_name.clone(),
         };
         assert_eq!(
-            block_on(net.resolve_child(&mislabelled)),
+            block_on(net.resolve_child(&scope, &mislabelled)),
             Err(SweepResolveFailure::Rejected),
         );
     }
@@ -5612,10 +5701,11 @@ mod tests {
         harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
         harness.stage(boundary, &descendant, Some(OWNER_ROOT_EPOCH));
         let net = harness.net(&[]);
-        let swept = block_on(net.resolve_scope(&child_ref(SCOPE, &root))).expect("gates");
+        let scope = child_ref(SCOPE, &root);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
 
         assert_eq!(
-            block_on(net.resolve_child(&swept.children[0])),
+            block_on(net.resolve_child(&scope, &swept.children[0])),
             Ok(SweptChild::ScopeRoot(ChildScopeRef::new(
                 boundary,
                 descendant.name.as_str().as_bytes().to_vec(),
@@ -5646,6 +5736,97 @@ mod tests {
             interior_body(),
             "the body is carried forward verbatim",
         );
+    }
+
+    #[test]
+    fn a_swept_node_lands_above_the_sequence_the_network_already_holds() {
+        // Nothing on the sweep's read path adopts an interior record, so this
+        // device's durable sequence floor for the node starts at 0 while the
+        // network is at 7. Publishing at floor + 1 would lose the CAS forever.
+        let node_id = [0x01; 16];
+        let (node_name, node_block) = interior_record(node_id, OWNER_ROOT_EPOCH, Vec::new());
+        let root = swept_root(vec![body_ref(node_id, &node_name)], &[]);
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage_node_at(node_id, &node_name, &node_block, 7);
+        assert_eq!(
+            block_on(floor::sequence_floor(
+                &harness.floors,
+                node_name.as_str().as_bytes()
+            ))
+            .expect("floor read"),
+            None,
+            "the node was never adopted on this device",
+        );
+
+        let net = harness.net(&[]);
+        let outcome =
+            block_on(sweep_pass(&net, &net, &child_ref(SCOPE, &root))).expect("the pass converges");
+        assert_eq!(outcome.converged, vec![node_id]);
+        let (published, _) = published_head(&harness, &node_name);
+        assert_eq!(
+            published.sequence, 8,
+            "the CAS ran off the record the pass read, not the empty floor",
+        );
+    }
+
+    #[test]
+    fn an_interior_unseal_advances_the_names_sequence_floor() {
+        // The floor law's child arm, so a rolled-back record stops being
+        // admissible the moment the sweep has read the real one.
+        let node_id = [0x01; 16];
+        let (node_name, node_block) = interior_record(node_id, OWNER_ROOT_EPOCH, Vec::new());
+        let root = swept_root(vec![body_ref(node_id, &node_name)], &[]);
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage_node_at(node_id, &node_name, &node_block, 7);
+        let net = harness.net(&[]);
+        let scope = child_ref(SCOPE, &root);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
+        block_on(net.resolve_child(&scope, &swept.children[0])).expect("opens");
+
+        assert_eq!(
+            block_on(floor::sequence_floor(
+                &harness.floors,
+                node_name.as_str().as_bytes()
+            ))
+            .expect("floor read"),
+            Some(7),
+        );
+    }
+
+    /// The owner's own vault root, planted in a swept node's read body as if it
+    /// were a descendant scope root. Every gate stage passes on it — it is a
+    /// real owner-signed record — and a vault root carries no ascent link, so
+    /// only the sweep's own requirement for one stops it being repaired into
+    /// this scope's committed index, where a later cascade would re-key it
+    /// under this scope's seed.
+    #[test]
+    fn the_vault_root_planted_as_a_child_scope_root_is_refused() {
+        let vault_scope = [0x77; 16];
+        let planted = vault_root(vault_scope, Vec::new());
+        assert!(
+            planted.grant_section.ascent_link.is_none(),
+            "a vault root is exactly the record with nothing binding it to us",
+        );
+        let root = swept_root(vec![body_ref(vault_scope, &planted.name)], &[]);
+        let harness = Harness::plain();
+        harness.stage(SCOPE, &root, Some(OWNER_ROOT_EPOCH));
+        harness.stage(vault_scope, &planted, Some(OWNER_ROOT_EPOCH));
+        let net = harness.net(&[]);
+        let scope = child_ref(SCOPE, &root);
+        let swept = block_on(net.resolve_scope(&scope)).expect("gates");
+
+        assert_eq!(
+            block_on(net.resolve_child(&scope, &swept.children[0])),
+            Err(SweepResolveFailure::Rejected),
+        );
+
+        // And the whole pass fails closed rather than repairing it in.
+        let net = harness.net(&[]);
+        let err = block_on(sweep_pass(&net, &net, &scope)).expect_err("fails closed");
+        assert_eq!(err.check(), "node-unresolved");
+        assert!(!err.is_retryable());
     }
 
     #[test]
@@ -5853,12 +6034,16 @@ mod tests {
     fn the_sweep_simulation_and_the_production_seams_agree() {
         for scenario in sim::SCENARIOS {
             let fake = scenario.fake();
-            let simulated = block_on(sweep_pass(&fake, &fake, &sim::scope_ref(0x00)));
+            // Both must *complete*: two identical aborts would agree while
+            // proving nothing about the population either side walked.
+            let simulated = block_on(sweep_pass(&fake, &fake, &sim::scope_ref(0x00)))
+                .unwrap_or_else(|e| panic!("simulated {:?}: {e}", scenario.label));
 
             let harness = Harness::plain();
             let scope = stage_scenario(&harness, scenario);
             let net = harness.net(&[]);
-            let real = block_on(sweep_pass(&net, &net, &scope));
+            let real = block_on(sweep_pass(&net, &net, &scope))
+                .unwrap_or_else(|e| panic!("real {:?}: {e}", scenario.label));
 
             assert_eq!(simulated, real, "scenario {:?} diverged", scenario.label);
         }

--- a/crates/engine/src/rotation/cascade.rs
+++ b/crates/engine/src/rotation/cascade.rs
@@ -81,9 +81,7 @@ use cipherbox_core::hex::lower as hex_lower;
 ///
 /// Both omissions are load-bearing. No `parent_node_seed`: the ascent link
 /// re-seals under the parent's **freshly-minted** derivation, threaded top-down,
-/// never the descendant's own stale published one (contrast
-/// [`SweepTarget`](super::sweep::SweepTarget), which *does* carry it because the
-/// sweep reuses the published derivation). No self-identifying `scope_id` /
+/// never the descendant's own stale published one. No self-identifying `scope_id` /
 /// `ipns_name`: re-seal, publish, parent-seed derivation, and floor-raise all run
 /// under the **enumerated** [`ChildScopeRef`] alone, so there is no second copy
 /// for a network hint to diverge from.

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -13,10 +13,10 @@
 //! - [`trigger`] — the read-revoke / scope-exit / manual trigger surface, and
 //!   the driver that turns a replay's queued scope-exit triggers into one flat
 //!   `rotateScope` per source scope root.
-//! - [`sweep`] — the lazy-wave epoch-lag convergence pass (metadata-only,
-//!   existing seed, `prev = None`) plus its idle-cadence driver and the
-//!   direct-child-scope index self-heal. It does **not** mint fresh descendant
-//!   seeds — that fresh-seed eager-set republish is the [`cascade`]'s job.
+//! - [`sweep`] — the lazy wave over a scope's **interior nodes**: re-seal every
+//!   node whose epoch lags its scope's, plus the idle-cadence driver and the
+//!   direct-child-scope index self-heal. Descendant scope roots are eager-set
+//!   members it stops at — their re-key is the [`cascade`]'s job.
 //! - [`cascade`] — the owner-revocation eager cascade (`rotateScope` on a read
 //!   revoke): re-key the root **and every transitively-reachable descendant scope
 //!   root** with a **fresh** override seed (`prev = Some`), threaded top-down.
@@ -29,10 +29,10 @@
 //!   inventory swap, and root linger. The write-plane sibling of `rotate_scope`.
 //!
 //! [`ChildIndexResolver`], [`CascadeResealResolver`], [`ScopeRootPublisher`],
-//! [`WriteSubtreeResolver`] and [`WriteWavePublisher`] have production
-//! implementations over the real transport in [`crate::net::rotation`].
-//! [`SweepResolver`] and [`ScopeExitRotator`] have no production implementation
-//! yet; tests fake them.
+//! [`SweepResolver`], [`SweepPublisher`], [`WriteSubtreeResolver`] and
+//! [`WriteWavePublisher`] have production implementations over the real
+//! transport in [`crate::net::rotation`]. [`ScopeExitRotator`] has no production
+//! implementation yet; tests fake it.
 
 pub mod cascade;
 pub mod eager_set;
@@ -51,7 +51,7 @@ pub use eager_set::{
 };
 pub use reseal::{
     CommittedSet, PrevEpochSeed, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory,
-    reseal_scope_root,
+    reseal_scope_root, seed_at_epoch,
 };
 pub use rotate::{
     ResealedScopeRoot, RotateError, RotateScopePlan, RotationOutcome, ScopeRootPublishError,
@@ -62,7 +62,10 @@ pub use rotate_write::{
     WriteRotateError, WriteRotationOutcome, WriteScopeNode, WriteSubtreeResolver,
     WriteWavePublisher, build_repoint_object, derive_write_name, rotate_scope_write,
 };
-pub use sweep::{SweepError, SweepOutcome, SweepResolver, SweepTarget, run_sweep, sweep_pass};
+pub use sweep::{
+    LaggingNode, NodeRef, SweepError, SweepOutcome, SweepPublisher, SweepResolveFailure,
+    SweepResolver, SweptChild, SweptNode, SweptScope, run_sweep, sweep_pass,
+};
 pub use trigger::{
     RevokeError, RevokedCommittedSet, RotationTrigger, ScopeExitReport, ScopeExitRotator,
     consume_scope_exit_triggers, revoke_read_grant,

--- a/crates/engine/src/rotation/mod.rs
+++ b/crates/engine/src/rotation/mod.rs
@@ -64,7 +64,7 @@ pub use rotate_write::{
 };
 pub use sweep::{
     LaggingNode, NodeRef, SweepError, SweepOutcome, SweepPublisher, SweepResolveFailure,
-    SweepResolver, SweptChild, SweptNode, SweptScope, run_sweep, sweep_pass,
+    SweepResolver, SweptChild, SweptNode, SweptScope, converge_subtree, run_sweep, sweep_pass,
 };
 pub use trigger::{
     RevokeError, RevokedCommittedSet, RotationTrigger, ScopeExitReport, ScopeExitRotator,

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -55,7 +55,8 @@ use crate::grants::{enforce_committed_ledger, entry_tag_is_bound};
 /// How many history links a re-seal carries forward — the ratchet's retained
 /// window, in rotations (blueprint/core.md "History-link retention"). The window
 /// is the deepest epoch lag a backward walk can cover; a node past it is
-/// re-sealed forward by the next sweep rather than lost.
+/// readable by nobody, and the sweep reports it unreachable rather than
+/// re-sealing it forward.
 const MAX_RETAINED_HISTORY_LINKS: usize = 64;
 
 // Under the decode bound, or a re-seal mints sections the decoder refuses; at
@@ -278,20 +279,34 @@ fn walkable_chain_start(
     let mut seed = Zeroizing::new(*head.seed);
     let mut epoch = head.epoch;
     for (i, link) in carried.iter().enumerate().rev() {
-        let key = kdf::structure_key(&seed, STRUCT_TAG_HISTORY_LINK);
-        let ctx = ctx_for(v, scope_id, epoch, STRUCT_TAG_HISTORY_LINK);
-        let Ok(payload) = open_history_link(key.as_bytes(), &ctx, &link.sealed) else {
+        let Some(prev) = ratchet_step(v, scope_id, &seed, epoch, link) else {
             return i + 1;
         };
-        // The ratchet only ever steps backward; a flat or rising epoch is a
-        // chain that cannot terminate.
-        if payload.prev_epoch >= epoch {
-            return i + 1;
-        }
-        seed = Zeroizing::new(*payload.prev_seed());
-        epoch = payload.prev_epoch;
+        (seed, epoch) = prev;
     }
     0
+}
+
+/// One backward step of the key-regression ratchet: open `link` under `seed`'s
+/// structure key at `epoch` and yield the epoch before it. `None` when the link
+/// will not open, or when its epoch does not descend — a chain that cannot
+/// terminate. The one home of the ratchet's key and AAD derivation, so the
+/// writer's retention decision ([`walkable_chain_start`]) and the reader's seed
+/// recovery ([`seed_at_epoch`]) can never disagree on it.
+fn ratchet_step(
+    v: u64,
+    scope_id: [u8; 16],
+    seed: &[u8; SECRET_LEN],
+    epoch: u64,
+    link: &SignedSealed,
+) -> Option<(Zeroizing<[u8; SECRET_LEN]>, u64)> {
+    let key = kdf::structure_key(seed, STRUCT_TAG_HISTORY_LINK);
+    let ctx = ctx_for(v, scope_id, epoch, STRUCT_TAG_HISTORY_LINK);
+    let payload = open_history_link(key.as_bytes(), &ctx, &link.sealed).ok()?;
+    if payload.prev_epoch >= epoch {
+        return None;
+    }
+    Some((Zeroizing::new(*payload.prev_seed()), payload.prev_epoch))
 }
 
 /// Walk a scope's key-regression ratchet backward from its current seed to the
@@ -319,15 +334,7 @@ pub fn seed_at_epoch(
         if epoch == target_epoch {
             return Some(seed);
         }
-        let key = kdf::structure_key(&seed, STRUCT_TAG_HISTORY_LINK);
-        let ctx = ctx_for(v, scope_id, epoch, STRUCT_TAG_HISTORY_LINK);
-        let payload = open_history_link(key.as_bytes(), &ctx, &link.sealed).ok()?;
-        // The ratchet only ever steps backward.
-        if payload.prev_epoch >= epoch {
-            return None;
-        }
-        seed = Zeroizing::new(*payload.prev_seed());
-        epoch = payload.prev_epoch;
+        (seed, epoch) = ratchet_step(v, scope_id, &seed, epoch, link)?;
     }
     (epoch == target_epoch).then_some(seed)
 }

--- a/crates/engine/src/rotation/reseal.rs
+++ b/crates/engine/src/rotation/reseal.rs
@@ -294,6 +294,44 @@ fn walkable_chain_start(
     0
 }
 
+/// Walk a scope's key-regression ratchet backward from its current seed to the
+/// seed `target_epoch` was sealed under — the read a lagging interior node needs
+/// before it can be re-sealed forward (CONTEXT.md "History link").
+///
+/// `carried_history_links` are a published section's, oldest epoch first, so the
+/// newest opens under `current_seed` at `current_epoch`. Every step descends, so
+/// an epoch at or above `current_epoch` is only reachable when it *is*
+/// `current_epoch`. Returns `None` when the ratchet cannot reach
+/// `target_epoch`: a link that will not open, an epoch that does not descend, or
+/// an epoch older than the retained window — all unreadable to every reader, not
+/// just this one.
+pub fn seed_at_epoch(
+    v: u64,
+    scope_id: [u8; 16],
+    current_seed: &[u8; SECRET_LEN],
+    current_epoch: u64,
+    carried_history_links: &[SignedSealed],
+    target_epoch: u64,
+) -> Option<Zeroizing<[u8; SECRET_LEN]>> {
+    let mut seed = Zeroizing::new(*current_seed);
+    let mut epoch = current_epoch;
+    for link in carried_history_links.iter().rev() {
+        if epoch == target_epoch {
+            return Some(seed);
+        }
+        let key = kdf::structure_key(&seed, STRUCT_TAG_HISTORY_LINK);
+        let ctx = ctx_for(v, scope_id, epoch, STRUCT_TAG_HISTORY_LINK);
+        let payload = open_history_link(key.as_bytes(), &ctx, &link.sealed).ok()?;
+        // The ratchet only ever steps backward.
+        if payload.prev_epoch >= epoch {
+            return None;
+        }
+        seed = Zeroizing::new(*payload.prev_seed());
+        epoch = payload.prev_epoch;
+    }
+    (epoch == target_epoch).then_some(seed)
+}
+
 /// Seal one history link — `prev`'s seed under `seed`'s structure key, bound to
 /// `epoch` — the ratchet's single backward step, on either plane.
 fn mint_history_link<E: Entropy>(
@@ -1827,5 +1865,49 @@ mod tests {
                 "history-link-not-descending"
             );
         }
+    }
+
+    // --- The key-regression ratchet walked backward ---
+
+    #[test]
+    fn the_ratchet_reaches_every_epoch_its_links_span() {
+        // A published record at epoch 5 carrying the links for 2..=5: the seed
+        // for any epoch in that span is recoverable, and each one is the epoch's
+        // own.
+        let links = real_chain(5);
+        for target in 1..=5u64 {
+            let seed = seed_at_epoch(V, SCOPE, &chain_seed(5), 5, &links, target)
+                .unwrap_or_else(|| panic!("epoch {target} is inside the retained window"));
+            assert!(ct_eq(&seed, &chain_seed(target)), "epoch {target}");
+        }
+    }
+
+    #[test]
+    fn the_ratchet_never_steps_forward() {
+        assert!(seed_at_epoch(V, SCOPE, &chain_seed(5), 5, &real_chain(5), 6).is_none());
+    }
+
+    #[test]
+    fn an_epoch_older_than_the_retained_window_is_unreachable() {
+        // The links only span 4..=5, so epoch 2 is behind the ratchet's reach —
+        // unreadable to every reader, not just this one.
+        let links = real_chain(5)[3..].to_vec();
+        assert!(seed_at_epoch(V, SCOPE, &chain_seed(5), 5, &links, 2).is_none());
+    }
+
+    #[test]
+    fn a_link_from_another_scope_breaks_the_walk() {
+        let links = real_chain(5);
+        assert!(seed_at_epoch(V, [0x9e; 16], &chain_seed(5), 5, &links, 4).is_none());
+        assert!(
+            seed_at_epoch(V, SCOPE, &chain_seed(4), 5, &links, 4).is_none(),
+            "nor does a walk started from the wrong seed open the newest link",
+        );
+    }
+
+    #[test]
+    fn a_scope_at_epoch_one_resolves_its_own_seed_with_no_links() {
+        let seed = seed_at_epoch(V, SCOPE, &chain_seed(1), 1, &[], 1).expect("the current seed");
+        assert!(ct_eq(&seed, &chain_seed(1)));
     }
 }

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -40,7 +40,7 @@ use cipherbox_core::seal::{ChildScopeRef, PreservedFields, ReadBody};
 
 use super::eager_set::ResolveFailure;
 use super::rotate::ScopeRootPublishError;
-use crate::grants::child_index::repair_observed;
+use crate::grants::child_index::{canonicalize, repair_observed};
 use crate::seams::Scheduler;
 use cipherbox_core::hex::lower as hex_lower;
 
@@ -79,6 +79,9 @@ pub struct SweptScope {
 pub struct SweptNode {
     /// The published record's read epoch — the epoch-lag operand.
     pub current_read_epoch: u64,
+    /// That record's sequence: the CAS basis a re-seal must publish above, since
+    /// nothing on this read path raises the name's durable sequence floor to it.
+    pub sequence: u64,
     /// The node's unsealed read body.
     pub read_body: ReadBody,
     /// Top-level envelope fields a republish preserves byte-stable (#27 D10).
@@ -113,13 +116,25 @@ pub enum SweepResolveFailure {
     Unavailable,
     /// A scope root's record sits below its own durable read-epoch floor.
     Superseded,
+    /// The node's body could not be opened at all: no seed on this scope's
+    /// key-regression ratchet reaches the epoch its record claims — an epoch
+    /// older than the retained window, a broken chain, or one above the scope
+    /// root's own. Unreadable to every reader, so no retry can change it and it
+    /// is not a verdict on the record's trustworthiness.
+    Unreadable,
+    /// The same node id was reached through two parents carrying **different**
+    /// `ipnsName` labels — the read plane's C2 conflict
+    /// ([`ResolveFailure::ConflictingChildLabel`]). Converging the one picked
+    /// would leave the other name live at the old epoch, so the walk aborts.
+    ConflictingChildLabel,
 }
 
 impl From<ResolveFailure> for SweepResolveFailure {
     fn from(failure: ResolveFailure) -> Self {
         match failure {
             ResolveFailure::Unavailable => Self::Unavailable,
-            ResolveFailure::Rejected | ResolveFailure::ConflictingChildLabel => Self::Rejected,
+            ResolveFailure::Rejected => Self::Rejected,
+            ResolveFailure::ConflictingChildLabel => Self::ConflictingChildLabel,
         }
     }
 }
@@ -130,16 +145,21 @@ impl core::fmt::Display for SweepResolveFailure {
             Self::Rejected => f.write_str("record rejected by adoption gate"),
             Self::Unavailable => f.write_str("record unavailable"),
             Self::Superseded => f.write_str("scope root superseded: record below its own floor"),
+            Self::ConflictingChildLabel => {
+                f.write_str("node id reached with conflicting ipnsName labels")
+            }
+            Self::Unreadable => f.write_str("node epoch beyond this scope's ratchet"),
         }
     }
 }
 
 impl SweepResolveFailure {
-    /// Whether re-running the pass could clear this — availability only. A
-    /// rejection is a trust violation, and a `Superseded` that survives the
-    /// consult means the re-pointed record is below the floor too.
+    /// Whether re-running the pass could clear this: an availability stall, or a
+    /// C2 conflict the write-rotation re-point wave repairs. A rejection is a
+    /// trust violation, and a `Superseded` that survives the consult means the
+    /// re-pointed record is below the floor too.
     fn is_retryable(self) -> bool {
-        matches!(self, Self::Unavailable)
+        matches!(self, Self::Unavailable | Self::ConflictingChildLabel)
     }
 }
 
@@ -165,9 +185,14 @@ pub trait SweepResolver {
         scope_id: &[u8; 16],
     ) -> Result<Option<Vec<u8>>, SweepResolveFailure>;
 
-    /// Resolve one child of a node already swept in this scope, at whatever
-    /// epoch its record carries.
-    async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure>;
+    /// Resolve one child of a node inside `scope`, at whatever epoch its record
+    /// carries. `scope` is the ref [`Self::resolve_scope`] proved current, and
+    /// the only scope this child may be gated under.
+    async fn resolve_child(
+        &self,
+        scope: &ChildScopeRef,
+        child: &NodeRef,
+    ) -> Result<SweptChild, SweepResolveFailure>;
 }
 
 /// One interior node being advanced to its scope's current epoch. The publisher
@@ -180,6 +205,9 @@ pub struct LaggingNode<'a> {
     pub ipns_name: &'a [u8],
     /// The scope's current read epoch: what the node is re-sealed up to.
     pub read_epoch: u64,
+    /// The sequence of the record this body came from — the CAS basis the
+    /// re-seal must land above ([`SweptNode::sequence`]).
+    pub sequence: u64,
     /// The body carried forward verbatim.
     pub read_body: &'a ReadBody,
     /// Envelope fields a republish preserves byte-stable (#27 D10).
@@ -191,8 +219,13 @@ pub struct LaggingNode<'a> {
 /// The write edge the sweep runs on. Both methods are register-first CAS
 /// publishes; `Ok` means the record is durably the freshest at its name.
 pub trait SweepPublisher {
-    /// Re-seal `node`'s carried body at `node.read_epoch` and CAS-publish it.
-    async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError>;
+    /// Re-seal `node`'s carried body at `node.read_epoch` and CAS-publish it,
+    /// under `scope` — the ref [`SweepResolver::resolve_scope`] proved current.
+    async fn publish_node(
+        &self,
+        scope: &ChildScopeRef,
+        node: &LaggingNode<'_>,
+    ) -> Result<(), ScopeRootPublishError>;
 
     /// Republish `scope`'s scope root carrying `index` as its
     /// `directChildScopeIndex` — the #38 D6 self-heal. Metadata-only: the
@@ -218,6 +251,12 @@ pub struct SweepOutcome {
     /// Descendant scope roots the walk stopped at: eager-set members the cascade
     /// rotates, never swept.
     pub skipped_scope_roots: Vec<[u8; 16]>,
+    /// Nodes whose body no seed on this scope's ratchet opens
+    /// ([`SweepResolveFailure::Unreadable`]). Neither swept nor descended into,
+    /// and no retry clears it — surfaced so a caller that needs the subtree
+    /// proven converged (grant creation) can refuse, rather than reading an
+    /// `Ok` outcome as complete.
+    pub unreachable: Vec<[u8; 16]>,
     /// Scope roots the walk encountered that were missing from the scope's
     /// direct-child-scope index, repaired into it and **durably published** —
     /// "repaired and flagged" (#38 D6). A repair that loses the CAS is not
@@ -320,20 +359,13 @@ impl SweepError {
 /// children in.
 fn canonicalize_frontier(mut nodes: Vec<NodeRef>) -> Vec<NodeRef> {
     nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
-    let mut seen: Option<[u8; 16]> = None;
-    nodes.retain(|node| {
-        if seen == Some(node.node_id) {
-            false
-        } else {
-            seen = Some(node.node_id);
-            true
-        }
-    });
+    nodes.dedup_by_key(|node| node.node_id);
     nodes
 }
 
-/// The in-scope children a swept body names.
-fn body_children(body: &ReadBody) -> Vec<NodeRef> {
+/// The in-scope children a gated read body names — the walk's frontier rule,
+/// stated once for both the pure pass and the production resolver.
+pub(crate) fn body_children(body: &ReadBody) -> Vec<NodeRef> {
     match body {
         ReadBody::Folder { children, .. } => children
             .iter()
@@ -357,9 +389,11 @@ async fn resolve_scope_current<R: SweepResolver>(
     match resolver.resolve_scope(scope).await {
         Ok(swept) => Ok((scope.clone(), swept)),
         Err(SweepResolveFailure::Superseded) => {
-            let repointed = repointed_ref(resolver, scope).await?;
-            // One consult, one re-resolve: a fresh record still below the floor
-            // fails closed here rather than consulting again.
+            // One consult, one re-resolve.
+            let repointed = ChildScopeRef::new(
+                scope.scope_id,
+                repointed_name(resolver, &scope.scope_id).await?,
+            );
             let swept = resolver.resolve_scope(&repointed).await?;
             Ok((repointed, swept))
         }
@@ -371,18 +405,17 @@ async fn resolve_scope_current<R: SweepResolver>(
 /// Returns the ref the child resolved current at.
 async fn resolve_child_current<R: SweepResolver>(
     resolver: &R,
+    scope: &ChildScopeRef,
     child: &NodeRef,
 ) -> Result<(NodeRef, SweptChild), SweepResolveFailure> {
-    match resolver.resolve_child(child).await {
+    match resolver.resolve_child(scope, child).await {
         Ok(found) => Ok((child.clone(), found)),
         Err(SweepResolveFailure::Superseded) => {
-            let scope = ChildScopeRef::new(child.node_id, child.ipns_name.clone());
-            let repointed = repointed_ref(resolver, &scope).await?;
             let node = NodeRef {
                 node_id: child.node_id,
-                ipns_name: repointed.ipns_name,
+                ipns_name: repointed_name(resolver, &child.node_id).await?,
             };
-            let found = resolver.resolve_child(&node).await?;
+            let found = resolver.resolve_child(scope, &node).await?;
             Ok((node, found))
         }
         Err(other) => Err(other),
@@ -391,18 +424,17 @@ async fn resolve_child_current<R: SweepResolver>(
 
 /// The scope's `currentRootName` from its pointer. A scope with no pointer has
 /// no fresher name, so the below-floor record is refused as it stands.
-async fn repointed_ref<R: SweepResolver>(
+async fn repointed_name<R: SweepResolver>(
     resolver: &R,
-    scope: &ChildScopeRef,
-) -> Result<ChildScopeRef, SweepResolveFailure> {
-    let current = resolver
-        .consult_pointer(&scope.scope_id)
+    scope_id: &[u8; 16],
+) -> Result<Vec<u8>, SweepResolveFailure> {
+    resolver
+        .consult_pointer(scope_id)
         .await?
-        .ok_or(SweepResolveFailure::Superseded)?;
-    Ok(ChildScopeRef::new(scope.scope_id, current))
+        .ok_or(SweepResolveFailure::Superseded)
 }
 
-/// Run one idempotent sweep pass over `scope`'s interior nodes.
+/// Run one idempotent sweep pass over `scope`'s whole interior.
 ///
 /// Resolves the scope root (consulting the pointer on a superseded verdict),
 /// walks its read body stopping at every scope-root boundary, self-heals the
@@ -413,6 +445,40 @@ pub async fn sweep_pass<R, P>(
     resolver: &R,
     publisher: &P,
     scope: &ChildScopeRef,
+) -> Result<SweepOutcome, SweepError>
+where
+    R: SweepResolver,
+    P: SweepPublisher,
+{
+    walk_and_converge(resolver, publisher, scope, None).await
+}
+
+/// Converge just the subtree rooted at `node` inside `scope` — grant creation's
+/// gate, which owes the epoch-converged guarantee over the folder it is sharing
+/// and not over the whole scope it happens to sit in (#26 D2).
+///
+/// `node` itself is measured against the scope's epoch too: the granted folder
+/// is an interior node until the mint publishes its new scope root over it.
+pub async fn converge_subtree<R, P>(
+    resolver: &R,
+    publisher: &P,
+    scope: &ChildScopeRef,
+    node: &NodeRef,
+) -> Result<SweepOutcome, SweepError>
+where
+    R: SweepResolver,
+    P: SweepPublisher,
+{
+    walk_and_converge(resolver, publisher, scope, Some(node)).await
+}
+
+/// The one pass both entry points run: gate the scope root, walk from `from`
+/// (or from the root's own body), self-heal the index, re-seal what lags.
+async fn walk_and_converge<R, P>(
+    resolver: &R,
+    publisher: &P,
+    scope: &ChildScopeRef,
+    from: Option<&NodeRef>,
 ) -> Result<SweepOutcome, SweepError>
 where
     R: SweepResolver,
@@ -436,12 +502,21 @@ where
     // corrupt back-edge terminates rather than looping.
     let mut visited: BTreeSet<[u8; 16]> = BTreeSet::new();
     visited.insert(scope_ref.scope_id);
+    // The single authoritative `node_id -> ipnsName` binding for this walk
+    // ([`SweepResolveFailure::ConflictingChildLabel`]).
+    let mut labels: BTreeMap<[u8; 16], Vec<u8>> = BTreeMap::new();
     // Scope roots the walk met that the index does not name (#38 D6), at the
     // name each resolved current at.
-    let mut omitted: BTreeMap<[u8; 16], ChildScopeRef> = BTreeMap::new();
+    let mut omitted: Vec<ChildScopeRef> = Vec::new();
     let mut lagging: Vec<(NodeRef, SweptNode)> = Vec::new();
 
-    let mut frontier = canonicalize_frontier(swept.children);
+    let mut frontier = match from {
+        Some(node) => vec![node.clone()],
+        None => swept.children,
+    };
+    bind_labels(&mut labels, &frontier).map_err(conflict)?;
+    frontier = canonicalize_frontier(frontier);
+
     while !frontier.is_empty() {
         let mut next: Vec<NodeRef> = Vec::new();
         for child in &frontier {
@@ -452,20 +527,31 @@ where
                 outcome.skipped_scope_roots.push(child.node_id);
                 continue;
             }
-            let (resolved, found) =
-                resolve_child_current(resolver, child)
-                    .await
-                    .map_err(|reason| SweepError::Node {
+            let (resolved, found) = match resolve_child_current(resolver, &scope_ref, child).await {
+                Ok(pair) => pair,
+                // Nothing to re-seal from and no body to descend into, and a
+                // committed writer can plant one — so it is isolated to this
+                // node rather than aborting the scope's whole pass.
+                Err(SweepResolveFailure::Unreadable) => {
+                    outcome.unreachable.push(child.node_id);
+                    continue;
+                }
+                Err(reason) => {
+                    return Err(SweepError::Node {
                         node_id: child.node_id,
                         reason,
-                    })?;
+                    });
+                }
+            };
             match found {
                 SweptChild::ScopeRoot(scope_root) => {
                     outcome.skipped_scope_roots.push(child.node_id);
-                    omitted.insert(child.node_id, scope_root);
+                    omitted.push(scope_root);
                 }
                 SweptChild::Interior(node) => {
-                    next.extend(body_children(&node.read_body));
+                    let grandchildren = body_children(&node.read_body);
+                    bind_labels(&mut labels, &grandchildren).map_err(conflict)?;
+                    next.extend(grandchildren);
                     if node.current_read_epoch >= swept.current_read_epoch {
                         outcome.already_converged.push(child.node_id);
                     } else {
@@ -479,14 +565,17 @@ where
 
     // The self-heal runs on the walk result, before any epoch comparison is
     // acted on, so it lands whether or not this pass re-seals a node (#38 D6,
-    // ADR 0003 D3).
-    if !omitted.is_empty() {
-        let mut index = swept.direct_child_scope_index.clone();
-        for scope_root in omitted.values() {
-            index = repair_observed(&index, scope_root.clone());
-        }
+    // ADR 0003 D3). It repairs the whole invariant: the index the scope commits
+    // to is canonical and names every scope root the walk observed.
+    let mut index = canonicalize(&swept.direct_child_scope_index);
+    for scope_root in &omitted {
+        index = repair_observed(&index, scope_root.clone());
+    }
+    if index != swept.direct_child_scope_index {
         match publisher.repair_child_scope_index(&scope_ref, &index).await {
-            Ok(()) => outcome.flagged_indexes.extend(omitted.keys().copied()),
+            Ok(()) => outcome
+                .flagged_indexes
+                .extend(omitted.iter().map(|root| root.scope_id)),
             // Never landed, so never flagged; the next pass re-derives it.
             Err(ScopeRootPublishError::LostRace) => {}
             Err(error) => {
@@ -503,11 +592,12 @@ where
             node_id: node.node_id,
             ipns_name: &node.ipns_name,
             read_epoch: swept.current_read_epoch,
+            sequence: swept_node.sequence,
             read_body: &swept_node.read_body,
             carried_unknown: &swept_node.carried_unknown,
             carried_epoch_tag_unknown: &swept_node.carried_epoch_tag_unknown,
         };
-        match publisher.publish_node(&lagging_node).await {
+        match publisher.publish_node(&scope_ref, &lagging_node).await {
             Ok(()) => outcome.converged.push(node.node_id),
             // The one spec-mandated non-abort per-node path. The winner may be a
             // non-advancing ordinary write, so the node is not proven converged;
@@ -523,6 +613,29 @@ where
     }
 
     Ok(outcome)
+}
+
+/// Bind each ref's `node_id -> ipnsName` into `labels`, aborting on the C2
+/// conflict: an id already bound to a **different** name. Returns the
+/// conflicting id.
+fn bind_labels(labels: &mut BTreeMap<[u8; 16], Vec<u8>>, refs: &[NodeRef]) -> Result<(), [u8; 16]> {
+    for node in refs {
+        match labels.get(&node.node_id) {
+            Some(name) if name != &node.ipns_name => return Err(node.node_id),
+            Some(_) => {}
+            None => {
+                labels.insert(node.node_id, node.ipns_name.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn conflict(node_id: [u8; 16]) -> SweepError {
+    SweepError::Node {
+        node_id,
+        reason: SweepResolveFailure::ConflictingChildLabel,
+    }
 }
 
 /// Drive the sweep as an idle-cadence job: run [`sweep_pass`] and re-run it, one
@@ -576,7 +689,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::sim::{FakeNet, id, name, scope_ref};
+    use super::sim::{FakeNet, id, name, node_ref, scope_ref};
     use super::*;
     use crate::seams::UnixMillis;
     use crate::testkit::block_on;
@@ -683,7 +796,7 @@ mod tests {
         // anything below it is swept — that is the cascade's population.
         let net = FakeNet::new(5, &[0x01, 0x0a])
             .node(0x01, 1, &[])
-            .scope_root(0x0a, true, &[0x0d])
+            .scope_root(0x0a, true)
             .node(0x0d, 1, &[]);
 
         let outcome = run(&net, 0x00).expect("sweep");
@@ -698,7 +811,7 @@ mod tests {
     fn an_indexed_scope_root_is_not_resolved_as_an_interior_node() {
         // The index names S(0a), so the walk stops without a child resolve —
         // even though S's record would otherwise resolve as a scope root.
-        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, true, &[]);
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, true);
         let outcome = run(&net, 0x00).expect("sweep");
         assert_eq!(outcome.skipped_scope_roots, vec![id(0x0a)]);
         assert!(
@@ -717,7 +830,7 @@ mod tests {
         // nothing re-sealed — the self-heal no longer rides the epoch comparison.
         let net = FakeNet::new(5, &[0x01, 0x0a])
             .node(0x01, 5, &[])
-            .scope_root(0x0a, false, &[]);
+            .scope_root(0x0a, false);
 
         let outcome = run(&net, 0x00).expect("sweep");
         assert_eq!(outcome.flagged_indexes, vec![id(0x0a)]);
@@ -731,8 +844,29 @@ mod tests {
     }
 
     #[test]
+    fn a_non_canonical_index_is_republished_canonical_with_nothing_omitted() {
+        // The other half of the #38 D6 invariant: crash residue in the stored
+        // index is repaired on the walk result too, with no scope root missing.
+        let net = FakeNet::new(5, &[0x0a])
+            .scope_root(0x0a, true)
+            .duplicate_index_entry(0x0a);
+
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert!(
+            outcome.flagged_indexes.is_empty(),
+            "no scope root was missing, so none is flagged"
+        );
+        assert_eq!(net.index_repairs.get(), 1);
+        assert_eq!(
+            net.state.borrow().repaired_index.clone().expect("repaired"),
+            vec![scope_ref(0x0a)],
+            "the duplicate is dropped"
+        );
+    }
+
+    #[test]
     fn a_repaired_index_is_not_flagged_again_on_the_next_pass() {
-        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false, &[]);
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false);
         assert_eq!(run(&net, 0x00).expect("first").flagged_indexes.len(), 1);
         let again = run(&net, 0x00).expect("second");
         assert!(again.flagged_indexes.is_empty());
@@ -741,7 +875,7 @@ mod tests {
 
     #[test]
     fn an_index_repair_that_lost_the_cas_is_not_flagged() {
-        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false, &[]);
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false);
         net.state.borrow_mut().index_repair_fault = Some(ScopeRootPublishError::LostRace);
 
         let outcome = run(&net, 0x00).expect("sweep");
@@ -754,7 +888,7 @@ mod tests {
 
     #[test]
     fn an_index_repair_that_did_not_land_fails_closed() {
-        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false, &[]);
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false);
         net.state.borrow_mut().index_repair_fault = Some(ScopeRootPublishError::NotPublished);
 
         let err = run(&net, 0x00).expect_err("fails closed");
@@ -768,7 +902,7 @@ mod tests {
         // self-heal runs on the walk result rather than behind a re-seal.
         let net = FakeNet::new(5, &[0x01, 0x0a])
             .node(0x01, 1, &[])
-            .scope_root(0x0a, false, &[])
+            .scope_root(0x0a, false)
             .fault(0x01, ScopeRootPublishError::NotPublished);
 
         let err = run(&net, 0x00).expect_err("the node publish aborts");
@@ -861,7 +995,7 @@ mod tests {
         // S(0a) is missing from the index and its indexed-at name is stale. Only
         // the name the walk resolved current may be written into the index.
         let net = FakeNet::new(5, &[0x0a])
-            .scope_root(0x0a, false, &[])
+            .scope_root(0x0a, false)
             .superseded(0x0a)
             .pointer_to(0x0b);
 
@@ -873,6 +1007,110 @@ mod tests {
             vec![ChildScopeRef::new(id(0x0a), name(0x0b))],
             "the repair persists the re-pointed name, never the superseded one"
         );
+    }
+
+    // --- Nodes no seed of this scope's ratchet opens ---
+
+    #[test]
+    fn an_unreadable_node_is_isolated_and_the_rest_still_converges() {
+        // One node's record claims an epoch this scope's ratchet cannot reach.
+        // Nothing can re-seal it and no retry clears it, so it is surfaced and
+        // stepped past rather than aborting every other node's convergence.
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 1, &[])
+            .node(0x02, 1, &[])
+            .node_fault(0x01, SweepResolveFailure::Unreadable);
+
+        let outcome = run(&net, 0x00).expect("the pass completes");
+        assert_eq!(outcome.unreachable, vec![id(0x01)]);
+        assert_eq!(outcome.converged, vec![id(0x02)]);
+        assert_eq!(net.publishes(0x01), 0, "nothing to re-seal it from");
+    }
+
+    #[test]
+    fn an_unreadable_nodes_subtree_is_not_walked() {
+        // Its body is what named its children, so an unreadable node hides them.
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[0x02])
+            .node(0x02, 1, &[])
+            .node_fault(0x01, SweepResolveFailure::Unreadable);
+
+        let outcome = run(&net, 0x00).expect("the pass completes");
+        assert_eq!(outcome.unreachable, vec![id(0x01)]);
+        assert!(outcome.converged.is_empty());
+        assert!(outcome.already_converged.is_empty());
+    }
+
+    // --- One node id, one name ---
+
+    #[test]
+    fn two_parents_naming_one_node_differently_abort_fail_closed() {
+        // C2: converging the name we picked would leave the other live at the
+        // old epoch — a hole no outcome bucket could describe.
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 5, &[0x05])
+            .node(0x02, 5, &[0x05])
+            .node(0x05, 1, &[])
+            .names_child(0x02, 0x05, "via-b");
+
+        let err = run(&net, 0x00).expect_err("the conflict aborts");
+        assert!(matches!(
+            err,
+            SweepError::Node {
+                node_id,
+                reason: SweepResolveFailure::ConflictingChildLabel,
+            } if node_id == id(0x05)
+        ));
+        assert!(err.is_retryable(), "the re-point wave repairs both parents");
+        assert_eq!(net.publishes(0x05), 0);
+    }
+
+    #[test]
+    fn two_parents_naming_one_node_identically_is_no_conflict() {
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 5, &[0x05])
+            .node(0x02, 5, &[0x05])
+            .node(0x05, 1, &[]);
+        let outcome = run(&net, 0x00).expect("a legitimate diamond converges");
+        assert_eq!(outcome.converged, vec![id(0x05)]);
+        assert_eq!(net.publishes(0x05), 1, "the shared node published once");
+    }
+
+    // --- Converging one subtree rather than the whole scope ---
+
+    #[test]
+    fn converge_subtree_walks_only_the_named_node_and_below() {
+        // A(01) holds the subtree; B(02) lags elsewhere in the same scope and
+        // must be left alone.
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 5, &[0x03])
+            .node(0x02, 1, &[])
+            .node(0x03, 1, &[]);
+
+        let outcome = block_on(converge_subtree(
+            &net,
+            &net,
+            &scope_ref(0x00),
+            &node_ref(0x01),
+        ))
+        .expect("the subtree converges");
+        assert_eq!(outcome.converged, vec![id(0x03)]);
+        assert_eq!(outcome.already_converged, vec![id(0x01)]);
+        assert_eq!(net.publishes(0x02), 0, "a sibling subtree is untouched");
+        assert_eq!(net.epoch(0x02), 1);
+    }
+
+    #[test]
+    fn converge_subtree_measures_the_named_node_itself() {
+        let net = FakeNet::new(5, &[0x01]).node(0x01, 1, &[]);
+        let outcome = block_on(converge_subtree(
+            &net,
+            &net,
+            &scope_ref(0x00),
+            &node_ref(0x01),
+        ))
+        .expect("converges");
+        assert_eq!(outcome.converged, vec![id(0x01)]);
     }
 
     // --- Fail-closed completeness ---

--- a/crates/engine/src/rotation/sweep.rs
+++ b/crates/engine/src/rotation/sweep.rs
@@ -1,197 +1,262 @@
-//! The sweep — idempotent lazy-wave epoch-lag convergence (blueprint/engine.md
-//! "sweep", L269-278; #26 D2, #38 D6).
+//! The sweep — the idempotent lazy wave over a scope's **interior nodes**
+//! (blueprint/engine.md "sweep"; #26 D2, #38 D6,
+//! [ADR 0003](https://github.com/FSM1/cipher-box-next/blob/main/decisions/0003-sweep-population-and-below-floor-scope-roots.md)).
 //!
-//! # What the sweep is (and is not)
+//! # Population
 //!
-//! The rotation architecture is an O(1) root cut plus a lazy wave (CONTEXT.md
-//! "Lazy wave", "Epoch lag"). This module is the **lazy wave**: it walks the
-//! eager set from a rotated root and, for every descendant scope root whose
-//! published record epoch lags its scope's durable epoch floor, re-seals that
-//! scope root's **metadata** up to the floor epoch — reusing the scope's
-//! **existing** override seed, `prev = None`, minting no new seed, epoch, or
-//! history link. Content bytes are never re-encrypted (#26 D6).
+//! The work-list is the epoch-lag predicate over the nodes *inside* one scope: a
+//! node whose envelope epoch is behind the scope root's current read epoch. The
+//! walk descends the scope root's own read body and **stops at scope-root
+//! boundaries** — a descendant scope root is an eager-set member the
+//! [`cascade`](super::cascade) rotates, and is never swept. Each lagging node is
+//! re-sealed at the scope's current epoch and CAS-published; a node already at
+//! the epoch is a no-op, so a re-run changes nothing and concurrent sweepers are
+//! safe under CAS.
 //!
-//! It deliberately mints **no** fresh descendant seeds, so it does not on its own
-//! complete a read revoke: that fresh-seed republish is the
-//! [`cascade`](super::cascade)'s job. The sweep completes only epoch-lag
-//! convergence and the direct-child-scope index self-heal.
+//! # A scope root below its own floor is superseded, never repaired
+//!
+//! Rotations publish before they raise the floor, so `recordEpoch < floor` on a
+//! scope root cannot mean it lags — it means the name we asked at is not the
+//! current one. It resolves to a distinct [`SweepResolveFailure::Superseded`]
+//! verdict, routed through the scope-pointer consult (#38 D4) and re-resolved at
+//! the re-pointed `currentRootName`, failing closed if the fresh record is still
+//! below the floor. Admitting such a record would republish the scope's existing
+//! override seed at the current epoch — a revocation bypass, not a repair.
 //!
 //! # Completeness is fail-closed
 //!
-//! The work-list is computed purely from **published records** (epoch-lag
-//! predicate: record epoch `<` the scope's durable floor) — no pending-rotation
-//! store, job record, or checkpoint — so a re-run reconstructs the identical
-//! work-list and the pass is idempotent.
-//!
-//! A lagging descendant that cannot be enumerated, resolved, re-sealed, or
-//! published is **never silently skipped** — mirroring the eager-set walk's
-//! hard-abort posture ([`enumerate_eager_set`]), a pass aborts with a
-//! [`SweepError`] naming the offending scope rather than a partial "converged"
-//! claim. The one spec-mandated per-node exception is a **lost CAS race**: a
-//! concurrent write won the sequence CAS, so the loser drops it and re-resolves
-//! (blueprint/engine.md L276-278). The winner may be an ordinary metadata write
-//! (bumps the sequence without advancing the read epoch), so a dropped node is
-//! **not** proven converged by the drop alone — the idle-cadence driver
-//! ([`run_sweep`]) re-runs the idempotent pass until one drops nothing (or the
-//! cap is hit), which is what confirms convergence. Availability failures
-//! (unavailable resolve, transport `NotPublished`, floor-read) abort but are
-//! **retryable**; trust failures (a rejected record, a divergent ledger, an
-//! uncommitted signer) are fatal.
-//!
-//! # Determinism
-//!
-//! Time (the idle cadence) enters only through [`Scheduler`] and entropy only
-//! through [`Entropy`]; the sole impure edges are the injected [`SweepResolver`]
-//! and [`ScopeRootPublisher`] (CAS-publish), mirroring `rotate_scope`. The
-//! publisher is wired in [`crate::net::rotation`]; the resolver has no
-//! production implementation yet and tests fake it.
+//! The work-list is computed purely from published records, so a re-run
+//! reconstructs it identically. A node that cannot be resolved, re-sealed or
+//! published is never silently skipped: the pass aborts with a [`SweepError`]
+//! naming it. The one spec-mandated per-node exception is a **lost CAS race** —
+//! the loser drops the node and re-resolves, and since the winner may be an
+//! ordinary metadata write that does not advance the epoch, a drop is not proof
+//! of convergence; [`run_sweep`] re-runs until a pass drops nothing.
 
 use core::time::Duration;
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use zeroize::Zeroizing;
+use cipherbox_core::seal::{ChildScopeRef, PreservedFields, ReadBody};
 
-use cipherbox_core::seal::{ChildScopeRef, GrantLedgerEntry, GrantSetCommitment, SignedSealed};
-use cipherbox_core::suite::ecdsa::SIGNATURE_LEN as ECDSA_SIG_LEN;
-use cipherbox_core::suite::ed25519::Ed25519Signer;
-use cipherbox_core::suite::secret::SECRET_LEN;
-use cipherbox_core::suite::x25519::X25519Public;
-
-use super::eager_set::{ChildIndexResolver, EnumerationError, ResolveFailure, enumerate_eager_set};
-use super::reseal::{
-    CommittedSet, ResealError, ResealSeeds, ScopeRootIdentity, WriteHistory, reseal_scope_root,
-};
-use super::rotate::{ResealedScopeRoot, ScopeRootPublishError, ScopeRootPublisher};
-use crate::entropy::Entropy;
-use crate::gate::floor;
-use crate::grants::child_index::canonicalize;
-use crate::seams::{FloorStore, Scheduler, SeamError};
+use super::eager_set::ResolveFailure;
+use super::rotate::ScopeRootPublishError;
+use crate::grants::child_index::repair_observed;
+use crate::seams::Scheduler;
 use cipherbox_core::hex::lower as hex_lower;
 
-/// One scope root's current re-seal material, as resolved from its published
-/// record: everything [`reseal_scope_root`] needs **except** a self-identifying
-/// `scope_id`/`ipns_name`, plus the record epoch the epoch-lag predicate compares
-/// against the floor. The re-seal identity and CAS-publish destination run under
-/// the **enumerated** [`ChildScopeRef`] (`scope_id`/`ipns_name`) alone — the
-/// target carries no second copy for a network hint to diverge from.
-///
-/// Owns its secrets so the sweep is their terminal owner: the seed fields are
-/// [`Zeroizing`] and the pseudonym signer zeroizes on drop, so a resolved target
-/// wipes its key material when it leaves the work-list. The seeds are handed to
-/// `reseal_scope_root` **by borrow**; that callee never zeroes caller-owned
-/// buffers (AGENTS.md rule 7).
-pub struct SweepTarget {
-    /// The envelope format+suite version.
-    pub v: u64,
-    /// The published record's current read epoch — the epoch-lag operand.
+#[cfg(test)]
+pub(crate) mod sim;
+
+/// One node inside a scope, as the gated parent body named it. A node id locates
+/// nothing on its own — only a gated parent's read body binds it to a name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeRef {
+    /// The node id the parent's `ChildRef` carried.
+    pub node_id: [u8; 16],
+    /// That ref's opaque `ipnsName` bytes.
+    pub ipns_name: Vec<u8>,
+}
+
+/// The swept scope as its scope root's gated read found it. Carries no key
+/// material: re-sealing is the publisher's half of the seam, so the sweep never
+/// holds a seed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweptScope {
+    /// The scope root's published read epoch — the epoch every interior node is
+    /// measured against and re-sealed up to.
     pub current_read_epoch: u64,
-    /// The vault owner's X25519 encryption-subkey public (owner-blob recipient).
-    pub owner_enc_pub: X25519Public,
-    /// The parent node seed the ascent link derives from; `None` at the vault
-    /// root (which carries no ascent link).
-    pub parent_node_seed: Option<Zeroizing<[u8; SECRET_LEN]>>,
-    /// The owner-committed writer pseudonym signer (re-sealer identity).
-    pub pseudonym_signer: Ed25519Signer,
-    /// The scope's existing override (read scope) seed — reused verbatim; the
-    /// sweep mints no fresh seed.
-    pub override_seed: Zeroizing<[u8; SECRET_LEN]>,
-    /// The write-plane scope seed (unchanged by a read-plane sweep).
-    pub write_scope_seed: Zeroizing<[u8; SECRET_LEN]>,
-    /// The stable per-scope pointer read key carried in every grant blob.
-    pub pointer_read_key: Zeroizing<[u8; SECRET_LEN]>,
-    /// The write epoch (unchanged by a read-plane sweep).
-    pub write_epoch: u64,
-    /// The owner-signed, epoch-free commitment.
-    pub commitment: GrantSetCommitment,
-    /// The 64-byte compact ECDSA owner signature over `commitment`.
-    pub commitment_sig: [u8; ECDSA_SIG_LEN],
-    /// The authoritative grant ledger (one blob re-wrapped per entry).
-    pub grant_ledger: Vec<GrantLedgerEntry>,
-    /// The opaque write-plane history-link blob (carried through).
-    pub write_history_link: Vec<u8>,
-    /// This scope root's own direct-child-scope index — both the next-level
-    /// enumeration adjacency and the index the sweep self-heals on re-seal.
+    /// The scope root's own read-body children: the walk's level-1 frontier.
+    pub children: Vec<NodeRef>,
+    /// The committed direct-child-scope index — both the walk's scope-root
+    /// boundary set and the index the self-heal repairs (#38 D6).
     pub direct_child_scope_index: Vec<ChildScopeRef>,
-    /// The scope's existing per-epoch history links, oldest first. A sweep
-    /// appends none and prunes none — it re-signs them as they stand (see
-    /// [`reseal_scope_root`](super::reseal::reseal_scope_root)).
-    pub carried_history_links: Vec<SignedSealed>,
 }
 
-/// The impure edge that resolves a scope root's current re-seal material — the
-/// sweep's analogue of the eager-set walk's [`ChildIndexResolver`] and
-/// `rotate_scope`'s [`ScopeRootPublisher`]. Resolve + adoption-gate + unseal live
-/// behind this trait; the real network/gate wiring is not landed and tests fake
-/// it. A resolve either yields the full [`SweepTarget`] or a fail-closed
-/// [`ResolveFailure`] — a partial or gate-failing record is never a work-list
-/// entry.
+/// One interior node as the sweep's gated read found it. The body is carried
+/// forward verbatim — a sweep re-seals metadata only, and content bytes are
+/// never re-encrypted by any rotation path (#26 D6).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweptNode {
+    /// The published record's read epoch — the epoch-lag operand.
+    pub current_read_epoch: u64,
+    /// The node's unsealed read body.
+    pub read_body: ReadBody,
+    /// Top-level envelope fields a republish preserves byte-stable (#27 D10).
+    pub carried_unknown: PreservedFields,
+    /// `epochTag` fields a republish preserves byte-stable (#27 D10).
+    pub carried_epoch_tag_unknown: PreservedFields,
+}
+
+/// What the walk found at one child of a swept node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SweptChild {
+    /// An ordinary interior node: sweepable, and descended into.
+    Interior(SweptNode),
+    /// The child's record is a **scope root**, carrying the name the resolver
+    /// gated it current at. The walk stops here, and — when the scope's index
+    /// does not name it — repairs the index with this name (#38 D6).
+    ScopeRoot(ChildScopeRef),
+}
+
+/// Why a sweep read could not be authoritatively completed.
+///
+/// [`Superseded`](Self::Superseded) is the third verdict ADR 0003 adds: a scope
+/// root below its own read-epoch floor is neither a trust violation the caller
+/// must not retry nor a transport stall, but a stale name — routed through the
+/// pointer consult.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepResolveFailure {
+    /// The record failed the adoption gate — a fail-closed trust violation,
+    /// never mere staleness.
+    Rejected,
+    /// The record could not be fetched or read — host I/O or availability.
+    Unavailable,
+    /// A scope root's record sits below its own durable read-epoch floor.
+    Superseded,
+}
+
+impl From<ResolveFailure> for SweepResolveFailure {
+    fn from(failure: ResolveFailure) -> Self {
+        match failure {
+            ResolveFailure::Unavailable => Self::Unavailable,
+            ResolveFailure::Rejected | ResolveFailure::ConflictingChildLabel => Self::Rejected,
+        }
+    }
+}
+
+impl core::fmt::Display for SweepResolveFailure {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Rejected => f.write_str("record rejected by adoption gate"),
+            Self::Unavailable => f.write_str("record unavailable"),
+            Self::Superseded => f.write_str("scope root superseded: record below its own floor"),
+        }
+    }
+}
+
+impl SweepResolveFailure {
+    /// Whether re-running the pass could clear this — availability only. A
+    /// rejection is a trust violation, and a `Superseded` that survives the
+    /// consult means the re-pointed record is below the floor too.
+    fn is_retryable(self) -> bool {
+        matches!(self, Self::Unavailable)
+    }
+}
+
+/// The read edge the sweep runs on: resolve + adoption-gate + unseal. The owner
+/// arm is [`crate::net::rotation::OwnerRotationNet`].
+///
+/// # Binding contract (obligation on the real resolver)
+///
+/// Every record is gated under the **caller's own label** — the `scope_id` /
+/// `node_id` the gated parent body named it by — so a record claiming another
+/// identity is a transplant it rejects. No self-identifying id is returned; the
+/// caller's ref stays the sole identity authority.
 pub trait SweepResolver {
-    /// Resolve `scope`'s current re-seal material, or a fail-closed
-    /// [`ResolveFailure`] if its record cannot be authoritatively obtained.
-    ///
-    /// One resolve returns the whole [`SweepTarget`] — enumeration/lag fields
-    /// *and* the heavy re-seal material. Splitting it into a light enumeration
-    /// edge plus a heavy re-seal edge fetched only for lagging nodes is a
-    /// designed-for optimization, not a correctness requirement.
-    ///
-    /// # Binding contract (obligation on the real resolver)
-    ///
-    /// The same edge discipline [`ChildIndexResolver`] carries applies: gate
-    /// `scope`'s record under the enumerated `scope.scope_id`/`scope.ipns_name`,
-    /// with `commitment.ipns_name` equal to `scope.ipns_name`, and return **no**
-    /// self-identifying ids (see [`SweepTarget`]).
-    async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure>;
+    /// Gate `scope`'s scope root and yield the scope's current sweep state.
+    async fn resolve_scope(&self, scope: &ChildScopeRef)
+    -> Result<SweptScope, SweepResolveFailure>;
+
+    /// The scope's `currentRootName` from its owner-signed scope pointer
+    /// (#38 D4). `None` means the scope has never been re-pointed, so there is
+    /// no fresher name to re-resolve at.
+    async fn consult_pointer(
+        &self,
+        scope_id: &[u8; 16],
+    ) -> Result<Option<Vec<u8>>, SweepResolveFailure>;
+
+    /// Resolve one child of a node already swept in this scope, at whatever
+    /// epoch its record carries.
+    async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure>;
 }
 
-/// A completed sweep pass. Every reachable descendant is accounted for in exactly
-/// one bucket — the fail-closed guarantee made observable: nothing is silently
-/// dropped. (A pass that could not account for a node returns [`SweepError`]
-/// instead of an outcome.)
+/// One interior node being advanced to its scope's current epoch. The publisher
+/// re-seals the carried body under the node's current read key and CAS-publishes
+/// it; the sweep hands over no key material.
+pub struct LaggingNode<'a> {
+    /// The node id, as the gated parent body named it.
+    pub node_id: [u8; 16],
+    /// That parent ref's opaque `ipnsName` bytes — the publish destination.
+    pub ipns_name: &'a [u8],
+    /// The scope's current read epoch: what the node is re-sealed up to.
+    pub read_epoch: u64,
+    /// The body carried forward verbatim.
+    pub read_body: &'a ReadBody,
+    /// Envelope fields a republish preserves byte-stable (#27 D10).
+    pub carried_unknown: &'a PreservedFields,
+    /// `epochTag` fields a republish preserves byte-stable (#27 D10).
+    pub carried_epoch_tag_unknown: &'a PreservedFields,
+}
+
+/// The write edge the sweep runs on. Both methods are register-first CAS
+/// publishes; `Ok` means the record is durably the freshest at its name.
+pub trait SweepPublisher {
+    /// Re-seal `node`'s carried body at `node.read_epoch` and CAS-publish it.
+    async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError>;
+
+    /// Republish `scope`'s scope root carrying `index` as its
+    /// `directChildScopeIndex` — the #38 D6 self-heal. Metadata-only: the
+    /// scope's existing seed at its current epoch, minting no seed, epoch or
+    /// history link.
+    async fn repair_child_scope_index(
+        &self,
+        scope: &ChildScopeRef,
+        index: &[ChildScopeRef],
+    ) -> Result<(), ScopeRootPublishError>;
+}
+
+/// A completed sweep pass. Every node the walk reached is accounted for in
+/// exactly one bucket — the fail-closed guarantee made observable.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SweepOutcome {
-    /// Descendants that lagged and were re-sealed up to the floor this pass.
+    /// Interior nodes that lagged and were re-sealed to the scope's epoch.
     pub converged: Vec<[u8; 16]>,
-    /// Descendants already at or above the floor — no re-seal, a no-op.
+    /// Interior nodes already at the scope's epoch — no re-seal, a no-op.
     pub already_converged: Vec<[u8; 16]>,
-    /// Descendants dropped because a concurrent writer won the CAS race; a
-    /// fresher record for them already landed, so they re-resolve as converged.
+    /// Interior nodes dropped because a concurrent writer won the CAS race.
     pub dropped_lost_race: Vec<[u8; 16]>,
-    /// Descendants whose stored direct-child-scope index was non-canonical and
-    /// was repaired (canonicalized) on re-seal **and durably published** — the
-    /// index self-heal, surfaced to the host (#38 D6 "repaired and flagged"). A
-    /// repair that loses the CAS is not flagged (it never landed).
+    /// Descendant scope roots the walk stopped at: eager-set members the cascade
+    /// rotates, never swept.
+    pub skipped_scope_roots: Vec<[u8; 16]>,
+    /// Scope roots the walk encountered that were missing from the scope's
+    /// direct-child-scope index, repaired into it and **durably published** —
+    /// "repaired and flagged" (#38 D6). A repair that loses the CAS is not
+    /// flagged; it never landed.
     pub flagged_indexes: Vec<[u8; 16]>,
 }
 
-/// A fail-closed sweep failure. A pass returns this rather than a partial
-/// [`SweepOutcome`] whenever it cannot prove every reachable descendant
-/// converged — the completeness guarantee. [`SweepError::is_retryable`]
-/// distinguishes an availability stall (the idle-cadence driver re-runs) from a
-/// trust violation (fatal).
+/// A fail-closed sweep failure, returned instead of a partial [`SweepOutcome`]
+/// whenever the pass cannot account for every node the walk reached.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SweepError {
-    /// The eager set could not be enumerated — a reachable descendant's index
-    /// was unobtainable, so the work-list is not provably complete.
-    Enumeration(EnumerationError),
-    /// Reading the durable epoch floor failed (host I/O). Availability, retryable.
-    Floor(SeamError),
-    /// Re-sealing a lagging descendant failed a trust invariant (divergent
-    /// ledger, uncommitted signer, unusable recipient key). Fatal.
-    Reseal {
-        /// The scope that could not be legitimately re-sealed.
+    /// The scope root could not be authoritatively resolved — including a
+    /// `Superseded` verdict the pointer consult could not clear.
+    Scope {
+        /// The scope whose root could not be resolved.
         scope_id: [u8; 16],
-        /// The underlying re-seal rejection.
-        error: ResealError,
+        /// Why the resolve failed.
+        reason: SweepResolveFailure,
     },
-    /// A re-sealed record could not be published; nothing landed for that node.
-    /// Retryable only when the publish failure is (see
-    /// [`ScopeRootPublishError::is_retryable`]).
+    /// A reachable node could not be authoritatively resolved.
+    Node {
+        /// The node that could not be resolved.
+        node_id: [u8; 16],
+        /// Why the resolve failed.
+        reason: SweepResolveFailure,
+    },
+    /// A re-sealed interior node could not be published; nothing landed for it.
     Publish {
-        /// The scope whose record did not land.
-        scope_id: [u8; 16],
+        /// The node whose record did not land.
+        node_id: [u8; 16],
         /// The publish failure (never [`ScopeRootPublishError::LostRace`] — a
-        /// lost race is not an error, it drops and re-resolves).
+        /// lost race drops the node and re-resolves).
+        error: ScopeRootPublishError,
+    },
+    /// The repaired direct-child-scope index could not be published.
+    IndexRepair {
+        /// The scope whose index repair did not land.
+        scope_id: [u8; 16],
+        /// The publish failure.
         error: ScopeRootPublishError,
     },
 }
@@ -199,16 +264,24 @@ pub enum SweepError {
 impl core::fmt::Display for SweepError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            SweepError::Enumeration(e) => write!(f, "sweep enumeration incomplete: {e}"),
-            SweepError::Floor(e) => write!(f, "sweep epoch-floor read failed: {e}"),
-            SweepError::Reseal { scope_id, error } => write!(
+            SweepError::Scope { scope_id, reason } => write!(
                 f,
-                "sweep re-seal of scope [{}] rejected: {error}",
+                "sweep scope-root resolve of [{}] failed: {reason}",
                 hex_lower(scope_id)
             ),
-            SweepError::Publish { scope_id, error } => write!(
+            SweepError::Node { node_id, reason } => write!(
                 f,
-                "sweep publish of scope [{}] failed: {error}",
+                "sweep resolve of node [{}] failed: {reason}",
+                hex_lower(node_id)
+            ),
+            SweepError::Publish { node_id, error } => write!(
+                f,
+                "sweep publish of node [{}] failed: {error}",
+                hex_lower(node_id)
+            ),
+            SweepError::IndexRepair { scope_id, error } => write!(
+                f,
+                "sweep index repair of scope [{}] failed: {error}",
                 hex_lower(scope_id)
             ),
         }
@@ -221,195 +294,230 @@ impl SweepError {
     /// A stable, key-material-free classification name (host/log facing).
     pub fn check(&self) -> &'static str {
         match self {
-            SweepError::Enumeration(_) => "enumeration-incomplete",
-            SweepError::Floor(_) => "floor-read-failed",
-            SweepError::Reseal { .. } => "reseal-rejected",
+            SweepError::Scope { .. } => "scope-root-unresolved",
+            SweepError::Node { .. } => "node-unresolved",
             SweepError::Publish { .. } => "publish-failed",
+            SweepError::IndexRepair { .. } => "index-repair-failed",
         }
     }
 
     /// Whether re-running the idempotent pass could clear this failure — an
-    /// availability stall (unavailable resolve, floor-read I/O, transport
-    /// not-published) or a C2 label conflict that the re-point wave repairs —
-    /// versus a trust violation (a gate-rejected record, a divergent ledger /
-    /// uncommitted signer), which no retry can fix.
+    /// availability stall — versus a trust violation, which no retry can fix.
     pub fn is_retryable(&self) -> bool {
         match self {
-            SweepError::Enumeration(e) => matches!(
-                e.reason,
-                ResolveFailure::Unavailable | ResolveFailure::ConflictingChildLabel
-            ),
-            SweepError::Floor(_) => true,
-            SweepError::Publish { error, .. } => error.is_retryable(),
-            SweepError::Reseal { .. } => false,
+            SweepError::Scope { reason, .. } | SweepError::Node { reason, .. } => {
+                reason.is_retryable()
+            }
+            SweepError::Publish { error, .. } | SweepError::IndexRepair { error, .. } => {
+                error.is_retryable()
+            }
         }
     }
 }
 
-/// Adapts a [`SweepResolver`] to the eager-set walk's [`ChildIndexResolver`] and
-/// caches each resolved [`SweepTarget`], so enumeration resolves every descendant
-/// exactly once and the convergence pass reuses those targets (no double
-/// resolve, no resolve/re-seal TOCTOU within a pass).
-struct WalkAdapter<'a, R: SweepResolver> {
-    resolver: &'a R,
-    cache: RefCell<HashMap<[u8; 16], SweepTarget>>,
-}
-
-impl<'a, R: SweepResolver> WalkAdapter<'a, R> {
-    fn new(resolver: &'a R) -> Self {
-        Self {
-            resolver,
-            cache: RefCell::new(HashMap::new()),
+/// Sort by node id and drop repeats, so the frontier — and thus the pass's
+/// publish order — is independent of the order a parent body listed its
+/// children in.
+fn canonicalize_frontier(mut nodes: Vec<NodeRef>) -> Vec<NodeRef> {
+    nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+    let mut seen: Option<[u8; 16]> = None;
+    nodes.retain(|node| {
+        if seen == Some(node.node_id) {
+            false
+        } else {
+            seen = Some(node.node_id);
+            true
         }
+    });
+    nodes
+}
+
+/// The in-scope children a swept body names.
+fn body_children(body: &ReadBody) -> Vec<NodeRef> {
+    match body {
+        ReadBody::Folder { children, .. } => children
+            .iter()
+            .map(|child| NodeRef {
+                node_id: child.id,
+                ipns_name: child.ipns_name.clone(),
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
-impl<R: SweepResolver> ChildIndexResolver for WalkAdapter<'_, R> {
-    async fn direct_child_index(
-        &self,
-        child: &ChildScopeRef,
-    ) -> Result<Vec<ChildScopeRef>, ResolveFailure> {
-        let target = self.resolver.resolve(child).await?;
-        let adjacency = target.direct_child_scope_index.clone();
-        // Borrow only after the await completes — never across a suspend point.
-        self.cache.borrow_mut().insert(child.scope_id, target);
-        Ok(adjacency)
+/// Resolve `scope`'s root, routing a [`SweepResolveFailure::Superseded`] verdict
+/// through the pointer consult and re-resolving at the re-pointed
+/// `currentRootName`. Returns the ref the scope resolved current at, which is
+/// the only name a repair may write into an index.
+async fn resolve_scope_current<R: SweepResolver>(
+    resolver: &R,
+    scope: &ChildScopeRef,
+) -> Result<(ChildScopeRef, SweptScope), SweepResolveFailure> {
+    match resolver.resolve_scope(scope).await {
+        Ok(swept) => Ok((scope.clone(), swept)),
+        Err(SweepResolveFailure::Superseded) => {
+            let repointed = repointed_ref(resolver, scope).await?;
+            // One consult, one re-resolve: a fresh record still below the floor
+            // fails closed here rather than consulting again.
+            let swept = resolver.resolve_scope(&repointed).await?;
+            Ok((repointed, swept))
+        }
+        Err(other) => Err(other),
     }
 }
 
-/// Run one idempotent sweep pass over the eager set rooted at `root_scope_id`
-/// (whose level-1 adjacency is the caller-held `root_child_index`, e.g. the
-/// just-cut root's write-body index).
+/// Resolve one child, routing the same superseded verdict through the consult.
+/// Returns the ref the child resolved current at.
+async fn resolve_child_current<R: SweepResolver>(
+    resolver: &R,
+    child: &NodeRef,
+) -> Result<(NodeRef, SweptChild), SweepResolveFailure> {
+    match resolver.resolve_child(child).await {
+        Ok(found) => Ok((child.clone(), found)),
+        Err(SweepResolveFailure::Superseded) => {
+            let scope = ChildScopeRef::new(child.node_id, child.ipns_name.clone());
+            let repointed = repointed_ref(resolver, &scope).await?;
+            let node = NodeRef {
+                node_id: child.node_id,
+                ipns_name: repointed.ipns_name,
+            };
+            let found = resolver.resolve_child(&node).await?;
+            Ok((node, found))
+        }
+        Err(other) => Err(other),
+    }
+}
+
+/// The scope's `currentRootName` from its pointer. A scope with no pointer has
+/// no fresher name, so the below-floor record is refused as it stands.
+async fn repointed_ref<R: SweepResolver>(
+    resolver: &R,
+    scope: &ChildScopeRef,
+) -> Result<ChildScopeRef, SweepResolveFailure> {
+    let current = resolver
+        .consult_pointer(&scope.scope_id)
+        .await?
+        .ok_or(SweepResolveFailure::Superseded)?;
+    Ok(ChildScopeRef::new(scope.scope_id, current))
+}
+
+/// Run one idempotent sweep pass over `scope`'s interior nodes.
 ///
-/// Enumerates the eager set fail-closed via [`enumerate_eager_set`], then for
-/// each descendant scope root whose current record epoch lags its durable epoch
-/// floor, re-seals its metadata up to the floor epoch through
-/// [`reseal_scope_root`] with the scope's **existing** seed and **`prev = None`**
-/// (no fresh seed, no epoch bump, no new history link), CAS-publishes it, and
-/// self-heals its direct-child-scope index. Returns a complete [`SweepOutcome`]
-/// or a fail-closed [`SweepError`] — never a partial convergence claim.
-pub async fn sweep_pass<E, F, R, P>(
-    entropy: &mut E,
-    floors: &F,
+/// Resolves the scope root (consulting the pointer on a superseded verdict),
+/// walks its read body stopping at every scope-root boundary, self-heals the
+/// direct-child-scope index from the walk result, and re-seals every node whose
+/// epoch lags the scope's. Returns a complete [`SweepOutcome`] or a fail-closed
+/// [`SweepError`] — never a partial convergence claim.
+pub async fn sweep_pass<R, P>(
     resolver: &R,
     publisher: &P,
-    root_scope_id: [u8; 16],
-    root_child_index: &[ChildScopeRef],
+    scope: &ChildScopeRef,
 ) -> Result<SweepOutcome, SweepError>
 where
-    E: Entropy,
-    F: FloorStore,
     R: SweepResolver,
-    P: ScopeRootPublisher,
+    P: SweepPublisher,
 {
-    let adapter = WalkAdapter::new(resolver);
-    let eager_set = enumerate_eager_set(root_scope_id, root_child_index, &adapter)
+    let (scope_ref, swept) = resolve_scope_current(resolver, scope)
         .await
-        .map_err(SweepError::Enumeration)?;
-    let mut cache = adapter.cache.into_inner();
+        .map_err(|reason| SweepError::Scope {
+            scope_id: scope.scope_id,
+            reason,
+        })?;
+
+    let boundaries: BTreeSet<[u8; 16]> = swept
+        .direct_child_scope_index
+        .iter()
+        .map(|child| child.scope_id)
+        .collect();
 
     let mut outcome = SweepOutcome::default();
+    // Keyed by node id: the walk resolves each node once, so a diamond or a
+    // corrupt back-edge terminates rather than looping.
+    let mut visited: BTreeSet<[u8; 16]> = BTreeSet::new();
+    visited.insert(scope_ref.scope_id);
+    // Scope roots the walk met that the index does not name (#38 D6), at the
+    // name each resolved current at.
+    let mut omitted: BTreeMap<[u8; 16], ChildScopeRef> = BTreeMap::new();
+    let mut lagging: Vec<(NodeRef, SweptNode)> = Vec::new();
 
-    for descendant in eager_set.descendants() {
-        let scope_id = descendant.scope_id;
-        // Enumeration resolves and caches every descendant before it can appear in
-        // `descendants()` (the walk aborts on the first unresolvable node), so the
-        // cache is 1:1 with the eager set — a miss is an internal invariant break,
-        // never adversarial input.
-        let target = cache
-            .remove(&scope_id)
-            .expect("every enumerated descendant was resolved into the cache");
-
-        // Epoch-lag predicate, computed purely from published state: a node lags
-        // when its record epoch is below its scope's durable floor. No floor (or
-        // a record at/above it) means nothing to converge.
-        let durable = floor::read_epoch_floor(floors, &scope_id)
-            .await
-            .map_err(SweepError::Floor)?;
-        let Some(floor_epoch) = durable else {
-            outcome.already_converged.push(scope_id);
-            continue;
-        };
-        if target.current_read_epoch >= floor_epoch {
-            outcome.already_converged.push(scope_id);
-            continue;
-        }
-
-        // Index self-heal: re-publish the direct-child-scope index in canonical,
-        // deduplicated form; flag the node when the stored index needed repair
-        // (#38 D6 "repaired and flagged"). The heal rides the re-seal, so it
-        // reaches only nodes being re-sealed this pass — a converged node's index
-        // heals on its next ordinary write ("ordinary writes advance it for free").
-        let canonical_index = canonicalize(&target.direct_child_scope_index);
-        // Flagged only after the canonical index durably publishes below — a
-        // repair that loses the CAS never landed, so it must not be reported
-        // (fail-closed, symmetric with `converged`).
-        let index_repaired = canonical_index != target.direct_child_scope_index;
-
-        let identity = ScopeRootIdentity {
-            v: target.v,
-            scope_id,
-            // The enumerated ChildScopeRef is the sole identity authority
-            // (see SweepTarget).
-            ipns_name: &descendant.ipns_name,
-            owner_enc_pub: &target.owner_enc_pub,
-            // A sweep runs for a write-grantee as readily as for the owner, and a
-            // resolved target carries the owner's public half only.
-            owner_enc_secret: None,
-            parent_node_seed: target.parent_node_seed.as_deref(),
-            pseudonym_signer: &target.pseudonym_signer,
-        };
-        let seeds = ResealSeeds {
-            override_seed: &target.override_seed,
-            read_epoch: floor_epoch,
-            // The catch-up mints no new epoch, so no fresh history link.
-            prev: None,
-            write_scope_seed: &target.write_scope_seed,
-            write_epoch: target.write_epoch,
-            write_history: WriteHistory::Carried(&target.write_history_link),
-            pointer_read_key: &target.pointer_read_key,
-        };
-        let committed = CommittedSet {
-            commitment: &target.commitment,
-            commitment_sig: &target.commitment_sig,
-            grant_ledger: &target.grant_ledger,
-            direct_child_scope_index: &canonical_index,
-        };
-
-        let section = reseal_scope_root(
-            entropy,
-            &identity,
-            &seeds,
-            &committed,
-            &target.carried_history_links,
-        )
-        .map_err(|error| SweepError::Reseal { scope_id, error })?;
-
-        let record = ResealedScopeRoot {
-            scope_id,
-            ipns_name: descendant.ipns_name.clone(),
-            read_epoch: floor_epoch,
-            write_epoch: target.write_epoch,
-            section,
-        };
-
-        match publisher.publish_scope_root(&record).await {
-            Ok(()) => {
-                outcome.converged.push(scope_id);
-                if index_repaired {
-                    outcome.flagged_indexes.push(scope_id);
+    let mut frontier = canonicalize_frontier(swept.children);
+    while !frontier.is_empty() {
+        let mut next: Vec<NodeRef> = Vec::new();
+        for child in &frontier {
+            if !visited.insert(child.node_id) {
+                continue;
+            }
+            if boundaries.contains(&child.node_id) {
+                outcome.skipped_scope_roots.push(child.node_id);
+                continue;
+            }
+            let (resolved, found) =
+                resolve_child_current(resolver, child)
+                    .await
+                    .map_err(|reason| SweepError::Node {
+                        node_id: child.node_id,
+                        reason,
+                    })?;
+            match found {
+                SweptChild::ScopeRoot(scope_root) => {
+                    outcome.skipped_scope_roots.push(child.node_id);
+                    omitted.insert(child.node_id, scope_root);
+                }
+                SweptChild::Interior(node) => {
+                    next.extend(body_children(&node.read_body));
+                    if node.current_read_epoch >= swept.current_read_epoch {
+                        outcome.already_converged.push(child.node_id);
+                    } else {
+                        lagging.push((resolved, node));
+                    }
                 }
             }
-            // A concurrent write won the sequence CAS: no clobber, and this pass
-            // does not advance the node. The single spec-mandated non-abort
-            // per-node path — but the winner may be a non-advancing ordinary
-            // write, so the node is not proven converged; `run_sweep` re-resolves
-            // it until a pass drops nothing.
-            Err(ScopeRootPublishError::LostRace) => outcome.dropped_lost_race.push(scope_id),
-            // Nothing landed: fail-closed rather than mark the node converged.
-            // Whether the idle-cadence driver re-runs is `is_retryable`'s call.
+        }
+        frontier = canonicalize_frontier(next);
+    }
+
+    // The self-heal runs on the walk result, before any epoch comparison is
+    // acted on, so it lands whether or not this pass re-seals a node (#38 D6,
+    // ADR 0003 D3).
+    if !omitted.is_empty() {
+        let mut index = swept.direct_child_scope_index.clone();
+        for scope_root in omitted.values() {
+            index = repair_observed(&index, scope_root.clone());
+        }
+        match publisher.repair_child_scope_index(&scope_ref, &index).await {
+            Ok(()) => outcome.flagged_indexes.extend(omitted.keys().copied()),
+            // Never landed, so never flagged; the next pass re-derives it.
+            Err(ScopeRootPublishError::LostRace) => {}
             Err(error) => {
-                return Err(SweepError::Publish { scope_id, error });
+                return Err(SweepError::IndexRepair {
+                    scope_id: scope_ref.scope_id,
+                    error,
+                });
+            }
+        }
+    }
+
+    for (node, swept_node) in &lagging {
+        let lagging_node = LaggingNode {
+            node_id: node.node_id,
+            ipns_name: &node.ipns_name,
+            read_epoch: swept.current_read_epoch,
+            read_body: &swept_node.read_body,
+            carried_unknown: &swept_node.carried_unknown,
+            carried_epoch_tag_unknown: &swept_node.carried_epoch_tag_unknown,
+        };
+        match publisher.publish_node(&lagging_node).await {
+            Ok(()) => outcome.converged.push(node.node_id),
+            // The one spec-mandated non-abort per-node path. The winner may be a
+            // non-advancing ordinary write, so the node is not proven converged;
+            // `run_sweep` re-resolves it until a pass drops nothing.
+            Err(ScopeRootPublishError::LostRace) => outcome.dropped_lost_race.push(node.node_id),
+            Err(error) => {
+                return Err(SweepError::Publish {
+                    node_id: node.node_id,
+                    error,
+                });
             }
         }
     }
@@ -417,70 +525,41 @@ where
     Ok(outcome)
 }
 
-/// Drive the sweep as an idle-cadence job: run [`sweep_pass`] and re-run it,
-/// one `cadence` sleep apart via the [`Scheduler`] seam, until a pass both
-/// succeeds **and** drops nothing to a lost race — the point convergence is
-/// actually confirmed — or the `max_passes` cap is hit. A **retryable**
-/// availability stall re-runs; a **lost CAS race** re-runs (the winner may be a
-/// non-advancing write, so a drop is not proof of convergence); a **trust
-/// failure** returns immediately.
+/// Drive the sweep as an idle-cadence job: run [`sweep_pass`] and re-run it, one
+/// `cadence` sleep apart via the [`Scheduler`] seam, until a pass both succeeds
+/// **and** drops nothing to a lost race — the point convergence is actually
+/// confirmed — or the `max_passes` cap is hit. A retryable availability stall
+/// re-runs; a trust failure returns immediately.
 ///
-/// Returns `Ok` on the first fully-converged pass. On cap exhaustion it returns
-/// the last availability `Err`, or — if the final pass merely still had lost-race
-/// drops — `Ok` with those scopes surfaced in
+/// On cap exhaustion it returns the last availability `Err`, or — if the final
+/// pass merely still had lost-race drops — `Ok` with those nodes surfaced in
 /// [`SweepOutcome::dropped_lost_race`], so a host racing a persistently hot
 /// writer sees the residual rather than a false "complete".
 ///
 /// # Caller contract
 ///
 /// An `Ok` outcome is convergence-complete **only when
-/// [`SweepOutcome::dropped_lost_race`] is empty** — a caller that retires the
-/// sweep job must inspect that bucket, not just `is_ok()`, and re-enqueue on a
-/// non-empty residual. The returned outcome reflects the **final** pass;
-/// `converged`/`flagged_indexes` from earlier passes are durable on the network
-/// but are not aggregated into it.
-///
-/// Scheduling is engineering judgment (blueprint/engine.md L275-278): the cadence
-/// and attempt cap are the host's, injected here; time enters only through the
-/// scheduler seam so the harness runs multi-tick timelines in virtual time.
-// The determinism law keeps entropy, time, and the two network edges as separate
-// injected seams.
-#[allow(clippy::too_many_arguments)]
-pub async fn run_sweep<E, F, S, R, P>(
-    entropy: &mut E,
-    floors: &F,
+/// [`SweepOutcome::dropped_lost_race`] is empty**. The returned outcome reflects
+/// the **final** pass; earlier passes' work is durable on the network but is not
+/// aggregated into it.
+pub async fn run_sweep<S, R, P>(
     scheduler: &S,
     resolver: &R,
     publisher: &P,
-    root_scope_id: [u8; 16],
-    root_child_index: &[ChildScopeRef],
+    scope: &ChildScopeRef,
     cadence: Duration,
     max_passes: u32,
 ) -> Result<SweepOutcome, SweepError>
 where
-    E: Entropy,
-    F: FloorStore,
     S: Scheduler,
     R: SweepResolver,
-    P: ScopeRootPublisher,
+    P: SweepPublisher,
 {
     let mut attempts = 0u32;
     loop {
         attempts += 1;
-        match sweep_pass(
-            entropy,
-            floors,
-            resolver,
-            publisher,
-            root_scope_id,
-            root_child_index,
-        )
-        .await
-        {
-            // Fully converged: the pass succeeded and lost no race.
+        match sweep_pass(resolver, publisher, scope).await {
             Ok(outcome) if outcome.dropped_lost_race.is_empty() => return Ok(outcome),
-            // A lost race leaves those nodes unproven-converged; re-resolve on the
-            // next cadence. On cap exhaustion, surface the residual drops.
             Ok(outcome) => {
                 if attempts >= max_passes {
                     return Ok(outcome);
@@ -497,861 +576,443 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::sim::{FakeNet, id, name, scope_ref};
     use super::*;
     use crate::seams::UnixMillis;
-    use crate::testkit::fakes::{InMemoryFloorStore, VirtualScheduler};
-    use crate::testkit::{SeededEntropy, block_on};
-    use cipherbox_core::seal::{
-        AadContext, GrantSetCommitment, GrantSetEntry, Permission, PreservedFields,
-        STRUCT_TAG_OWNER_BLOB, open_owner_blob, sign_grant_set,
-    };
-    use cipherbox_core::suite::ecdsa::EcdsaSigner;
-    use cipherbox_core::suite::secret::ct_eq;
-    use cipherbox_core::suite::x25519::X25519Secret;
-    use std::rc::Rc;
+    use crate::testkit::block_on;
+    use crate::testkit::fakes::VirtualScheduler;
 
-    const V: u64 = 2;
-
-    fn sid(byte: u8) -> [u8; 16] {
-        [byte; 16]
+    fn run(net: &FakeNet, root: u8) -> Result<SweepOutcome, SweepError> {
+        block_on(sweep_pass(net, net, &scope_ref(root)))
     }
 
-    fn childref(byte: u8) -> ChildScopeRef {
-        ChildScopeRef::new(sid(byte), format!("ipns-{byte:02x}").into_bytes())
-    }
+    // --- The epoch-lag predicate over interior nodes ---
 
-    /// The one vault owner/pseudonym identity every scope in a scenario commits
-    /// to (so `reseal_scope_root`'s signer + committed-ledger guards pass).
-    struct Owner {
-        enc: X25519Secret,
-        pseudonym: Ed25519Signer,
-        ecdsa: EcdsaSigner,
-        grantee: X25519Secret,
-    }
+    #[test]
+    fn an_interior_node_behind_the_scope_epoch_is_resealed_to_it() {
+        // scope root (epoch 5) -> A(01)@1 -> B(02)@1. Both interior nodes lag.
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[0x02])
+            .node(0x02, 1, &[]);
 
-    impl Owner {
-        fn new() -> Self {
-            Self {
-                enc: X25519Secret::from_scalar([0x11; 32]),
-                pseudonym: Ed25519Signer::from_seed([0x22; 32]),
-                ecdsa: EcdsaSigner::from_scalar(&[0x33; 32]).unwrap(),
-                grantee: X25519Secret::from_scalar([0x77; 32]),
-            }
-        }
-    }
-
-    /// The immutable per-scope material a scope root resolves to, plus the
-    /// mutable current epoch and any injected CAS fault. Shared across the
-    /// resolver and publisher so a publish advances what a re-resolve observes —
-    /// the "network".
-    struct NetScope {
-        override_seed: [u8; 32],
-        write_scope_seed: [u8; 32],
-        pointer_read_key: [u8; 32],
-        parent_node_seed: Option<[u8; 32]>,
-        commitment: GrantSetCommitment,
-        commitment_sig: [u8; ECDSA_SIG_LEN],
-        grant_ledger: Vec<GrantLedgerEntry>,
-        children: Vec<ChildScopeRef>,
-        current_epoch: u64,
-        fault: Option<ScopeRootPublishError>,
-        /// A countdown of self-healing `NotPublished` failures — the next `n`
-        /// publishes fail, then the node heals (drives the retry driver).
-        fail_next: u32,
-        /// A countdown of `LostRace` losses that do **not** advance the epoch —
-        /// models a non-advancing ordinary writer winning the sequence CAS, so a
-        /// drop does not converge the node until the sweep finally wins.
-        lost_race_next: u32,
-        publishes: u32,
-    }
-
-    /// A fake resolver + publisher over one shared scope map — the sweep's fake
-    /// "network". A publish updates `current_epoch` so a re-resolve converges;
-    /// an injected `fault` scripts a lost race or a not-published stall.
-    #[derive(Clone)]
-    struct FakeNet {
-        owner: Rc<Owner>,
-        scopes: Rc<RefCell<HashMap<[u8; 16], NetScope>>>,
-        /// Scopes the resolver should fail (forged/unavailable subtree).
-        resolve_faults: Rc<RefCell<HashMap<[u8; 16], ResolveFailure>>>,
-    }
-
-    impl FakeNet {
-        fn new() -> Self {
-            Self {
-                owner: Rc::new(Owner::new()),
-                scopes: Rc::new(RefCell::new(HashMap::new())),
-                resolve_faults: Rc::new(RefCell::new(HashMap::new())),
-            }
-        }
-
-        /// Register a scope root: one read grant to the shared grantee, `children`
-        /// as its direct-child index, published at `current_epoch`.
-        fn scope(self, byte: u8, current_epoch: u64, children: &[u8]) -> Self {
-            self.scope_with_index(byte, current_epoch, children, false)
-        }
-
-        /// As [`Self::scope`] but optionally seeds a *non-canonical* stored index
-        /// (a duplicate child) to exercise the self-heal.
-        fn scope_with_index(
-            self,
-            byte: u8,
-            current_epoch: u64,
-            children: &[u8],
-            non_canonical: bool,
-        ) -> Self {
-            let tag = [byte.wrapping_add(0xa0); 32];
-            let commitment = GrantSetCommitment {
-                ipns_name: format!("ipns-{byte:02x}").into_bytes(),
-                owner_pseudonym_pk: self.owner.pseudonym.verifying_key().to_bytes(),
-                entries: vec![GrantSetEntry::new(tag, Permission::Read, [0x02; 32])],
-                unknown: PreservedFields::new(),
-            };
-            let commitment_sig = sign_grant_set(&self.owner.ecdsa, &commitment)
-                .unwrap()
-                .to_compact();
-            let grant_ledger = vec![GrantLedgerEntry::new(
-                [0x02; 33],
-                self.owner.grantee.public().to_bytes(),
-                Permission::Read,
-                tag,
-            )];
-            let mut index: Vec<ChildScopeRef> = children.iter().map(|b| childref(*b)).collect();
-            if non_canonical {
-                // A duplicate scope_id: canonicalize() drops it → flagged.
-                if let Some(first) = children.first() {
-                    index.push(ChildScopeRef::new(sid(*first), b"dup".to_vec()));
-                }
-            }
-            self.scopes.borrow_mut().insert(
-                sid(byte),
-                NetScope {
-                    override_seed: [byte; 32],
-                    write_scope_seed: [byte.wrapping_add(1); 32],
-                    pointer_read_key: [byte.wrapping_add(2); 32],
-                    parent_node_seed: Some([byte.wrapping_add(3); 32]),
-                    commitment,
-                    commitment_sig,
-                    grant_ledger,
-                    children: index,
-                    current_epoch,
-                    fault: None,
-                    fail_next: 0,
-                    lost_race_next: 0,
-                    publishes: 0,
-                },
-            );
-            self
-        }
-
-        /// The next `n` publishes of `byte` lose the CAS without advancing the
-        /// epoch (a non-advancing writer wins), then the sweep wins and converges.
-        fn lost_race_next(self, byte: u8, n: u32) -> Self {
-            self.scopes
-                .borrow_mut()
-                .get_mut(&sid(byte))
-                .expect("scope")
-                .lost_race_next = n;
-            self
-        }
-
-        /// The next `n` publishes of `byte` fail `NotPublished`, then heal.
-        fn fail_next(self, byte: u8, n: u32) -> Self {
-            self.scopes
-                .borrow_mut()
-                .get_mut(&sid(byte))
-                .expect("scope")
-                .fail_next = n;
-            self
-        }
-
-        fn fault(self, byte: u8, fault: ScopeRootPublishError) -> Self {
-            self.scopes
-                .borrow_mut()
-                .get_mut(&sid(byte))
-                .expect("scope")
-                .fault = Some(fault);
-            self
-        }
-
-        fn resolve_fault(self, byte: u8, reason: ResolveFailure) -> Self {
-            self.resolve_faults.borrow_mut().insert(sid(byte), reason);
-            self
-        }
-
-        fn clear_fault(&self, byte: u8) {
-            self.scopes
-                .borrow_mut()
-                .get_mut(&sid(byte))
-                .expect("scope")
-                .fault = None;
-        }
-
-        fn current_epoch(&self, byte: u8) -> u64 {
-            self.scopes
-                .borrow()
-                .get(&sid(byte))
-                .expect("scope")
-                .current_epoch
-        }
-
-        fn publishes(&self, byte: u8) -> u32 {
-            self.scopes
-                .borrow()
-                .get(&sid(byte))
-                .expect("scope")
-                .publishes
-        }
-    }
-
-    impl SweepResolver for FakeNet {
-        async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure> {
-            if let Some(reason) = self.resolve_faults.borrow().get(&scope.scope_id) {
-                return Err(*reason);
-            }
-            let scopes = self.scopes.borrow();
-            let s = scopes
-                .get(&scope.scope_id)
-                .ok_or(ResolveFailure::Unavailable)?;
-            Ok(SweepTarget {
-                v: V,
-                current_read_epoch: s.current_epoch,
-                owner_enc_pub: self.owner.enc.public(),
-                parent_node_seed: s.parent_node_seed.map(Zeroizing::new),
-                pseudonym_signer: self.owner.pseudonym.clone(),
-                override_seed: Zeroizing::new(s.override_seed),
-                write_scope_seed: Zeroizing::new(s.write_scope_seed),
-                pointer_read_key: Zeroizing::new(s.pointer_read_key),
-                write_epoch: 1,
-                commitment: s.commitment.clone(),
-                commitment_sig: s.commitment_sig,
-                grant_ledger: s.grant_ledger.clone(),
-                write_history_link: Vec::new(),
-                direct_child_scope_index: s.children.clone(),
-                carried_history_links: Vec::new(),
-            })
-        }
-    }
-
-    impl ScopeRootPublisher for FakeNet {
-        async fn publish_scope_root(
-            &self,
-            record: &ResealedScopeRoot,
-        ) -> Result<(), ScopeRootPublishError> {
-            let mut scopes = self.scopes.borrow_mut();
-            let s = scopes.get_mut(&record.scope_id).expect("scope");
-            s.publishes += 1;
-            if s.fail_next > 0 {
-                s.fail_next -= 1;
-                return Err(ScopeRootPublishError::NotPublished);
-            }
-            if s.lost_race_next > 0 {
-                // A non-advancing writer won the sequence CAS: the epoch does NOT
-                // move, so a single drop does not converge the node.
-                s.lost_race_next -= 1;
-                return Err(ScopeRootPublishError::LostRace);
-            }
-            match &s.fault {
-                None => {
-                    s.current_epoch = s.current_epoch.max(record.read_epoch);
-                    Ok(())
-                }
-                // A persistent lost race modelling a concurrent *sweeper* winner:
-                // the winner's record is at (at least) our epoch, so the node
-                // re-resolves as converged on the next pass.
-                Some(ScopeRootPublishError::LostRace) => {
-                    s.current_epoch = s.current_epoch.max(record.read_epoch);
-                    Err(ScopeRootPublishError::LostRace)
-                }
-                // Nothing landed, epoch unchanged.
-                Some(error) => Err(error.clone()),
-            }
-        }
-    }
-
-    /// Raise the epoch floor for each scope byte to `epoch`.
-    fn raise_floors(floors: &InMemoryFloorStore, scopes: &[u8], epoch: u64) {
-        for b in scopes {
-            block_on(floors.raise_epoch_floor(&sid(*b), epoch)).unwrap();
-        }
-    }
-
-    fn run(
-        net: &FakeNet,
-        floors: &InMemoryFloorStore,
-        seed: u64,
-        root: u8,
-        root_children: &[u8],
-    ) -> Result<SweepOutcome, SweepError> {
-        let index: Vec<ChildScopeRef> = root_children.iter().map(|b| childref(*b)).collect();
-        block_on(async {
-            let mut entropy = SeededEntropy::new(seed);
-            sweep_pass(&mut entropy, floors, net, net, sid(root), &index).await
-        })
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.converged, vec![id(0x01), id(0x02)]);
+        assert_eq!(net.epoch(0x01), 5);
+        assert_eq!(net.epoch(0x02), 5, "the walk reached the deeper level");
     }
 
     #[test]
-    fn completeness_every_reachable_descendant_converges_to_floor() {
-        // root(00) -> A(01) -> B(02) -> C(03); all descendants lag at epoch 1,
-        // floor raised to 5. One pass must converge every reachable descendant.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[0x02])
-            .scope(0x02, 1, &[0x03])
-            .scope(0x03, 1, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02, 0x03], 5);
-
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01]).expect("sweep");
-        let mut converged = outcome.converged.clone();
-        converged.sort();
-        assert_eq!(
-            converged,
-            vec![sid(0x01), sid(0x02), sid(0x03)],
-            "every reachable descendant converged"
-        );
-        // And the network now holds each descendant at the floor epoch: no node
-        // left lagging.
-        for b in [0x01, 0x02, 0x03] {
-            assert_eq!(net.current_epoch(b), 5, "descendant re-keyed up to floor");
-        }
-    }
-
-    #[test]
-    fn rerun_is_idempotent_noop() {
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[0x02])
-            .scope(0x02, 1, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 5);
-
-        let first = run(&net, &floors, 1, 0x00, &[0x01]).expect("first");
-        assert_eq!(first.converged.len(), 2);
-
-        let second = run(&net, &floors, 1, 0x00, &[0x01]).expect("second");
-        assert!(second.converged.is_empty(), "nothing left to converge");
-        let mut already = second.already_converged.clone();
-        already.sort();
-        assert_eq!(already, vec![sid(0x01), sid(0x02)], "all already converged");
-    }
-
-    #[test]
-    fn already_converged_nodes_are_not_resealed() {
-        // A(01) already at the floor; the sweep must not re-publish it.
-        let net = FakeNet::new().scope(0x00, 5, &[0x01]).scope(0x01, 5, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
-
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01]).expect("sweep");
-        assert_eq!(outcome.already_converged, vec![sid(0x01)]);
+    fn a_node_already_at_the_scope_epoch_is_never_republished() {
+        let net = FakeNet::new(5, &[0x01]).node(0x01, 5, &[]);
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.already_converged, vec![id(0x01)]);
         assert!(outcome.converged.is_empty());
-        assert_eq!(net.publishes(0x01), 0, "converged node never re-published");
-    }
-
-    #[test]
-    fn no_floor_means_not_lagging() {
-        // No floor was ever raised for A → nothing to converge to.
-        let net = FakeNet::new().scope(0x00, 5, &[0x01]).scope(0x01, 1, &[]);
-        let floors = InMemoryFloorStore::default();
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01]).expect("sweep");
-        assert_eq!(outcome.already_converged, vec![sid(0x01)]);
         assert_eq!(net.publishes(0x01), 0);
     }
 
     #[test]
-    fn metadata_only_reuses_seed_no_epoch_bump_no_history_link() {
-        // The crypto property: a swept descendant's owner blob still decrypts to
-        // its EXISTING override seed, at exactly the floor epoch (not floor+1),
-        // with no history link appended.
-        let net = FakeNet::new().scope(0x00, 4, &[0x01]).scope(0x01, 2, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 4);
-
-        // Capture the published record via a recording publisher wrapper.
-        let published = Rc::new(RefCell::new(Vec::<ResealedScopeRoot>::new()));
-        struct Recorder {
-            net: FakeNet,
-            log: Rc<RefCell<Vec<ResealedScopeRoot>>>,
-        }
-        impl SweepResolver for Recorder {
-            async fn resolve(&self, scope: &ChildScopeRef) -> Result<SweepTarget, ResolveFailure> {
-                self.net.resolve(scope).await
-            }
-        }
-        impl ScopeRootPublisher for Recorder {
-            async fn publish_scope_root(
-                &self,
-                record: &ResealedScopeRoot,
-            ) -> Result<(), ScopeRootPublishError> {
-                self.log.borrow_mut().push(record.clone());
-                self.net.publish_scope_root(record).await
-            }
-        }
-        let rec = Recorder {
-            net: net.clone(),
-            log: Rc::clone(&published),
-        };
-        let index = vec![childref(0x01)];
-        block_on(async {
-            let mut entropy = SeededEntropy::new(1);
-            sweep_pass(&mut entropy, &floors, &rec, &rec, sid(0x00), &index).await
-        })
-        .expect("sweep");
-
-        let log = published.borrow();
-        assert_eq!(log.len(), 1);
-        let record = &log[0];
-        assert_eq!(
-            record.read_epoch, 4,
-            "re-sealed at the floor, no epoch bump"
-        );
-        assert_eq!(record.write_epoch, 1, "write epoch unchanged");
-        assert!(
-            record.section.history_links.is_empty(),
-            "prev=None: no history link minted"
-        );
-        let ctx = AadContext {
-            v: V,
-            id: sid(0x01),
-            scope: sid(0x01),
-            epoch: 4,
-            struct_tag: STRUCT_TAG_OWNER_BLOB,
-        };
-        let payload = open_owner_blob(
-            &net.owner.enc,
-            &record.section.owner_blob.enc,
-            &ctx,
-            &record.section.owner_blob.ciphertext,
-        )
-        .unwrap();
-        assert!(
-            ct_eq(payload.override_seed(), &[0x01; 32]),
-            "sweep reused the existing seed, minted none"
-        );
+    fn a_node_ahead_of_the_scope_epoch_is_never_republished() {
+        let net = FakeNet::new(5, &[0x01]).node(0x01, 9, &[]);
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.already_converged, vec![id(0x01)]);
+        assert_eq!(net.publishes(0x01), 0);
     }
 
     #[test]
-    fn lost_cas_race_drops_node_and_continues() {
-        // A(01) lost the CAS; B(02) still converges. The loser drops and
-        // re-resolves converged — never a clobber or a hard abort.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01, 0x02])
-            .scope(0x01, 1, &[])
-            .scope(0x02, 1, &[])
-            .fault(0x01, ScopeRootPublishError::LostRace);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 5);
+    fn rerunning_the_pass_is_an_idempotent_noop() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[0x02])
+            .node(0x02, 1, &[]);
+        let first = run(&net, 0x00).expect("first");
+        assert_eq!(first.converged.len(), 2);
 
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01, 0x02]).expect("sweep");
-        assert_eq!(outcome.dropped_lost_race, vec![sid(0x01)]);
-        assert_eq!(outcome.converged, vec![sid(0x02)]);
-        // Re-resolve: the lost-race node reads converged (the winner advanced it).
-        let second = run(&net, &floors, 1, 0x00, &[0x01, 0x02]).expect("second");
+        let second = run(&net, 0x00).expect("second");
+        assert!(second.converged.is_empty(), "nothing left to converge");
+        assert_eq!(second.already_converged, vec![id(0x01), id(0x02)]);
+        assert_eq!((net.publishes(0x01), net.publishes(0x02)), (1, 1));
+    }
+
+    #[test]
+    fn a_second_concurrent_sweeper_republishes_nothing() {
+        let net = FakeNet::new(7, &[0x01])
+            .node(0x01, 3, &[0x02])
+            .node(0x02, 3, &[]);
+        run(&net, 0x00).expect("sweeper 1");
+        let counts = (net.publishes(0x01), net.publishes(0x02));
+
+        let second = run(&net, 0x00).expect("sweeper 2");
         assert!(second.converged.is_empty());
-        assert!(second.dropped_lost_race.is_empty());
-        let mut already = second.already_converged.clone();
-        already.sort();
-        assert_eq!(already, vec![sid(0x01), sid(0x02)]);
+        assert_eq!((net.publishes(0x01), net.publishes(0x02)), counts);
     }
 
     #[test]
-    fn not_published_hard_aborts_fail_closed_never_silent_skip() {
-        // A(01) cannot be published. The pass aborts naming A rather than marking
-        // it converged — under-convergence must never be silently swallowed.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[])
-            .fault(0x01, ScopeRootPublishError::NotPublished);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
-
-        let err = run(&net, &floors, 1, 0x00, &[0x01]).expect_err("fails closed");
-        assert_eq!(err.check(), "publish-failed");
-        assert!(err.is_retryable(), "availability stall is retryable");
-        match err {
-            SweepError::Publish { scope_id, .. } => assert_eq!(scope_id, sid(0x01)),
-            other => panic!("unexpected: {other}"),
-        }
+    fn the_publish_order_is_independent_of_the_bodys_child_order() {
+        let converged = |order: &[u8]| {
+            let net = FakeNet::new(5, order)
+                .node(0x01, 1, &[])
+                .node(0x02, 1, &[])
+                .node(0x03, 1, &[]);
+            run(&net, 0x00).expect("sweep").converged
+        };
+        assert_eq!(
+            converged(&[0x03, 0x01, 0x02]),
+            converged(&[0x01, 0x02, 0x03]),
+        );
+        assert_eq!(
+            converged(&[0x03, 0x01, 0x02]),
+            vec![id(0x01), id(0x02), id(0x03)],
+        );
     }
 
     #[test]
-    fn enumeration_rejected_descendant_fails_closed_fatal() {
-        // B(02) is a forged/rejected subtree. The pass aborts fail-closed and the
-        // trust rejection is NOT retryable.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[0x02])
-            .scope(0x02, 1, &[])
-            .resolve_fault(0x02, ResolveFailure::Rejected);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 5);
+    fn a_cyclic_child_edge_terminates() {
+        // A names B, B names A: a corrupt back-edge the walk must not follow.
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[0x02])
+            .node(0x02, 1, &[0x01]);
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.converged, vec![id(0x01), id(0x02)]);
+    }
 
-        let err = run(&net, &floors, 1, 0x00, &[0x01]).expect_err("fails closed");
-        assert_eq!(err.check(), "enumeration-incomplete");
-        assert!(!err.is_retryable(), "a trust rejection is fatal");
+    // --- The scope-root boundary ---
+
+    #[test]
+    fn the_walk_stops_at_a_descendant_scope_root_and_never_sweeps_it() {
+        // The scope root names an interior node A(01) and a descendant scope
+        // root S(0a) whose own subtree holds a lagging node D(0d). Neither S nor
+        // anything below it is swept — that is the cascade's population.
+        let net = FakeNet::new(5, &[0x01, 0x0a])
+            .node(0x01, 1, &[])
+            .scope_root(0x0a, true, &[0x0d])
+            .node(0x0d, 1, &[]);
+
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.converged, vec![id(0x01)], "only the interior node");
+        assert_eq!(outcome.skipped_scope_roots, vec![id(0x0a)]);
+        assert_eq!(net.publishes(0x0a), 0, "a scope root is never swept");
+        assert_eq!(net.publishes(0x0d), 0, "nor is anything below it");
+        assert_eq!(net.epoch(0x0d), 1, "the descendant scope kept its epoch");
     }
 
     #[test]
-    fn enumeration_unavailable_descendant_is_retryable() {
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[])
-            .resolve_fault(0x01, ResolveFailure::Unavailable);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
-        let err = run(&net, &floors, 1, 0x00, &[0x01]).expect_err("unavailable");
-        assert_eq!(err.check(), "enumeration-incomplete");
+    fn an_indexed_scope_root_is_not_resolved_as_an_interior_node() {
+        // The index names S(0a), so the walk stops without a child resolve —
+        // even though S's record would otherwise resolve as a scope root.
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, true, &[]);
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.skipped_scope_roots, vec![id(0x0a)]);
+        assert!(
+            outcome.flagged_indexes.is_empty(),
+            "the index already names it"
+        );
+        assert_eq!(net.index_repairs.get(), 0);
+    }
+
+    // --- The direct-child-scope index self-heal (#38 D6) ---
+
+    #[test]
+    fn an_omitted_scope_root_is_repaired_and_flagged_with_no_node_resealed() {
+        // S(0a) is a scope root the walk meets, absent from the index. Every
+        // interior node is already at the scope epoch, so the repair lands with
+        // nothing re-sealed — the self-heal no longer rides the epoch comparison.
+        let net = FakeNet::new(5, &[0x01, 0x0a])
+            .node(0x01, 5, &[])
+            .scope_root(0x0a, false, &[]);
+
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.flagged_indexes, vec![id(0x0a)]);
+        assert!(
+            outcome.converged.is_empty(),
+            "no node was re-sealed in the repairing pass"
+        );
+        assert_eq!(net.index_repairs.get(), 1);
+        let repaired = net.state.borrow().repaired_index.clone().expect("repaired");
+        assert_eq!(repaired, vec![scope_ref(0x0a)]);
+    }
+
+    #[test]
+    fn a_repaired_index_is_not_flagged_again_on_the_next_pass() {
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false, &[]);
+        assert_eq!(run(&net, 0x00).expect("first").flagged_indexes.len(), 1);
+        let again = run(&net, 0x00).expect("second");
+        assert!(again.flagged_indexes.is_empty());
+        assert_eq!(net.index_repairs.get(), 1, "no redundant republish");
+    }
+
+    #[test]
+    fn an_index_repair_that_lost_the_cas_is_not_flagged() {
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false, &[]);
+        net.state.borrow_mut().index_repair_fault = Some(ScopeRootPublishError::LostRace);
+
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert!(
+            outcome.flagged_indexes.is_empty(),
+            "a repair that never landed must not be reported"
+        );
+        assert_eq!(outcome.skipped_scope_roots, vec![id(0x0a)]);
+    }
+
+    #[test]
+    fn an_index_repair_that_did_not_land_fails_closed() {
+        let net = FakeNet::new(5, &[0x0a]).scope_root(0x0a, false, &[]);
+        net.state.borrow_mut().index_repair_fault = Some(ScopeRootPublishError::NotPublished);
+
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert_eq!(err.check(), "index-repair-failed");
         assert!(err.is_retryable());
     }
 
     #[test]
-    fn reseal_trust_failure_is_fatal() {
-        // Corrupt A(01)'s ledger so it diverges from the committed set: the
-        // re-seal rejects it fail-closed and it is not retryable.
-        let net = FakeNet::new().scope(0x00, 5, &[0x01]).scope(0x01, 1, &[]);
-        net.scopes
-            .borrow_mut()
-            .get_mut(&sid(0x01))
-            .unwrap()
-            .grant_ledger
-            .push(GrantLedgerEntry::new(
-                [0x09; 33],
-                X25519Secret::from_scalar([0x0f; 32]).public().to_bytes(),
-                Permission::Write,
-                [0xff; 32], // uncommitted tag
-            ));
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
+    fn the_index_repair_lands_before_a_node_publish_can_abort_the_pass() {
+        // A(01) lags and can never publish; the repair still landed, because the
+        // self-heal runs on the walk result rather than behind a re-seal.
+        let net = FakeNet::new(5, &[0x01, 0x0a])
+            .node(0x01, 1, &[])
+            .scope_root(0x0a, false, &[])
+            .fault(0x01, ScopeRootPublishError::NotPublished);
 
-        let err = run(&net, &floors, 1, 0x00, &[0x01]).expect_err("diverging ledger");
-        assert_eq!(err.check(), "reseal-rejected");
-        assert!(!err.is_retryable(), "a trust violation is fatal");
-        match err {
-            SweepError::Reseal { scope_id, error } => {
-                assert_eq!(scope_id, sid(0x01));
-                assert_eq!(error.check(), "ledger-diverges-from-commitment");
-            }
-            other => panic!("unexpected: {other}"),
-        }
-    }
-
-    #[test]
-    fn self_heal_canonicalizes_index_and_flags() {
-        // A(01)'s stored index carries a duplicate child scope_id (crash residue).
-        // The sweep re-publishes it canonical and flags A.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope_with_index(0x01, 1, &[0x02], true)
-            .scope(0x02, 1, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 5);
-
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01]).expect("sweep");
-        assert_eq!(
-            outcome.flagged_indexes,
-            vec![sid(0x01)],
-            "repaired index flagged"
-        );
-        // A converged canonical index is not re-flagged on a subsequent sweep.
-        let again = run(&net, &floors, 1, 0x00, &[0x01]).expect("second");
-        assert!(again.flagged_indexes.is_empty());
-    }
-
-    #[test]
-    fn lost_race_does_not_flag_an_unpublished_index_repair() {
-        // A(01)'s stored index is non-canonical, but its publish loses the CAS:
-        // the canonical index never landed, so A must surface only in
-        // `dropped_lost_race`, never in `flagged_indexes` (fail-closed).
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope_with_index(0x01, 1, &[0x02], true)
-            .scope(0x02, 1, &[])
-            .fault(0x01, ScopeRootPublishError::LostRace);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 5);
-
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01]).expect("sweep");
-        assert_eq!(outcome.dropped_lost_race, vec![sid(0x01)]);
-        assert!(
-            outcome.flagged_indexes.is_empty(),
-            "an index repair that lost the CAS was never published, so must not be flagged"
-        );
-    }
-
-    #[test]
-    fn partial_sweep_then_resume_converges_all() {
-        // A(01) publishes; B(02) is not-published this pass (abort after A). Heal,
-        // re-run: A is already converged, B now converges. No node is stranded.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01, 0x02])
-            .scope(0x01, 1, &[])
-            .scope(0x02, 1, &[])
-            .fault(0x02, ScopeRootPublishError::NotPublished);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 5);
-
-        // First pass aborts on B, but A durably converged in the network.
-        let err = run(&net, &floors, 1, 0x00, &[0x01, 0x02]).expect_err("partial");
+        let err = run(&net, 0x00).expect_err("the node publish aborts");
         assert_eq!(err.check(), "publish-failed");
-        assert_eq!(net.current_epoch(0x01), 5, "A converged before the abort");
-        assert_eq!(net.current_epoch(0x02), 1, "B did not land");
+        assert_eq!(net.index_repairs.get(), 1);
+        assert!(net.state.borrow().repaired_index.is_some());
+    }
+
+    // --- The superseded verdict and the pointer consult (ADR 0003 D2) ---
+
+    #[test]
+    fn a_below_floor_scope_root_converges_after_the_pointer_consult() {
+        // The scope root is asked at a name a write rotation has moved off: its
+        // record is below the floor. The pointer re-points to the fresh name,
+        // where the scope resolves and its lagging node converges.
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .superseded(0x00)
+            .pointer_to(0x09);
+
+        let outcome = run(&net, 0x00).expect("the consult converges the scope");
+        assert_eq!(net.consults.get(), 1);
+        assert_eq!(outcome.converged, vec![id(0x01)]);
+    }
+
+    #[test]
+    fn a_below_floor_scope_root_whose_fresh_record_still_lags_is_refused() {
+        // The re-pointed record is below the floor too: fail closed, and never
+        // consult a second time.
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .superseded(0x00)
+            .superseded(0x09)
+            .pointer_to(0x09);
+
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert_eq!(err.check(), "scope-root-unresolved");
+        assert!(!err.is_retryable(), "a surviving supersede is fatal");
+        assert_eq!(net.consults.get(), 1, "one consult, one re-resolve");
+        assert_eq!(net.publishes(0x01), 0);
+    }
+
+    #[test]
+    fn a_below_floor_scope_root_with_no_pointer_is_refused() {
+        let net = FakeNet::new(5, &[0x01]).node(0x01, 1, &[]).superseded(0x00);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert!(matches!(
+            err,
+            SweepError::Scope {
+                reason: SweepResolveFailure::Superseded,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn a_forged_scope_root_is_refused_without_any_consult() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .forged(0x00)
+            .pointer_to(0x09);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert_eq!(err.check(), "scope-root-unresolved");
+        assert!(!err.is_retryable());
+        assert_eq!(net.consults.get(), 0, "a trust rejection never consults");
+    }
+
+    #[test]
+    fn a_consult_that_re_points_at_a_forged_record_is_refused() {
+        // The consult cannot launder a forgery: the re-pointed record still
+        // faces the gate.
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .superseded(0x00)
+            .forged(0x09)
+            .pointer_to(0x09);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert!(matches!(
+            err,
+            SweepError::Scope {
+                reason: SweepResolveFailure::Rejected,
+                ..
+            }
+        ));
+        assert_eq!(net.publishes(0x01), 0);
+    }
+
+    #[test]
+    fn an_encountered_scope_root_below_its_floor_is_repaired_at_the_repointed_name() {
+        // S(0a) is missing from the index and its indexed-at name is stale. Only
+        // the name the walk resolved current may be written into the index.
+        let net = FakeNet::new(5, &[0x0a])
+            .scope_root(0x0a, false, &[])
+            .superseded(0x0a)
+            .pointer_to(0x0b);
+
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.flagged_indexes, vec![id(0x0a)]);
+        let repaired = net.state.borrow().repaired_index.clone().expect("repaired");
+        assert_eq!(
+            repaired,
+            vec![ChildScopeRef::new(id(0x0a), name(0x0b))],
+            "the repair persists the re-pointed name, never the superseded one"
+        );
+    }
+
+    // --- Fail-closed completeness ---
+
+    #[test]
+    fn a_rejected_node_aborts_the_pass_fatally() {
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 1, &[])
+            .node(0x02, 1, &[])
+            .node_fault(0x02, SweepResolveFailure::Rejected);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert_eq!(err.check(), "node-unresolved");
+        assert!(!err.is_retryable());
+        assert_eq!(net.publishes(0x01), 0, "nothing is published on an abort");
+    }
+
+    #[test]
+    fn an_unavailable_node_aborts_retryably() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .node_fault(0x01, SweepResolveFailure::Unavailable);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn a_node_that_did_not_publish_aborts_rather_than_claiming_convergence() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .fault(0x01, ScopeRootPublishError::NotPublished);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert!(matches!(err, SweepError::Publish { node_id, .. } if node_id == id(0x01)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn a_publish_the_publisher_refused_is_never_retried() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .fault(0x01, ScopeRootPublishError::Rejected);
+        let err = run(&net, 0x00).expect_err("fails closed");
+        assert!(!err.is_retryable(), "a trust rejection is fatal");
+    }
+
+    #[test]
+    fn a_partial_pass_resumes_without_stranding_a_node() {
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 1, &[])
+            .node(0x02, 1, &[])
+            .fault(0x02, ScopeRootPublishError::NotPublished);
+        run(&net, 0x00).expect_err("aborts on B");
+        assert_eq!(net.epoch(0x01), 5, "A converged before the abort");
+        assert_eq!(net.epoch(0x02), 1);
 
         net.clear_fault(0x02);
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01, 0x02]).expect("resume");
-        assert_eq!(
-            outcome.converged,
-            vec![sid(0x02)],
-            "only B still needed work"
-        );
-        assert_eq!(outcome.already_converged, vec![sid(0x01)]);
-        assert_eq!(net.current_epoch(0x02), 5, "B converged on resume");
+        let outcome = run(&net, 0x00).expect("resume");
+        assert_eq!(outcome.converged, vec![id(0x02)]);
+        assert_eq!(outcome.already_converged, vec![id(0x01)]);
     }
 
     #[test]
-    fn run_sweep_retries_availability_until_converged() {
-        // The idle-cadence driver: A(01)'s first publish is NotPublished (the pass
-        // aborts), the node self-heals, and the driver's next pass — after one
-        // cadence sleep on the virtual clock — converges it.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[])
-            .fail_next(0x01, 1);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
+    fn a_lost_cas_race_drops_the_node_and_the_rest_still_converges() {
+        let net = FakeNet::new(5, &[0x01, 0x02])
+            .node(0x01, 1, &[])
+            .node(0x02, 1, &[])
+            .fault(0x01, ScopeRootPublishError::LostRace);
+        let outcome = run(&net, 0x00).expect("sweep");
+        assert_eq!(outcome.dropped_lost_race, vec![id(0x01)]);
+        assert_eq!(outcome.converged, vec![id(0x02)]);
+    }
 
+    // --- The idle-cadence driver ---
+
+    /// Drive the pass on a virtual clock, asserting that every re-run cost one
+    /// cadence sleep — time enters only through the scheduler seam.
+    fn drive(
+        net: &FakeNet,
+        max_passes: u32,
+        expected_sleeps: u32,
+    ) -> Result<SweepOutcome, SweepError> {
         let scheduler = VirtualScheduler::new().with_auto_advance();
-        let index = vec![childref(0x01)];
-        let outcome = block_on(async {
-            let mut entropy = SeededEntropy::new(1);
-            run_sweep(
-                &mut entropy,
-                &floors,
-                &scheduler,
-                &net,
-                &net,
-                sid(0x00),
-                &index,
-                Duration::from_secs(30),
-                4,
-            )
-            .await
-        })
-        .expect("driver converges after retry");
-        assert_eq!(outcome.converged, vec![sid(0x01)]);
+        let result = block_on(run_sweep(
+            &scheduler,
+            net,
+            net,
+            &scope_ref(0x00),
+            Duration::from_secs(30),
+            max_passes,
+        ));
         assert_eq!(
-            net.publishes(0x01),
-            2,
-            "one failed pass, one succeeding retry"
+            scheduler.now(),
+            UnixMillis(u64::from(expected_sleeps) * 30_000),
+            "one cadence sleep per re-run",
         );
-        assert!(
-            scheduler.now() >= UnixMillis(30_000),
-            "the driver slept one cadence before the retry"
-        );
+        result
     }
 
     #[test]
-    fn run_sweep_gives_up_after_max_passes_on_persistent_stall() {
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[])
-            .fault(0x01, ScopeRootPublishError::NotPublished);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
-        let scheduler = VirtualScheduler::new().with_auto_advance();
-        let index = vec![childref(0x01)];
-        let err = block_on(async {
-            let mut entropy = SeededEntropy::new(1);
-            run_sweep(
-                &mut entropy,
-                &floors,
-                &scheduler,
-                &net,
-                &net,
-                sid(0x00),
-                &index,
-                Duration::from_secs(30),
-                3,
-            )
-            .await
-        })
-        .expect_err("persistent stall surfaces");
-        assert_eq!(err.check(), "publish-failed");
-        // Three attempts were made (one per allowed pass).
-        assert_eq!(net.publishes(0x01), 3);
-    }
-
-    #[test]
-    fn run_sweep_loops_past_non_advancing_lost_race_until_it_wins() {
-        // The Finding-1 scenario: a non-advancing writer wins the sequence CAS
-        // twice (the epoch never moves, so a single drop does NOT converge the
-        // node). run_sweep must keep re-resolving — not return Ok on the drop —
-        // until the sweep finally wins the CAS and the node truly converges.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[])
+    fn the_driver_loops_past_a_non_advancing_lost_race_until_it_wins() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
             .lost_race_next(0x01, 2);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
-
-        let scheduler = VirtualScheduler::new().with_auto_advance();
-        let index = vec![childref(0x01)];
-        let outcome = block_on(async {
-            let mut entropy = SeededEntropy::new(1);
-            run_sweep(
-                &mut entropy,
-                &floors,
-                &scheduler,
-                &net,
-                &net,
-                sid(0x00),
-                &index,
-                Duration::from_secs(30),
-                5,
-            )
-            .await
-        })
-        .expect("driver converges after two lost races");
-        assert_eq!(outcome.converged, vec![sid(0x01)], "the sweep finally won");
-        assert!(
-            outcome.dropped_lost_race.is_empty(),
-            "no residual drop once converged"
-        );
-        assert_eq!(net.current_epoch(0x01), 5, "node truly at the floor");
+        let outcome = drive(&net, 5, 2).expect("converges after two lost races");
+        assert_eq!(outcome.converged, vec![id(0x01)]);
+        assert!(outcome.dropped_lost_race.is_empty());
         assert_eq!(
             net.publishes(0x01),
             3,
             "two lost races, one winning publish"
         );
+        assert_eq!(net.epoch(0x01), 5);
     }
 
     #[test]
-    fn run_sweep_surfaces_residual_drop_on_cap_exhaustion() {
-        // A persistently hot non-advancing writer: run_sweep exhausts its passes
-        // and returns Ok, but surfaces the still-dropped node rather than a false
-        // "complete".
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01])
-            .scope(0x01, 1, &[])
+    fn the_driver_surfaces_a_residual_drop_on_cap_exhaustion() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
             .lost_race_next(0x01, 10);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01], 5);
-        let scheduler = VirtualScheduler::new().with_auto_advance();
-        let index = vec![childref(0x01)];
-        let outcome = block_on(async {
-            let mut entropy = SeededEntropy::new(1);
-            run_sweep(
-                &mut entropy,
-                &floors,
-                &scheduler,
-                &net,
-                &net,
-                sid(0x00),
-                &index,
-                Duration::from_secs(30),
-                3,
-            )
-            .await
-        })
-        .expect("returns Ok with residual surfaced");
-        assert_eq!(
-            outcome.dropped_lost_race,
-            vec![sid(0x01)],
-            "residual lost-race node surfaced, not silently complete"
-        );
+        let outcome = drive(&net, 3, 2).expect("returns Ok with the residual surfaced");
+        assert_eq!(outcome.dropped_lost_race, vec![id(0x01)]);
         assert!(outcome.converged.is_empty());
+        assert_eq!(net.publishes(0x01), 3);
+    }
+
+    #[test]
+    fn the_driver_gives_up_on_a_persistent_availability_stall() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .fault(0x01, ScopeRootPublishError::NotPublished);
+        let err = drive(&net, 3, 2).expect_err("the stall surfaces");
+        assert_eq!(err.check(), "publish-failed");
         assert_eq!(net.publishes(0x01), 3, "one attempt per allowed pass");
     }
 
     #[test]
-    fn concurrent_sweepers_converge_without_double_advance() {
-        // Two sweepers over the same shared network. The first converges the
-        // subtree; the second sees every node already converged — no re-publish,
-        // no clobber, no floor double-advance.
-        let net = FakeNet::new()
-            .scope(0x00, 7, &[0x01])
-            .scope(0x01, 3, &[0x02])
-            .scope(0x02, 3, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02], 7);
-
-        let first = run(&net, &floors, 1, 0x00, &[0x01]).expect("sweeper 1");
-        assert_eq!(first.converged.len(), 2);
-        let p1 = (net.publishes(0x01), net.publishes(0x02));
-
-        let second = run(&net, &floors, 2, 0x00, &[0x01]).expect("sweeper 2");
-        assert!(second.converged.is_empty(), "second sweeper is a no-op");
-        assert_eq!(second.already_converged.len(), 2);
-        assert_eq!(
-            (net.publishes(0x01), net.publishes(0x02)),
-            p1,
-            "no redundant re-publish by the second sweeper"
-        );
-    }
-
-    #[test]
-    fn diamond_shared_descendant_converged_once() {
-        // root -> A(01), B(02); both -> D(04). D converges exactly once.
-        let net = FakeNet::new()
-            .scope(0x00, 5, &[0x01, 0x02])
-            .scope(0x01, 1, &[0x04])
-            .scope(0x02, 1, &[0x04])
-            .scope(0x04, 1, &[]);
-        let floors = InMemoryFloorStore::default();
-        raise_floors(&floors, &[0x01, 0x02, 0x04], 5);
-
-        let outcome = run(&net, &floors, 1, 0x00, &[0x01, 0x02]).expect("sweep");
-        let mut converged = outcome.converged.clone();
-        converged.sort();
-        assert_eq!(converged, vec![sid(0x01), sid(0x02), sid(0x04)]);
-        assert_eq!(net.publishes(0x04), 1, "shared descendant published once");
-    }
-
-    #[test]
-    fn determinism_same_entropy_same_published_bytes() {
-        let build = || {
-            let net = FakeNet::new()
-                .scope(0x00, 5, &[0x01])
-                .scope(0x01, 1, &[0x02])
-                .scope(0x02, 1, &[]);
-            let floors = InMemoryFloorStore::default();
-            raise_floors(&floors, &[0x01, 0x02], 5);
-            let log = Rc::new(RefCell::new(Vec::<ResealedScopeRoot>::new()));
-            struct Rec {
-                net: FakeNet,
-                log: Rc<RefCell<Vec<ResealedScopeRoot>>>,
-            }
-            impl SweepResolver for Rec {
-                async fn resolve(
-                    &self,
-                    scope: &ChildScopeRef,
-                ) -> Result<SweepTarget, ResolveFailure> {
-                    self.net.resolve(scope).await
-                }
-            }
-            impl ScopeRootPublisher for Rec {
-                async fn publish_scope_root(
-                    &self,
-                    record: &ResealedScopeRoot,
-                ) -> Result<(), ScopeRootPublishError> {
-                    self.log.borrow_mut().push(record.clone());
-                    self.net.publish_scope_root(record).await
-                }
-            }
-            let rec = Rec {
-                net: net.clone(),
-                log: Rc::clone(&log),
-            };
-            let index = vec![childref(0x01)];
-            block_on(async {
-                let mut entropy = SeededEntropy::new(42);
-                sweep_pass(&mut entropy, &floors, &rec, &rec, sid(0x00), &index).await
-            })
-            .expect("sweep");
-            let mut records = log.borrow().clone();
-            records.sort_by(|a, b| a.scope_id.cmp(&b.scope_id));
-            records
-        };
-        assert_eq!(build(), build(), "same entropy → byte-identical publishes");
+    fn the_driver_returns_a_trust_failure_immediately() {
+        let net = FakeNet::new(5, &[0x01])
+            .node(0x01, 1, &[])
+            .node_fault(0x01, SweepResolveFailure::Rejected);
+        let err = drive(&net, 5, 0).expect_err("fatal");
+        assert!(!err.is_retryable());
     }
 }

--- a/crates/engine/src/rotation/sweep/sim.rs
+++ b/crates/engine/src/rotation/sweep/sim.rs
@@ -32,6 +32,36 @@ pub(crate) fn scope_ref(byte: u8) -> ChildScopeRef {
     ChildScopeRef::new(id(byte), name(byte))
 }
 
+/// A folder body naming `children`, at each byte's own simulated name unless
+/// `overrides` gives this parent a different one for it — the C2 conflict,
+/// where two parents disagree on one node's name.
+pub(crate) fn folder_named(
+    parent: u8,
+    children: &[u8],
+    overrides: &HashMap<(u8, u8), Vec<u8>>,
+) -> ReadBody {
+    ReadBody::Folder {
+        created_at: 1,
+        modified_at: 2,
+        children: children
+            .iter()
+            .map(|b| ChildRef {
+                id: id(*b),
+                name: format!("n{b:02x}"),
+                ipns_name: overrides
+                    .get(&(parent, *b))
+                    .cloned()
+                    .unwrap_or_else(|| name(*b)),
+                kind: NodeKind::Folder,
+                link_counter: 1,
+                unknown: PreservedFields::new(),
+            })
+            .collect(),
+        unknown: PreservedFields::new(),
+    }
+}
+
+#[allow(dead_code)]
 pub(crate) fn folder(children: &[u8]) -> ReadBody {
     ReadBody::Folder {
         created_at: 1,
@@ -98,6 +128,8 @@ pub(crate) struct NetState {
     /// The published index, once a repair lands.
     pub(crate) repaired_index: Option<Vec<ChildScopeRef>>,
     pub(crate) index_repair_fault: Option<ScopeRootPublishError>,
+    /// `(parent, child)` pairs the parent names at a caller-chosen `ipnsName`.
+    pub(crate) child_names: HashMap<(u8, u8), Vec<u8>>,
 }
 
 /// The sweep's fake network: one scope, its interior nodes, and its pointer.
@@ -128,12 +160,13 @@ impl FakeNet {
         self
     }
 
-    /// A descendant scope root: the walk stops at it. `indexed` lists it in
-    /// the scope's `directChildScopeIndex`; omitting it is the #38 D6 gap.
-    pub(crate) fn scope_root(self, byte: u8, indexed: bool, children: &[u8]) -> Self {
+    /// A descendant scope root: the walk stops at it, so it never publishes a
+    /// body and never yields children. `indexed` lists it in the scope's
+    /// `directChildScopeIndex`; omitting it is the #38 D6 gap.
+    pub(crate) fn scope_root(self, byte: u8, indexed: bool) -> Self {
         {
             let mut state = self.state.borrow_mut();
-            let mut node = FakeNode::new(0, children);
+            let mut node = FakeNode::new(0, &[]);
             node.is_scope_root = true;
             state.nodes.insert(id(byte), node);
             if indexed {
@@ -179,6 +212,23 @@ impl FakeNet {
 
     pub(crate) fn pointer_to(self, byte: u8) -> Self {
         self.state.borrow_mut().pointer = Some(name(byte));
+        self
+    }
+
+    /// `parent` names `child` at a name of its own, so a second parent naming
+    /// the same child differently is the C2 conflict.
+    pub(crate) fn names_child(self, parent: u8, child: u8, ipns_name: &str) -> Self {
+        self.state
+            .borrow_mut()
+            .child_names
+            .insert((parent, child), ipns_name.as_bytes().to_vec());
+        self
+    }
+
+    /// Seed a **non-canonical** stored index: `byte` listed twice — the crash
+    /// residue #38 D6's repair also covers.
+    pub(crate) fn duplicate_index_entry(self, byte: u8) -> Self {
+        self.state.borrow_mut().index.push(byte);
         self
     }
 
@@ -228,7 +278,18 @@ impl SweepResolver for FakeNet {
             .unwrap_or_else(|| state.index.iter().map(|b| scope_ref(*b)).collect());
         Ok(SweptScope {
             current_read_epoch: state.scope_epoch,
-            children: state.root_children.iter().map(|b| node_ref(*b)).collect(),
+            children: state
+                .root_children
+                .iter()
+                .map(|b| NodeRef {
+                    node_id: id(*b),
+                    ipns_name: state
+                        .child_names
+                        .get(&(0x00, *b))
+                        .cloned()
+                        .unwrap_or_else(|| name(*b)),
+                })
+                .collect(),
             direct_child_scope_index: index,
         })
     }
@@ -241,7 +302,11 @@ impl SweepResolver for FakeNet {
         Ok(self.state.borrow().pointer.clone())
     }
 
-    async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+    async fn resolve_child(
+        &self,
+        _scope: &ChildScopeRef,
+        child: &NodeRef,
+    ) -> Result<SweptChild, SweepResolveFailure> {
         let state = self.state.borrow();
         if let Some(reason) = state.node_faults.get(&child.node_id) {
             return Err(*reason);
@@ -264,7 +329,8 @@ impl SweepResolver for FakeNet {
         }
         Ok(SweptChild::Interior(SweptNode {
             current_read_epoch: node.epoch,
-            read_body: folder(&node.children),
+            sequence: 1,
+            read_body: folder_named(child.node_id[0], &node.children, &state.child_names),
             carried_unknown: PreservedFields::new(),
             carried_epoch_tag_unknown: PreservedFields::new(),
         }))
@@ -272,7 +338,11 @@ impl SweepResolver for FakeNet {
 }
 
 impl SweepPublisher for FakeNet {
-    async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+    async fn publish_node(
+        &self,
+        _scope: &ChildScopeRef,
+        node: &LaggingNode<'_>,
+    ) -> Result<(), ScopeRootPublishError> {
         let mut state = self.state.borrow_mut();
         let entry = state.nodes.get_mut(&node.node_id).expect("node");
         entry.publishes += 1;
@@ -335,7 +405,7 @@ impl Scenario {
             net = net.node(*byte, *epoch, &[]);
         }
         for (byte, indexed) in self.scope_roots {
-            net = net.scope_root(*byte, *indexed, &[]);
+            net = net.scope_root(*byte, *indexed);
         }
         net
     }

--- a/crates/engine/src/rotation/sweep/sim.rs
+++ b/crates/engine/src/rotation/sweep/sim.rs
@@ -1,0 +1,374 @@
+//! The sweep's deterministic simulation network: the fake the pure pass is
+//! exercised against, and the scenarios the production seams are held to as
+//! well (`net/rotation.rs`), so a fake that drifts from its production
+//! counterpart fails a CI gate rather than being found by reading.
+
+use super::{
+    LaggingNode, NodeRef, SweepPublisher, SweepResolveFailure, SweepResolver, SweptChild,
+    SweptNode, SweptScope,
+};
+use crate::rotation::ScopeRootPublishError;
+use cipherbox_core::seal::{ChildRef, ChildScopeRef, NodeKind, PreservedFields, ReadBody};
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+pub(crate) fn id(byte: u8) -> [u8; 16] {
+    [byte; 16]
+}
+
+pub(crate) fn name(byte: u8) -> Vec<u8> {
+    format!("ipns-{byte:02x}").into_bytes()
+}
+
+pub(crate) fn node_ref(byte: u8) -> NodeRef {
+    NodeRef {
+        node_id: id(byte),
+        ipns_name: name(byte),
+    }
+}
+
+pub(crate) fn scope_ref(byte: u8) -> ChildScopeRef {
+    ChildScopeRef::new(id(byte), name(byte))
+}
+
+pub(crate) fn folder(children: &[u8]) -> ReadBody {
+    ReadBody::Folder {
+        created_at: 1,
+        modified_at: 2,
+        children: children
+            .iter()
+            .map(|b| ChildRef {
+                id: id(*b),
+                name: format!("n{b:02x}"),
+                ipns_name: name(*b),
+                kind: NodeKind::Folder,
+                link_counter: 1,
+                unknown: PreservedFields::new(),
+            })
+            .collect(),
+        unknown: PreservedFields::new(),
+    }
+}
+
+/// One interior node on the fake network.
+pub(crate) struct FakeNode {
+    epoch: u64,
+    children: Vec<u8>,
+    /// The node's record is a scope root: the walk must stop at it.
+    is_scope_root: bool,
+    publishes: u32,
+    /// A persistent publish fault.
+    fault: Option<ScopeRootPublishError>,
+    /// The next `n` publishes lose the CAS **without** advancing the epoch —
+    /// a non-advancing ordinary writer winning the race.
+    lost_race_next: u32,
+}
+
+impl FakeNode {
+    pub(crate) fn new(epoch: u64, children: &[u8]) -> Self {
+        Self {
+            epoch,
+            children: children.to_vec(),
+            is_scope_root: false,
+            publishes: 0,
+            fault: None,
+            lost_race_next: 0,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct NetState {
+    /// The scope root's own published epoch.
+    pub(crate) scope_epoch: u64,
+    /// The scope root's read-body children.
+    pub(crate) root_children: Vec<u8>,
+    /// The committed direct-child-scope index.
+    pub(crate) index: Vec<u8>,
+    pub(crate) nodes: HashMap<[u8; 16], FakeNode>,
+    /// Names whose scope-root record sits below the scope's floor.
+    pub(crate) superseded: Vec<Vec<u8>>,
+    /// Names whose record the adoption gate refuses outright.
+    pub(crate) forged: Vec<Vec<u8>>,
+    /// Per-node resolve faults.
+    pub(crate) node_faults: HashMap<[u8; 16], SweepResolveFailure>,
+    /// The scope pointer's `currentRootName`, if the scope was re-pointed.
+    pub(crate) pointer: Option<Vec<u8>>,
+    /// The published index, once a repair lands.
+    pub(crate) repaired_index: Option<Vec<ChildScopeRef>>,
+    pub(crate) index_repair_fault: Option<ScopeRootPublishError>,
+}
+
+/// The sweep's fake network: one scope, its interior nodes, and its pointer.
+/// A publish advances the node's epoch so a re-resolve converges.
+#[derive(Clone, Default)]
+pub(crate) struct FakeNet {
+    pub(crate) state: Rc<RefCell<NetState>>,
+    pub(crate) consults: Rc<Cell<u32>>,
+    pub(crate) index_repairs: Rc<Cell<u32>>,
+}
+
+impl FakeNet {
+    pub(crate) fn new(scope_epoch: u64, root_children: &[u8]) -> Self {
+        let net = Self::default();
+        {
+            let mut state = net.state.borrow_mut();
+            state.scope_epoch = scope_epoch;
+            state.root_children = root_children.to_vec();
+        }
+        net
+    }
+
+    pub(crate) fn node(self, byte: u8, epoch: u64, children: &[u8]) -> Self {
+        self.state
+            .borrow_mut()
+            .nodes
+            .insert(id(byte), FakeNode::new(epoch, children));
+        self
+    }
+
+    /// A descendant scope root: the walk stops at it. `indexed` lists it in
+    /// the scope's `directChildScopeIndex`; omitting it is the #38 D6 gap.
+    pub(crate) fn scope_root(self, byte: u8, indexed: bool, children: &[u8]) -> Self {
+        {
+            let mut state = self.state.borrow_mut();
+            let mut node = FakeNode::new(0, children);
+            node.is_scope_root = true;
+            state.nodes.insert(id(byte), node);
+            if indexed {
+                state.index.push(byte);
+            }
+        }
+        self
+    }
+
+    pub(crate) fn with<Fun: FnOnce(&mut FakeNode)>(self, byte: u8, edit: Fun) -> Self {
+        edit(
+            self.state
+                .borrow_mut()
+                .nodes
+                .get_mut(&id(byte))
+                .expect("node"),
+        );
+        self
+    }
+
+    pub(crate) fn fault(self, byte: u8, fault: ScopeRootPublishError) -> Self {
+        self.with(byte, |node| node.fault = Some(fault))
+    }
+
+    pub(crate) fn lost_race_next(self, byte: u8, n: u32) -> Self {
+        self.with(byte, |node| node.lost_race_next = n)
+    }
+
+    pub(crate) fn node_fault(self, byte: u8, reason: SweepResolveFailure) -> Self {
+        self.state.borrow_mut().node_faults.insert(id(byte), reason);
+        self
+    }
+
+    pub(crate) fn superseded(self, byte: u8) -> Self {
+        self.state.borrow_mut().superseded.push(name(byte));
+        self
+    }
+
+    pub(crate) fn forged(self, byte: u8) -> Self {
+        self.state.borrow_mut().forged.push(name(byte));
+        self
+    }
+
+    pub(crate) fn pointer_to(self, byte: u8) -> Self {
+        self.state.borrow_mut().pointer = Some(name(byte));
+        self
+    }
+
+    pub(crate) fn clear_fault(&self, byte: u8) {
+        self.state
+            .borrow_mut()
+            .nodes
+            .get_mut(&id(byte))
+            .expect("node")
+            .fault = None;
+    }
+
+    pub(crate) fn epoch(&self, byte: u8) -> u64 {
+        self.state
+            .borrow()
+            .nodes
+            .get(&id(byte))
+            .expect("node")
+            .epoch
+    }
+
+    pub(crate) fn publishes(&self, byte: u8) -> u32 {
+        self.state
+            .borrow()
+            .nodes
+            .get(&id(byte))
+            .expect("node")
+            .publishes
+    }
+}
+
+impl SweepResolver for FakeNet {
+    async fn resolve_scope(
+        &self,
+        scope: &ChildScopeRef,
+    ) -> Result<SweptScope, SweepResolveFailure> {
+        let state = self.state.borrow();
+        if state.forged.contains(&scope.ipns_name) {
+            return Err(SweepResolveFailure::Rejected);
+        }
+        if state.superseded.contains(&scope.ipns_name) {
+            return Err(SweepResolveFailure::Superseded);
+        }
+        let index = state
+            .repaired_index
+            .clone()
+            .unwrap_or_else(|| state.index.iter().map(|b| scope_ref(*b)).collect());
+        Ok(SweptScope {
+            current_read_epoch: state.scope_epoch,
+            children: state.root_children.iter().map(|b| node_ref(*b)).collect(),
+            direct_child_scope_index: index,
+        })
+    }
+
+    async fn consult_pointer(
+        &self,
+        _scope_id: &[u8; 16],
+    ) -> Result<Option<Vec<u8>>, SweepResolveFailure> {
+        self.consults.set(self.consults.get() + 1);
+        Ok(self.state.borrow().pointer.clone())
+    }
+
+    async fn resolve_child(&self, child: &NodeRef) -> Result<SweptChild, SweepResolveFailure> {
+        let state = self.state.borrow();
+        if let Some(reason) = state.node_faults.get(&child.node_id) {
+            return Err(*reason);
+        }
+        if state.forged.contains(&child.ipns_name) {
+            return Err(SweepResolveFailure::Rejected);
+        }
+        if state.superseded.contains(&child.ipns_name) {
+            return Err(SweepResolveFailure::Superseded);
+        }
+        let node = state
+            .nodes
+            .get(&child.node_id)
+            .ok_or(SweepResolveFailure::Unavailable)?;
+        if node.is_scope_root {
+            return Ok(SweptChild::ScopeRoot(ChildScopeRef::new(
+                child.node_id,
+                child.ipns_name.clone(),
+            )));
+        }
+        Ok(SweptChild::Interior(SweptNode {
+            current_read_epoch: node.epoch,
+            read_body: folder(&node.children),
+            carried_unknown: PreservedFields::new(),
+            carried_epoch_tag_unknown: PreservedFields::new(),
+        }))
+    }
+}
+
+impl SweepPublisher for FakeNet {
+    async fn publish_node(&self, node: &LaggingNode<'_>) -> Result<(), ScopeRootPublishError> {
+        let mut state = self.state.borrow_mut();
+        let entry = state.nodes.get_mut(&node.node_id).expect("node");
+        entry.publishes += 1;
+        if entry.lost_race_next > 0 {
+            entry.lost_race_next -= 1;
+            return Err(ScopeRootPublishError::LostRace);
+        }
+        match &entry.fault {
+            None => {
+                entry.epoch = entry.epoch.max(node.read_epoch);
+                Ok(())
+            }
+            // A concurrent *sweeper* winner: its record is at our epoch, so
+            // the node re-resolves converged on the next pass.
+            Some(ScopeRootPublishError::LostRace) => {
+                entry.epoch = entry.epoch.max(node.read_epoch);
+                Err(ScopeRootPublishError::LostRace)
+            }
+            Some(error) => Err(error.clone()),
+        }
+    }
+
+    async fn repair_child_scope_index(
+        &self,
+        _scope: &ChildScopeRef,
+        index: &[ChildScopeRef],
+    ) -> Result<(), ScopeRootPublishError> {
+        self.index_repairs.set(self.index_repairs.get() + 1);
+        let mut state = self.state.borrow_mut();
+        if let Some(error) = state.index_repair_fault.clone() {
+            return Err(error);
+        }
+        state.repaired_index = Some(index.to_vec());
+        Ok(())
+    }
+}
+
+/// One sweep scenario, described once and run twice: over [`FakeNet`] and over
+/// the production seams. Bytes name both a node id (`[byte; 16]`) and its
+/// simulated name, so the two runs' [`SweepOutcome`](super::SweepOutcome)s are
+/// directly comparable.
+pub(crate) struct Scenario {
+    /// A stable name for assertion messages.
+    pub(crate) label: &'static str,
+    /// The scope root's published read epoch.
+    pub(crate) scope_epoch: u64,
+    /// The scope root's read-body children, in body order.
+    pub(crate) children: &'static [u8],
+    /// Interior nodes: `(byte, published read epoch)`.
+    pub(crate) nodes: &'static [(u8, u64)],
+    /// Descendant scope roots: `(byte, named in the direct-child-scope index)`.
+    pub(crate) scope_roots: &'static [(u8, bool)],
+}
+
+impl Scenario {
+    /// The simulation network this scenario describes.
+    pub(crate) fn fake(&self) -> FakeNet {
+        let mut net = FakeNet::new(self.scope_epoch, self.children);
+        for (byte, epoch) in self.nodes {
+            net = net.node(*byte, *epoch, &[]);
+        }
+        for (byte, indexed) in self.scope_roots {
+            net = net.scope_root(*byte, *indexed, &[]);
+        }
+        net
+    }
+}
+
+/// The scenarios both the fake and the production seams must agree on.
+pub(crate) const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        label: "a lagging interior node converges",
+        scope_epoch: 2,
+        children: &[0x01],
+        nodes: &[(0x01, 1)],
+        scope_roots: &[],
+    },
+    Scenario {
+        label: "a node already at the scope epoch is a no-op",
+        scope_epoch: 2,
+        children: &[0x01],
+        nodes: &[(0x01, 2)],
+        scope_roots: &[],
+    },
+    Scenario {
+        label: "the walk stops at an indexed scope root",
+        scope_epoch: 2,
+        children: &[0x01, 0x0a],
+        nodes: &[(0x01, 1)],
+        scope_roots: &[(0x0a, true)],
+    },
+    Scenario {
+        label: "an unindexed scope root is repaired and flagged",
+        scope_epoch: 2,
+        children: &[0x0a],
+        nodes: &[],
+        scope_roots: &[(0x0a, false)],
+    },
+];

--- a/crates/engine/src/rotation/sweep/sim.rs
+++ b/crates/engine/src/rotation/sweep/sim.rs
@@ -61,26 +61,6 @@ pub(crate) fn folder_named(
     }
 }
 
-#[allow(dead_code)]
-pub(crate) fn folder(children: &[u8]) -> ReadBody {
-    ReadBody::Folder {
-        created_at: 1,
-        modified_at: 2,
-        children: children
-            .iter()
-            .map(|b| ChildRef {
-                id: id(*b),
-                name: format!("n{b:02x}"),
-                ipns_name: name(*b),
-                kind: NodeKind::Folder,
-                link_counter: 1,
-                unknown: PreservedFields::new(),
-            })
-            .collect(),
-        unknown: PreservedFields::new(),
-    }
-}
-
 /// One interior node on the fake network.
 pub(crate) struct FakeNode {
     epoch: u64,
@@ -391,8 +371,10 @@ pub(crate) struct Scenario {
     pub(crate) scope_epoch: u64,
     /// The scope root's read-body children, in body order.
     pub(crate) children: &'static [u8],
-    /// Interior nodes: `(byte, published read epoch)`.
-    pub(crate) nodes: &'static [(u8, u64)],
+    /// Interior nodes: `(byte, published read epoch, the children its read body
+    /// names)`. A child named here is reached one level deeper than the scope
+    /// root's own body, so the scenario drives the frontier expansion.
+    pub(crate) nodes: &'static [(u8, u64, &'static [u8])],
     /// Descendant scope roots: `(byte, named in the direct-child-scope index)`.
     pub(crate) scope_roots: &'static [(u8, bool)],
 }
@@ -401,8 +383,8 @@ impl Scenario {
     /// The simulation network this scenario describes.
     pub(crate) fn fake(&self) -> FakeNet {
         let mut net = FakeNet::new(self.scope_epoch, self.children);
-        for (byte, epoch) in self.nodes {
-            net = net.node(*byte, *epoch, &[]);
+        for (byte, epoch, children) in self.nodes {
+            net = net.node(*byte, *epoch, children);
         }
         for (byte, indexed) in self.scope_roots {
             net = net.scope_root(*byte, *indexed);
@@ -417,21 +399,21 @@ pub(crate) const SCENARIOS: &[Scenario] = &[
         label: "a lagging interior node converges",
         scope_epoch: 2,
         children: &[0x01],
-        nodes: &[(0x01, 1)],
+        nodes: &[(0x01, 1, &[])],
         scope_roots: &[],
     },
     Scenario {
         label: "a node already at the scope epoch is a no-op",
         scope_epoch: 2,
         children: &[0x01],
-        nodes: &[(0x01, 2)],
+        nodes: &[(0x01, 2, &[])],
         scope_roots: &[],
     },
     Scenario {
         label: "the walk stops at an indexed scope root",
         scope_epoch: 2,
         children: &[0x01, 0x0a],
-        nodes: &[(0x01, 1)],
+        nodes: &[(0x01, 1, &[])],
         scope_roots: &[(0x0a, true)],
     },
     Scenario {
@@ -439,6 +421,39 @@ pub(crate) const SCENARIOS: &[Scenario] = &[
         scope_epoch: 2,
         children: &[0x0a],
         nodes: &[],
+        scope_roots: &[(0x0a, false)],
+    },
+    Scenario {
+        label: "a nested subtree converges at every level",
+        scope_epoch: 2,
+        children: &[0x01],
+        nodes: &[(0x01, 1, &[0x02]), (0x02, 1, &[0x03]), (0x03, 1, &[])],
+        scope_roots: &[],
+    },
+    Scenario {
+        label: "two parents naming one child sweep it once",
+        scope_epoch: 2,
+        children: &[0x01, 0x02],
+        nodes: &[(0x01, 1, &[0x03]), (0x02, 1, &[0x03]), (0x03, 1, &[])],
+        scope_roots: &[],
+    },
+    Scenario {
+        label: "a mixed-epoch level walks past its converged nodes",
+        scope_epoch: 2,
+        children: &[0x02, 0x01],
+        nodes: &[
+            (0x01, 2, &[0x03]),
+            (0x02, 1, &[0x04]),
+            (0x03, 1, &[]),
+            (0x04, 2, &[]),
+        ],
+        scope_roots: &[],
+    },
+    Scenario {
+        label: "the walk stops at a scope root nested below the root",
+        scope_epoch: 2,
+        children: &[0x01],
+        nodes: &[(0x01, 1, &[0x0a])],
         scope_roots: &[(0x0a, false)],
     },
 ];


### PR DESCRIPTION
Rebuilds the sweep as the lazy wave [ADR 0003](https://github.com/FSM1/cipher-box-next/blob/main/decisions/0003-sweep-population-and-below-floor-scope-roots.md) settles: a scope's **interior nodes**, not its descendant scope roots. The old pass enumerated the eager set and called `reseal_scope_root` — the cascade's job, with a predicate nothing in production could satisfy.

### Scope

1. **Re-targeted at interior nodes.** `sweep_pass` now gates the scope root, walks its read body stopping at every scope-root boundary, and re-seals each node whose envelope epoch lags the scope's. A lagging body opens under the seed the scope's history-link ratchet walks back to (new `reseal::seed_at_epoch`, sharing one `ratchet_step` with `walkable_chain_start`) and re-seals via `net::author::author_child_envelope`. `SweepTarget` is gone: the pure pass now carries no key material at all.
2. **Concrete seams.** `SweepResolver` and the new `SweepPublisher` land on `OwnerRotationNet` over `RecordTransport` + `ApiClient`, reusing the existing gated root read.
3. **Superseded, not rejected.** A scope root below its own read-epoch floor gets a third verdict, routed through the scope-pointer consult and re-resolved at `currentRootName`, failing closed when the fresh record still lags.
4. **The index self-heal is decoupled** — it runs on the walk result before any epoch comparison is acted on, and repairs the whole invariant (canonical, and naming every scope root the walk saw).
5. **Grant creation's convergence gate now fires.** It converges the granted folder's own subtree rather than the whole parent scope, and refuses on a node left unproven.

Also lands the fake-vs-concrete equivalence check inherited from the earlier seam slice: one scenario set in `rotation/sweep/sim.rs` drives both the simulation network and the production seams, so a drifted fake fails the **Engine Tests** gate rather than being found by reading.

### Review findings folded back in

`/simplify`, `/security-review` and `/crypto-privacy-review` all ran on this diff. Two real defects came out of it, both now fixed and red-proofed:

- **Critical.** A walked child carrying a grant section was proved a scope root by its owner-signed commitment and node id alone. A vault root carries no ascent link, so the gate's ascent stage never runs on it — a committed writer could plant the owner's own vault root as a `ChildRef` and have the self-heal repair it into this scope's committed index, where a later cascade would re-key it under this scope's seed. The ascent link is now required, release-active.
- **High.** Nothing on the sweep's read path adopts an interior record, so no gate raised the name's durable sequence floor; publishing at `floor + 1` lost the CAS forever on any node this device had not browsed. The pass now carries the sequence it read as the CAS lower bound and advances the floor on the confirmed unseal, as the child pipeline does.

Plus: a node no seed on the ratchet opens is isolated into an `unreachable` bucket instead of aborting the scope's whole pass; one `ipnsName` per node id is bound across the walk, so the read plane's C2 conflict aborts instead of leaving the losing name live; the parked scope read is keyed on the scope root's own name and both seams take the scope explicitly.

### Residuals worth knowing

- The interior read deliberately skips the read-epoch floor — that is what the lazy wave *is*. The stage it skips carried authorship, so a party who held an old epoch's seed and still holds the node's write key can author a body this pass promotes. That is the write plane's residual forgery window (`CONTEXT.md` "Forgery window"), closed by `rotateScopeWrite`, and it is now stated where the skip happens.
- The gate's scope-transplant check runs after the floor stages, so an owner-signed root of another scope presented under this label classifies as *superseded* rather than rejected. It costs one pointer round-trip and admits nothing — the re-resolve runs the full gate — and both halves are covered by tests.
- A resolve that is `Rejected` or `Unavailable` still aborts the whole pass, inherited from the eager-set walk's posture. Converging the clean nodes first would be strictly safer and is worth a follow-up.

`blueprint/engine.md` gains the read-epoch-floor posture, the retained-window limit, and the grant gate's subtree scoping — facts the implementation exposed that the earlier correction did not record.

No TypeScript in this diff.

Closes #1025


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rebuild sweep as an interior-node lazy wave over real seams
> - Rewrites [`sweep.rs`](https://github.com/FSM1/cipher-box/pull/1200/files#diff-279b0c78488fd12f5b7c481a78e4bde585a3958554caf3ec373b0ce0f1de7f36) to operate only over interior nodes, stopping at descendant scope-root boundaries instead of resealing across the whole tree; descendant re-keying remains the cascade's responsibility.
> - Replaces the single `SweepResolver::resolve` method with three scoped methods (`resolve_scope`, `consult_pointer`, `resolve_child`) and introduces `SweepPublisher` for separate interior-node republish and child-scope index repair operations.
> - Adds `converge_subtree` as a targeted entrypoint for grant creation, replacing the prior `sweep_pass`+`FloorStore` gate in `create_read_grant`; convergence now fails if any interior node is unreachable or lost a CAS race.
> - Adds `seed_at_epoch` in [`reseal.rs`](https://github.com/FSM1/cipher-box/pull/1200/files#diff-b2fe57df54ee620bafe15db50cdad8bdda11d00bb30623ea3f30ad85b7f0b4fe) to walk the key-regression ratchet backward over carried history links to recover a seed for a specific epoch.
> - Implements `SweepResolver`, `SweepPublisher`, and `CascadeResealResolver` on `OwnerRotationNet` in [`rotation.rs`](https://github.com/FSM1/cipher-box/pull/1200/files#diff-d37e98e69d8d281a4e324a10d5954a5e73147013e3aa1330558044fce6b7773d), including child-scope verification against parent seed and commitment.
> - Adds `Superseded` verdict handling throughout: below-floor scope roots trigger a pointer consult and re-resolve rather than a hard failure.
> - Risk: `CreateGrantError::SubtreeNotConverged` now fires on unreachable nodes in addition to lost CAS races, making grant creation stricter than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39f39b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved folder and node synchronization during grant creation.
  * Added recovery for lagging records and retained history.
  * Added automatic repair of child-scope indexes.
  * Improved handling of unreachable, superseded, and unavailable records.

* **Bug Fixes**
  * Prevented unreachable records from being incorrectly reported as trust violations.
  * Improved recovery when records are at or above the durable sequence floor.

* **Documentation**
  * Clarified sweep, history-retention, cascade-reseal, and transport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->