### PR TITLE
feat: derive the owner writer pseudonym from a dedicated KDF edge

### DIFF
--- a/crates/core/kat/manifest.json
+++ b/crates/core/kat/manifest.json
@@ -62,7 +62,7 @@
   },
   "kdf": {
     "file": "vectors/kdf/edges.json",
-    "count": 15,
+    "count": 16,
     "edges": [
       {
         "name": "node-seed",
@@ -108,6 +108,11 @@
         "name": "blinded-tag",
         "context": "cipherbox/v2/blinded-tag",
         "inputLayout": "derive_key(ctx, ecdh[32] || scopeRootIpnsName[var])"
+      },
+      {
+        "name": "owner-pseudonym-seed",
+        "context": "cipherbox/v2/owner-pseudonym-seed",
+        "inputLayout": "derive_key(ctx, loginSecret[var])"
       },
       {
         "name": "pseudonym-sign",

--- a/crates/core/kat/vectors/kdf/edges.json
+++ b/crates/core/kat/vectors/kdf/edges.json
@@ -62,6 +62,12 @@
       "output": "58e8260d6f6afeff70a83b907cf63010fd815f0a760f29a7417e9bd1044667e9"
     },
     {
+      "name": "owner-pseudonym-seed",
+      "context": "cipherbox/v2/owner-pseudonym-seed",
+      "inputLayout": "derive_key(ctx, loginSecret[var])",
+      "output": "b5fdf0ec901009831dcc1f4fcb2736142c12406e8c61c7d987342f237bf777ad"
+    },
+    {
       "name": "pseudonym-sign",
       "context": "cipherbox/v2/pseudonym-sign",
       "inputLayout": "ed25519_from_seed(derive_key(ctx, pairwiseMaterial[32] || scopeId[16]))",

--- a/crates/core/src/kdf/mod.rs
+++ b/crates/core/src/kdf/mod.rs
@@ -1,6 +1,6 @@
 //! The frozen KDF edge catalog (blueprint/core.md "KDF edge catalog", #39 D8).
 //!
-//! Nothing in CipherBox derives a key outside these fifteen edges. Every edge
+//! Nothing in CipherBox derives a key outside these sixteen edges. Every edge
 //! is domain-separated by a fixed `cipherbox/v2/<edge>` context string fed to
 //! BLAKE3 `derive_key`; per-node/per-id material takes the frozen shape
 //! `keyed_hash(derive_key(context, seed), id)` — ids, tags, and indices are
@@ -38,6 +38,7 @@ const CTX_IPNS_KEYPAIR: &str = "cipherbox/v2/ipns-keypair";
 const CTX_ASCENT_KEYPAIR: &str = "cipherbox/v2/ascent-keypair";
 const CTX_ENC_SUBKEY: &str = "cipherbox/v2/enc-subkey";
 const CTX_BLINDED_TAG: &str = "cipherbox/v2/blinded-tag";
+const CTX_OWNER_PSEUDONYM_SEED: &str = "cipherbox/v2/owner-pseudonym-seed";
 const CTX_PSEUDONYM_SIGN: &str = "cipherbox/v2/pseudonym-sign";
 const CTX_OWNER_POINTER_SEED: &str = "cipherbox/v2/owner-pointer-seed";
 const CTX_SCOPE_POINTER: &str = "cipherbox/v2/scope-pointer";
@@ -55,7 +56,7 @@ pub struct EdgeSpec {
     pub input_layout: &'static str,
 }
 
-/// The fifteen edges, in catalog order. [`edge_probe_outputs`] returns one
+/// The sixteen edges, in catalog order. [`edge_probe_outputs`] returns one
 /// output per row in this same order.
 pub const EDGES: &[EdgeSpec] = &[
     EdgeSpec {
@@ -102,6 +103,11 @@ pub const EDGES: &[EdgeSpec] = &[
         name: "blinded-tag",
         context: CTX_BLINDED_TAG,
         input_layout: "derive_key(ctx, ecdh[32] || scopeRootIpnsName[var])",
+    },
+    EdgeSpec {
+        name: "owner-pseudonym-seed",
+        context: CTX_OWNER_PSEUDONYM_SEED,
+        input_layout: "derive_key(ctx, loginSecret[var])",
     },
     EdgeSpec {
         name: "pseudonym-sign",
@@ -186,6 +192,10 @@ fn blinded_tag_bytes(ecdh_shared: &[u8; SECRET_LEN], scope_root_ipns_name: &[u8]
     let out = derive_key(CTX_BLINDED_TAG, &ikm);
     ikm.zeroize();
     out
+}
+
+fn owner_pseudonym_seed_bytes(login_secret: &[u8]) -> SecretBytes {
+    derive_key(CTX_OWNER_PSEUDONYM_SEED, login_secret)
 }
 
 fn pseudonym_sign_bytes(pairwise_material: &[u8; SECRET_LEN], scope_id: &[u8; 16]) -> SecretBytes {
@@ -289,8 +299,16 @@ pub fn blinded_tag(
     *blinded_tag_bytes(ecdh_shared, scope_root_ipns_name).as_bytes()
 }
 
+/// `owner-pseudonym-seed`: the owner's `pseudonym-sign` input, from the login
+/// secret. A dedicated edge keeps structure-signing authority off the
+/// encryption and pointer planes (FSM1/cipher-box-next ADR 0005).
+pub fn owner_pseudonym_seed(login_secret: &[u8]) -> SecretBytes {
+    owner_pseudonym_seed_bytes(login_secret)
+}
+
 /// `pseudonym-sign`: the Ed25519 writer-pseudonym keypair from the pairwise
-/// material (ECDH, or the owner's root secret) and the scope id.
+/// material (a grantee's ECDH secret, or the owner's `ownerPseudonymSeed`) and
+/// the scope id.
 pub fn pseudonym_sign(pairwise_material: &[u8; SECRET_LEN], scope_id: &[u8; 16]) -> Ed25519Signer {
     Ed25519Signer::from_seed(*pseudonym_sign_bytes(pairwise_material, scope_id).as_bytes())
 }
@@ -385,7 +403,7 @@ impl core::fmt::Debug for EdgeProbeOutput {
 }
 
 /// Run every edge under one probe, in [`EDGES`] order. Backs the separation KAT
-/// (the fifteen outputs must be pairwise distinct), its property test, and the
+/// (the sixteen outputs must be pairwise distinct), its property test, and the
 /// frozen vectors the KAT generator writes.
 ///
 /// The **catalog-freezing / separation surface**, not the production derivation
@@ -432,6 +450,10 @@ pub fn edge_probe_outputs(probe: &EdgeProbe) -> Vec<EdgeProbeOutput> {
         EdgeProbeOutput {
             name: "blinded-tag",
             output: b(blinded_tag_bytes(probe.seed, probe.ipns_name)),
+        },
+        EdgeProbeOutput {
+            name: "owner-pseudonym-seed",
+            output: b(owner_pseudonym_seed_bytes(probe.seed)),
         },
         EdgeProbeOutput {
             name: "pseudonym-sign",
@@ -517,6 +539,10 @@ mod tests {
 
         assert_eq!(read_key(&seed).as_bytes(), &by("read-key"));
         assert_eq!(node_seed(&seed, &id).as_bytes(), &by("node-seed"));
+        assert_eq!(
+            owner_pseudonym_seed(&seed).as_bytes(),
+            &by("owner-pseudonym-seed")
+        );
         // Keypair edges: the public key must match a keypair built from the
         // frozen seed bytes.
         assert_eq!(

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -2190,7 +2190,7 @@ fn envelope_reject_vectors_fire_the_named_check() {
 }
 
 // ---------------------------------------------------------------------------
-// KDF edge catalog: the fifteen frozen edges, their contexts + layouts, the
+// KDF edge catalog: the sixteen frozen edges, their contexts + layouts, the
 // per-edge output freeze, and the mechanical separation KAT.
 // ---------------------------------------------------------------------------
 
@@ -2208,6 +2208,7 @@ const ALL_EDGE_NAMES: &[&str] = &[
     "ascent-keypair",
     "enc-subkey",
     "blinded-tag",
+    "owner-pseudonym-seed",
     "pseudonym-sign",
     "owner-pointer-seed",
     "scope-pointer",

--- a/crates/core/tests/kdf_props.rs
+++ b/crates/core/tests/kdf_props.rs
@@ -1,6 +1,6 @@
 //! Property layer over the KDF edge catalog (blueprint/testing.md
 //! "crates/core — KATs and property tests"): the mechanical separation law
-//! under arbitrary inputs — no two of the fifteen edges ever produce equal
+//! under arbitrary inputs — no two of the sixteen edges ever produce equal
 //! output for equal inputs — plus per-edge determinism. Case counts are bounded
 //! for CI speed; failing seeds persist natively but not under wasm, where the
 //! source tree may be read-only (mirrors tests/codec_props.rs).

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -31,6 +31,7 @@ pub mod gate;
 pub mod grants;
 pub mod mailbox;
 pub mod net;
+mod owner_keys;
 pub mod profile;
 pub mod rotation;
 pub mod seams;

--- a/crates/engine/src/owner_keys.rs
+++ b/crates/engine/src/owner_keys.rs
@@ -66,10 +66,9 @@ mod tests {
         );
     }
 
-    /// None of the three inputs ADR 0005 rejected may stand in for
-    /// `ownerPseudonymSeed`. A provisioned `ownerPseudonymPk` is committed
-    /// epoch-free and never revised, so a swapped input is a permanent
-    /// `SignerNotCommitted` on every later rotation of that account.
+    /// None of the three inputs FSM1/cipher-box-next ADR 0005 rejected may
+    /// stand in for `ownerPseudonymSeed` (why it is unrecoverable:
+    /// [`SessionIdentity::owner_writer_pseudonym_signer`]).
     #[test]
     fn writer_pseudonym_is_none_of_the_rejected_owner_inputs() {
         let session = session();

--- a/crates/engine/src/owner_keys.rs
+++ b/crates/engine/src/owner_keys.rs
@@ -1,0 +1,120 @@
+//! The owner's production [`OwnerScopeKeys`] arm over the session identity
+//! (blueprint/engine.md "Rotation primitives").
+
+use cipherbox_core::suite::ed25519::Ed25519Signer;
+use cipherbox_core::suite::secret::SECRET_LEN;
+use zeroize::Zeroizing;
+
+use crate::net::rotation::OwnerScopeKeys;
+use crate::session::SessionIdentity;
+
+/// The two per-scope owner derivations a re-seal needs, resolved off the live
+/// session.
+///
+/// Borrows the session rather than copying seeds out of it: a cascade discovers
+/// its scope ids at runtime, so the derivations must stay lazy, and the session
+/// stays the terminal owner of the secrets they come from.
+// The facade's rotation commands do not construct this yet.
+#[allow(dead_code)]
+pub(crate) struct OwnerSessionKeys<'a> {
+    session: &'a SessionIdentity,
+}
+
+#[allow(dead_code)]
+impl<'a> OwnerSessionKeys<'a> {
+    pub(crate) fn new(session: &'a SessionIdentity) -> Self {
+        Self { session }
+    }
+}
+
+impl OwnerScopeKeys for OwnerSessionKeys<'_> {
+    fn writer_pseudonym(&self, scope_id: &[u8; 16]) -> Ed25519Signer {
+        self.session.owner_writer_pseudonym_signer(scope_id)
+    }
+
+    fn pointer_read_key(&self, scope_id: &[u8; 16]) -> Zeroizing<[u8; SECRET_LEN]> {
+        Zeroizing::new(*self.session.pointer_read_key(scope_id).as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cipherbox_core::kdf;
+    use cipherbox_core::suite::secret::ct_eq;
+
+    use crate::facade::LoginSecret;
+
+    const SECRET: [u8; 32] = [0x11; 32];
+    const SCOPE: [u8; 16] = [0x22; 16];
+
+    fn session() -> SessionIdentity {
+        SessionIdentity::derive(&LoginSecret::new(SECRET.to_vec())).expect("valid identity")
+    }
+
+    fn pseudonym_from(seed: &[u8; 32]) -> [u8; 32] {
+        kdf::pseudonym_sign(seed, &SCOPE).verifying_key().to_bytes()
+    }
+
+    #[test]
+    fn writer_pseudonym_is_the_owner_pseudonym_seed_edge() {
+        let session = session();
+        let keys = OwnerSessionKeys::new(&session);
+        assert_eq!(
+            keys.writer_pseudonym(&SCOPE).verifying_key().to_bytes(),
+            pseudonym_from(kdf::owner_pseudonym_seed(&SECRET).as_bytes()),
+        );
+    }
+
+    /// None of the three inputs ADR 0005 rejected may stand in for
+    /// `ownerPseudonymSeed`. A provisioned `ownerPseudonymPk` is committed
+    /// epoch-free and never revised, so a swapped input is a permanent
+    /// `SignerNotCommitted` on every later rotation of that account.
+    #[test]
+    fn writer_pseudonym_is_none_of_the_rejected_owner_inputs() {
+        let session = session();
+        let keys = OwnerSessionKeys::new(&session);
+        let live = keys.writer_pseudonym(&SCOPE).verifying_key().to_bytes();
+
+        let enc = kdf::enc_subkey(&SECRET);
+        let self_ecdh = enc
+            .diffie_hellman(&enc.public())
+            .expect("self-ECDH is contributory");
+
+        for (name, seed) in [
+            ("the login secret", SECRET),
+            (
+                "the owner pointer seed",
+                *kdf::owner_pointer_seed(&SECRET).as_bytes(),
+            ),
+            ("self-ECDH over the enc subkey", *self_ecdh.as_bytes()),
+        ] {
+            assert_ne!(live, pseudonym_from(&seed), "{name} stood in for the edge");
+        }
+    }
+
+    #[test]
+    fn pointer_read_key_is_the_sessions_per_scope_key() {
+        let session = session();
+        let keys = OwnerSessionKeys::new(&session);
+        assert!(ct_eq(
+            &keys.pointer_read_key(&SCOPE),
+            session.pointer_read_key(&SCOPE).as_bytes(),
+        ));
+    }
+
+    #[test]
+    fn both_derivations_are_keyed_by_the_scope() {
+        let session = session();
+        let keys = OwnerSessionKeys::new(&session);
+        let other = [0x33u8; 16];
+        assert_ne!(
+            keys.writer_pseudonym(&SCOPE).verifying_key().to_bytes(),
+            keys.writer_pseudonym(&other).verifying_key().to_bytes(),
+        );
+        assert!(!ct_eq(
+            &keys.pointer_read_key(&SCOPE),
+            &keys.pointer_read_key(&other),
+        ));
+    }
+}

--- a/crates/engine/src/owner_keys.rs
+++ b/crates/engine/src/owner_keys.rs
@@ -14,7 +14,6 @@ use crate::session::SessionIdentity;
 /// Borrows the session rather than copying seeds out of it: a cascade discovers
 /// its scope ids at runtime, so the derivations must stay lazy, and the session
 /// stays the terminal owner of the secrets they come from.
-// The facade's rotation commands do not construct this yet.
 #[allow(dead_code)]
 pub(crate) struct OwnerSessionKeys<'a> {
     session: &'a SessionIdentity,

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -51,6 +51,10 @@ pub(crate) struct SessionIdentity {
     /// The owner pointer seed (`owner-pointer-seed` edge). Per-scope pointer
     /// signers and pointer read keys derive from it lazily. Zeroizes on drop.
     owner_pointer_seed: SecretBytes,
+    /// The owner pseudonym seed (`owner-pseudonym-seed` edge) — the owner's
+    /// `pseudonym-sign` input, kept off the encryption and pointer planes
+    /// (FSM1/cipher-box-next ADR 0005). Zeroizes on drop.
+    owner_pseudonym_seed: SecretBytes,
     /// The owner ECDSA identity: the login-secret scalar adopted directly (v1
     /// Web3Auth TSS export is the secp256k1 identity key), not a catalog edge.
     /// Signs the login challenge and structure commitments; its verifier is the
@@ -78,6 +82,7 @@ impl SessionIdentity {
             login_secret: Zeroizing::new(bytes.to_vec()),
             enc_subkey: kdf::enc_subkey(bytes),
             owner_pointer_seed: kdf::owner_pointer_seed(bytes),
+            owner_pseudonym_seed: kdf::owner_pseudonym_seed(bytes),
             identity,
         })
     }
@@ -149,19 +154,29 @@ impl SessionIdentity {
         kdf::ipns_keypair(write_seed.as_bytes())
     }
 
-    /// The writer-pseudonym signer (`pseudonym-sign` edge): the per-(scope,
-    /// writer) signing keypair the rotator detached-signs re-sealed structures
-    /// with, from the pairwise material (owner root secret or grant ECDH) and
-    /// the scope id. The pairwise material already fully encodes the
-    /// owner/writer identity, so — unlike every sibling factory — this one
-    /// consults no stored session field; its output is keyed solely by its
-    /// arguments.
-    pub(crate) fn writer_pseudonym_signer(
+    /// The owner's writer-pseudonym signer for a scope: the `pseudonym-sign`
+    /// edge over the session's `ownerPseudonymSeed`.
+    ///
+    /// Takes only the scope id, so the owner's pairwise input cannot be
+    /// supplied — and mis-supplied — by a caller. A provisioned
+    /// `ownerPseudonymPk` is committed epoch-free and never revised, so wrong
+    /// bytes here are a permanent `SignerNotCommitted` on every later rotation.
+    pub(crate) fn owner_writer_pseudonym_signer(&self, scope_id: &[u8; 16]) -> Ed25519Signer {
+        kdf::pseudonym_sign(self.owner_pseudonym_seed.as_bytes(), scope_id)
+    }
+
+    /// A **grantee's** writer-pseudonym signer (`pseudonym-sign` edge): the
+    /// per-(scope, writer) signing keypair a re-sealed structure is
+    /// detach-signed under, from the grant's pairwise ECDH secret and the scope
+    /// id. That secret already fully encodes the writer's identity, so — unlike
+    /// every sibling factory — this one consults no stored session field. The
+    /// owner arm is [`Self::owner_writer_pseudonym_signer`].
+    pub(crate) fn grantee_writer_pseudonym_signer(
         &self,
-        pairwise_material: &[u8; 32],
+        grant_ecdh: &[u8; 32],
         scope_id: &[u8; 16],
     ) -> Ed25519Signer {
-        kdf::pseudonym_sign(pairwise_material, scope_id)
+        kdf::pseudonym_sign(grant_ecdh, scope_id)
     }
 }
 
@@ -276,31 +291,31 @@ mod tests {
     }
 
     #[test]
-    fn writer_pseudonym_signer_binds_pairwise_material_and_scope() {
+    fn grantee_writer_pseudonym_signer_binds_pairwise_material_and_scope() {
         let id = identity(&[7u8; 32]);
         let pairwise = [2u8; 32];
         let scope = [3u8; 16];
         let base = id
-            .writer_pseudonym_signer(&pairwise, &scope)
+            .grantee_writer_pseudonym_signer(&pairwise, &scope)
             .verifying_key()
             .to_bytes();
         assert_eq!(
             base,
-            id.writer_pseudonym_signer(&pairwise, &scope)
+            id.grantee_writer_pseudonym_signer(&pairwise, &scope)
                 .verifying_key()
                 .to_bytes(),
             "same pairwise material and scope must yield the same pseudonym signer",
         );
         assert_ne!(
             base,
-            id.writer_pseudonym_signer(&[9u8; 32], &scope)
+            id.grantee_writer_pseudonym_signer(&[9u8; 32], &scope)
                 .verifying_key()
                 .to_bytes(),
             "different pairwise material is a different pseudonym",
         );
         assert_ne!(
             base,
-            id.writer_pseudonym_signer(&pairwise, &[4u8; 16])
+            id.grantee_writer_pseudonym_signer(&pairwise, &[4u8; 16])
                 .verifying_key()
                 .to_bytes(),
             "a different scope is a different pseudonym",


### PR DESCRIPTION
Adds the frozen KDF edge `owner-pseudonym-seed` to `crates/core`, and gives `OwnerScopeKeys` its first production implementor in `crates/engine`.

Closes #1163

## Why the bytes matter

Vault provisioning publishes `ownerPseudonymPk` into an owner-signed grant-set commitment that carries no epoch and cannot be revised. If provisioning derives the owner's pseudonym one way and `OwnerScopeKeys` derives it another, every rotation on every account provisioned before the correction fails permanently with `SignerNotCommitted`. Getting this derivation right, and pinning it, is the point of the PR.

## Core — the edge

`owner-pseudonym-seed`, context `cipherbox/v2/owner-pseudonym-seed`, layout `derive_key(ctx, loginSecret[var])` — the same shape as its neighbour `owner-pointer-seed`, returning the zeroizing `SecretBytes`. The per-scope split stays where it already is, in `pseudonym_sign`'s `scopeId` argument.

- Registered in `EDGES` and `edge_probe_outputs` in catalog order, between `blinded-tag` and `pseudonym-sign`, matching the `blueprint/core.md` catalog.
- KAT vector regenerated through the committed generator (`cargo run -p cipherbox-core --example kat_gen`) — new rows in `crates/core/kat/vectors/kdf/edges.json` and `crates/core/kat/manifest.json`. No existing vector output moved.
- The FSM1/cipher-box-next#39 D8 separation KAT now covers the edge: `ALL_EDGE_NAMES` in `crates/core/tests/kat_manifest.rs` gains the row, so the frozen-output separation test and the `kdf_props.rs` property test both include it. Sixteen edges.
- `pseudonym_sign`'s doc names `ownerPseudonymSeed` as the owner-side input instead of the unimplementable "root secret". Its signature and the grantee half of the edge are untouched.

## Engine — the production implementor

`OwnerScopeKeys` previously had no implementor outside `#[cfg(test)]`, so the owner arm of the rotation net could not be constructed in production at all.

- `OwnerSessionKeys` in the new `crates/engine/src/owner_keys.rs` borrows `SessionIdentity` rather than copying seeds out of it: a cascade discovers its scope ids at runtime, so the derivations stay lazy and the session stays the terminal owner of the secrets.
- `SessionIdentity` carries `owner_pseudonym_seed` beside `owner_pointer_seed`, and `owner_writer_pseudonym_signer(scope_id)` takes **only** a scope id — the owner's pairwise input can no longer be supplied, and so no longer mis-supplied, by a caller.
- The old pairwise-material factory is renamed `grantee_writer_pseudonym_signer`, which is what it always was. It had no production caller, so the rename is contained to `session.rs`.

The trait is implemented, not yet constructed by the facade's rotation commands; wiring `RotateNow`/`Revoke`/`Downgrade` through to a rotation primitive is separate work.

## Tests

`writer_pseudonym` is pinned to the `owner-pseudonym-seed` edge, and separately refused all three inputs ADR 0005 rejected — the login secret, the owner pointer seed, and self-ECDH over the enc subkey. Red-proofed: swapping the derivation to `owner_pointer_seed` fails both tests; restored green.

## Specification

`blueprint/core.md` already carries both catalog rows, merged in #1198. The decision is ADR 0005 in `FSM1/cipher-box-next` (`decisions/0005-owner-pseudonym-seed.md`, FSM1/cipher-box-next#59), amending FSM1/cipher-box-next#39 D2 and relating to its D8.

## Merge safety

`crates/engine/src/net/rotation.rs` is deliberately untouched, along with `rotation/{cascade,mod,reseal,sweep}.rs`, `grants/create.rs`, `gate/floor.rs` and `crates/contract/tests/contract.rs` — all owned by #1200. `OwnerScopeKeys` is consumed as `&dyn`, so a production implementor needs no edit to its defining file; the new module registers in `lib.rs` instead of `rotation/mod.rs` for the same reason. The two existing `#[cfg(test)]` impls are left exactly as they are.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown`, and `pnpm lint:tracker-refs` all pass locally.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive owner writer pseudonym from a dedicated `owner-pseudonym-seed` KDF edge
> - Adds a new `owner-pseudonym-seed` KDF edge (context `cipherbox/v2/owner-pseudonym-seed`) to the catalog in [`kdf/mod.rs`](https://github.com/FSM1/cipher-box/pull/1211/files#diff-6ed54529ce877d9e97780154c4e0966a28b486fd44f23f820b7cb74e12d82c4e), bringing the total edge count to 16.
> - Adds `kdf::owner_pseudonym_seed()` as a public API that derives `SecretBytes` from the login secret using BLAKE3.
> - Extends `SessionIdentity` in [`session.rs`](https://github.com/FSM1/cipher-box/pull/1211/files#diff-c74c3f1f6bf6504ed42b9177cedf0105e92258f8dabbffbc138de02118719a37) to store the derived seed and exposes `owner_writer_pseudonym_signer()`, separating owner and grantee pseudonym derivation paths.
> - Introduces [`owner_keys.rs`](https://github.com/FSM1/cipher-box/pull/1211/files#diff-6401bec7d58a1b557f668a6354defcc5f16a1536f1dc6b343b752665dcce4573) with `OwnerSessionKeys`, a concrete `OwnerScopeKeys` implementation backed by `SessionIdentity`.
> - KAT manifest, vectors, and test fixtures are updated to include the new edge and frozen output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbe754f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added owner-specific pseudonym derivation for secure, scope-bound signing.
  * Added session-backed owner key handling with separate owner and grantee signing flows.
  * Added pointer-read key derivation for owner-scoped sessions.
* **Bug Fixes**
  * Improved separation between owner and grantee cryptographic materials.
* **Tests**
  * Expanded key-derivation coverage with a new owner pseudonym seed vector.
  * Added validation for scope separation and supported derivation sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->