### PR TITLE
docs: correct what the web e2e README says blocks the write path

### DIFF
--- a/tests/web-e2e/README.md
+++ b/tests/web-e2e/README.md
@@ -20,28 +20,9 @@ Normative source: [`blueprint/testing.md`](../../blueprint/testing.md).
 ## What it does not cover yet
 
 Nothing on the write path — no folder create/rename/move/delete, no upload, no
-download. `blueprint/testing.md` scopes this tier at login-and-CRUD; two
-blockers, neither of them this suite's, hold the CRUD half. They are not
-independent: the first stops a write before it can reach the second.
-
-- **A first-run vault is never provisioned.** No production code publishes a
-  vault pointer — `seal_repoint` (`crates/engine/src/sync/pointer.rs`) has
-  callers only in tests, and both `deposit_write_seed` call sites in
-  `crates/engine/src/facade.rs` are fed from a pointer that already resolved.
-  So a cold start on a fresh account carries no write scope seed and no root
-  name; `spawn_resolve_tick_loop` returns without spawning, and the drain that
-  loop owns is the only thing that publishes. A queued op renders as pending
-  indefinitely, having reached no endpoint at all — which is what a folder
-  create in this suite does today.
-- **No pin store under the job.** The API pins hosted uploads through Kubo and
-  this workflow starts none, so `POST /content/upload` answers 503. The engine
-  reads that verdict as unclassified, charges no attempt, and retries instead of
-  dead-lettering — so once ops do drain, an upload spec would hang rather than
-  fail. A write-path slice needs a Kubo service here, as the contract suite
-  already runs one.
-
-Both are engine and workflow work, not suite work: specs that drive the shipped
-`data-testid`s can only follow them.
+download. `blueprint/testing.md` scopes this tier at login-and-CRUD, and the
+CRUD half is blocked on engine and workflow work outside this suite. The issue
+tracker carries what is outstanding and why.
 
 ## How the suite logs in
 

--- a/tests/web-e2e/README.md
+++ b/tests/web-e2e/README.md
@@ -21,17 +21,27 @@ Normative source: [`blueprint/testing.md`](../../blueprint/testing.md).
 
 Nothing on the write path — no folder create/rename/move/delete, no upload, no
 download. `blueprint/testing.md` scopes this tier at login-and-CRUD; two
-independent blockers, neither of them this suite's, hold the CRUD half:
+blockers, neither of them this suite's, hold the CRUD half. They are not
+independent: the first stops a write before it can reach the second.
 
-- **No affordance to drive.** `apps/web` ships no create, rename, move, delete,
-  or download control; the drop zone is the only write surface that exists.
-  Specs bind to `data-testid`s that ship, so those slices land with their
-  components rather than ahead of them.
+- **A first-run vault is never provisioned.** No production code publishes a
+  vault pointer — `seal_repoint` (`crates/engine/src/sync/pointer.rs`) has
+  callers only in tests, and both `deposit_write_seed` call sites in
+  `crates/engine/src/facade.rs` are fed from a pointer that already resolved.
+  So a cold start on a fresh account carries no write scope seed and no root
+  name; `spawn_resolve_tick_loop` returns without spawning, and the drain that
+  loop owns is the only thing that publishes. A queued op renders as pending
+  indefinitely, having reached no endpoint at all — which is what a folder
+  create in this suite does today.
 - **No pin store under the job.** The API pins hosted uploads through Kubo and
   this workflow starts none, so `POST /content/upload` answers 503. The engine
   reads that verdict as unclassified, charges no attempt, and retries instead of
-  dead-lettering — so an upload spec would hang rather than fail. A write-path
-  slice needs a Kubo service here first, as the contract suite already runs one.
+  dead-lettering — so once ops do drain, an upload spec would hang rather than
+  fail. A write-path slice needs a Kubo service here, as the contract suite
+  already runs one.
+
+Both are engine and workflow work, not suite work: specs that drive the shipped
+`data-testid`s can only follow them.
 
 ## How the suite logs in
 


### PR DESCRIPTION
The README's "What it does not cover yet" section described the blockers that hold the write-path half of this suite, with their call sites. That is outstanding work, and outstanding work is tracked in issues here — the prose goes stale the moment either blocker lands, and nothing in CI catches a README that has quietly become false.

The section now says what the suite does not cover and points at the tracker. Two claims it carried are gone for separate reasons:

- **"No affordance to drive"** was false. `apps/web` shipped create, rename, move and delete controls in wave 4; the README still said the drop zone was the only write surface.
- **The blocker analysis** moved to the tracker. #1205 carries the provisioning gap, #1096 carries the pin-store and Kubo service requirement, and #1208 carries the upload retry defect.

## What the investigation found

The premise of #1096 — that a Kubo service is the first thing a write needs — is wrong, so this PR does not add one.

Nothing in production provisions a first-run vault. `seal_repoint` has exactly one production caller, in write rotation, which re-points a vault that already exists; every other caller is behind `#[cfg(test)]`. With no pointer, cold start returns no write scope seed and no root name, `spawn_resolve_tick_loop` returns without spawning, and the drain lives inside that loop.

Driven against a real stack, a folder created in the browser renders, sits at `pending: "metadata"`, and 100 seconds later the tab has issued zero requests since `/auth/login`. No write reaches any endpoint, so a Kubo service and write specs would both have been dead weight.

Every write suite plants the vault pointer by hand, which is why no existing gate catches this.

The Kubo service and five CRUD specs were written and reverted: the specs fail at the settle after the mutation, and a red spec on a merge-blocking job is not a gate. Filed as #1205, with #1096 blocked by it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct the web e2e README description of what blocks the write path
> Updates the 'What it does not cover yet' section of [README.md](https://github.com/FSM1/cipher-box/pull/1206/files#diff-823a3248db4ed62adc46ef8b88bf8cac083b2bb733db96c7178f00f3a9a40444) to remove outdated blocker details (missing UI affordances and pin store/Kubo 503s) and replace them with a concise note that CRUD is blocked by engine/workflow work outside this suite, pointing readers to the issue tracker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7abf971.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->