### PR TITLE
docs: forbid tool attribution in commits, PRs, and issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,14 @@ Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`
 
 Enforcement: commitlint is configured via `commitlint.config.js`, and PR titles are validated in CI by `.github/workflows/pr-title.yml`. Note that the husky `commit-msg` hook was replaced by an Entire CLI wrapper and currently does not run commitlint locally — follow the format regardless, since CI will reject non-conforming PR titles.
 
+### No Tool Attribution
+
+A commit message, a PR title, a PR body, an issue, and a review comment carry **no attribution to the tool that wrote them** — no `🤖 Generated with …` line, no `Co-Authored-By:` trailer naming an assistant, no session link. This holds however the text was produced.
+
+The authorship that matters is the commit author and the PR author, which git and GitHub already record. A generated-by line adds nothing a reader can act on and turns every PR body into an advertisement.
+
+Agent harnesses commonly append such a line by default. That default does not apply here: strip it before opening or editing a PR, and check the rendered body afterwards rather than trusting that it was never added.
+
 ### Mandatory PR Review Flow
 
 Every code PR runs these review gates after it is opened as a **draft**, before it is driven toward merge — mandatory, not optional:


### PR DESCRIPTION
Agent harnesses commonly append a `🤖 Generated with …` line and a session link to a PR body by default. AGENTS.md covered commit format, PR titles, and the review flow, but said nothing about attribution — so the rule lived only in whatever brief each agent happened to be given, and held by luck rather than by enforcement. #1212 opened with the line in its body.

The new **No Tool Attribution** section states the rule where every agent already reads, covering commit messages, PR titles and bodies, issues, and review comments. It names the harness default explicitly, so an agent that sees the default has something specific to weigh against it, and asks for the rendered body to be checked afterwards rather than assumed clean.

The reasoning is recorded too: the authorship that matters is the commit author and the PR author, which git and GitHub already record, so a generated-by line adds nothing a reader can act on.

Documentation only, no code surface, so the review gates do not apply. Prettier and markdownlint are clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forbid tool attribution in commits, PRs, and issues
> Adds a 'No Tool Attribution' section to [AGENTS.md](https://github.com/FSM1/cipher-box/pull/1213/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) requiring that commit messages, PR titles, PR bodies, issues, and review comments omit tool attribution lines (e.g. `Generated with ...`, `Co-Authored-By:` naming an assistant, session links). Instructs stripping such lines from agent harness defaults and verifying the rendered PR body before submission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa084f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->