### PR TITLE
feat: seal the owner's contact book and land the invite-record store

### DIFF
--- a/crates/core/src/seal/settings_record.rs
+++ b/crates/core/src/seal/settings_record.rs
@@ -70,7 +70,7 @@ pub fn settings_record_aad(header: &SettingsRecordHeader) -> Vec<u8> {
 /// not open it, and only the secret's holder can author one.
 ///
 /// `ephemeral_scalar` must be **fresh per record**: HPKE ephemeral reuse across
-/// two seals under one recipient key is a confidentiality break
+/// two seals under one recipient key and `info` is a confidentiality break
 /// ([`hpke::hpke_seal`]).
 pub fn seal_settings_record(
     owner_enc_secret: &X25519Secret,

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -2402,6 +2402,9 @@ impl<T: SeamTypes> Engine<T> {
                     ContactStoreError::Full => EngineError::MalformedInput {
                         check: "contact-book-full",
                     },
+                    ContactStoreError::Encode(_) => EngineError::MalformedInput {
+                        check: "contact-book-unstorable",
+                    },
                     ContactStoreError::Seam(e) => EngineError::Seam {
                         message: e.message().to_owned(),
                     },

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -2387,27 +2387,35 @@ impl<T: SeamTypes> Engine<T> {
                     });
                 }
                 let session = self.session.as_ref().ok_or(EngineError::NotStarted)?;
-                StagingContactStore::new(&self.seams.staging_store, session.enc_subkey())
-                    .record(&contact_code)
-                    .await
-                    .map(CommandOutcome::ContactImported)
-                    .map_err(|err| match err {
-                        ContactStoreError::Import(e @ CodecError::Malformed(_)) => {
-                            EngineError::MalformedInput { check: e.check() }
-                        }
-                        ContactStoreError::Full => EngineError::MalformedInput {
-                            check: "contact-book-full",
-                        },
-                        ContactStoreError::Seam(e) => EngineError::Seam {
-                            message: e.message().to_owned(),
-                        },
-                        // A rejected binding, and a stored book this build
-                        // cannot read: both are fail-closed trust verdicts, not
-                        // outages a host should retry.
-                        other => EngineError::TrustViolation {
-                            message: other.to_string(),
-                        },
-                    })
+                StagingContactStore::new(
+                    &self.seams.staging_store,
+                    session.enc_subkey(),
+                    &self.entropy,
+                )
+                .record(&contact_code)
+                .await
+                .map(CommandOutcome::ContactImported)
+                .map_err(|err| match err {
+                    ContactStoreError::Import(e @ CodecError::Malformed(_)) => {
+                        EngineError::MalformedInput { check: e.check() }
+                    }
+                    ContactStoreError::Full => EngineError::MalformedInput {
+                        check: "contact-book-full",
+                    },
+                    ContactStoreError::Seam(e) => EngineError::Seam {
+                        message: e.message().to_owned(),
+                    },
+                    ContactStoreError::Entropy(e) => EngineError::from_entropy(e),
+                    ContactStoreError::Seal(e) => EngineError::Seam {
+                        message: e.check().to_owned(),
+                    },
+                    // A rejected binding, and a stored book this build
+                    // cannot read: both are fail-closed trust verdicts, not
+                    // outages a host should retry.
+                    other => EngineError::TrustViolation {
+                        message: other.to_string(),
+                    },
+                })
             }
             Command::ManualRefresh => self.manual_refresh().await.map(|()| CommandOutcome::Done),
             Command::SiweLogin { message, signature } => {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -2519,9 +2519,10 @@ impl<T: SeamTypes> Engine<T> {
                         message: e.message().to_owned(),
                     },
                     ContactStoreError::Entropy(e) => EngineError::from_entropy(e),
-                    ContactStoreError::Seal(e) => EngineError::Seam {
-                        message: e.check().to_owned(),
-                    },
+                    // A seal refusal is deterministic in the book it was handed,
+                    // so it joins `Encode` as an input the host must change —
+                    // never `Seam`, whose retry would never converge.
+                    ContactStoreError::Seal(e) => EngineError::MalformedInput { check: e.check() },
                     // A rejected binding, and a stored book this build
                     // cannot read: both are fail-closed trust verdicts, not
                     // outages a host should retry.

--- a/crates/engine/src/grants/accept.rs
+++ b/crates/engine/src/grants/accept.rs
@@ -25,9 +25,10 @@ use cipherbox_core::suite::secret::SecretBytes;
 use cipherbox_core::suite::x25519::X25519Secret;
 use zeroize::Zeroizing;
 
+use crate::entropy::EntropyError;
 use crate::gate::{Candidate, GateError, ReaderContext, RejectionReason, SeedBlob, adopt_deferred};
 use crate::mailbox::VerifiedMailboxItem;
-use crate::seams::{FloorStore, Mailbox, SeamError, SeamResult};
+use crate::seams::{FloorStore, Mailbox, SeamError};
 
 use super::contact::Contact;
 use super::ledger::{PublishedGrantBlob, recipient_blinded_tag, self_locate};
@@ -235,7 +236,7 @@ pub(crate) const STORED_LIST_V: u64 = 1;
 /// hostile contact would permanently shrink the vault's upload headroom. Bounded
 /// release-active in both directions like every other repeated collection in a
 /// sealed structure.
-pub(crate) const MAX_RECEIVED_SHARES: usize = 1024;
+pub const MAX_RECEIVED_SHARES: usize = 1024;
 /// The bound on a bookmark's courtesy display label.
 pub(crate) const MAX_DISPLAY_NAME_BYTES: usize = 256;
 /// The bound on a bookmarked scope root's opaque `ipnsName`.
@@ -403,16 +404,23 @@ fn read_stored_list(tree: &Value) -> Result<ReceivedSharesList, ReceivedSharesCo
 /// does not extend core's frozen `Malformed` registry, whose names the KAT
 /// manifest pins.
 #[derive(Debug)]
-pub(crate) enum ReceivedSharesCodecError {
+pub enum ReceivedSharesCodecError {
     /// The det-CBOR framing was malformed.
     Codec(CodecError),
+    /// The stored blob did not open under this session's `enc-subkey` as a
+    /// `received-shares` blob — tampered, another identity's, or another
+    /// owner-local store's.
+    DidNotOpen(CodecError),
     /// Two bookmarks named one scope root — a list with no defined authority
     /// for that scope, refused in both directions (AGENTS.md rule 8).
     DuplicateScopeRoot,
     /// A stored body written at a grammar version this build does not read.
     /// Never treated as empty: the bookmarks are there, this build just cannot
     /// interpret them.
-    UnsupportedVersion { version: u64 },
+    UnsupportedVersion {
+        /// The version the stored body declared.
+        version: u64,
+    },
     /// A collection or field past its frozen bound.
     TooLong(TooLong),
 }
@@ -421,6 +429,9 @@ impl fmt::Display for ReceivedSharesCodecError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReceivedSharesCodecError::Codec(e) => write!(f, "received-shares codec: {e}"),
+            ReceivedSharesCodecError::DidNotOpen(e) => {
+                write!(f, "received-shares list did not open: {}", e.check())
+            }
             ReceivedSharesCodecError::DuplicateScopeRoot => {
                 f.write_str("received-shares list names one scope root twice")
             }
@@ -501,9 +512,9 @@ impl Reconciled {
 /// persisted in turn silently erase each other, and the mailbox items behind the
 /// lost bookmarks are already acked.
 pub trait ReceivedShareStore {
-    /// Durably persist the whole received-shares list. A failure returns a
-    /// [`SeamError`] and the accept flow does not ack.
-    async fn persist(&self, shares: &ReceivedSharesList) -> SeamResult<()>;
+    /// Durably persist the whole received-shares list. A failure means the
+    /// accept flow does not ack.
+    async fn persist(&self, shares: &ReceivedSharesList) -> Result<(), ReceivedShareStoreError>;
 
     /// The persisted list, or an empty one on a backing that holds none.
     ///
@@ -511,7 +522,64 @@ pub trait ReceivedShareStore {
     /// stored list this build cannot open is unrecoverable state, and reporting
     /// it as empty would let the next [`persist`](Self::persist) overwrite every
     /// bookmark behind it.
-    async fn load(&self) -> SeamResult<ReceivedSharesList>;
+    async fn load(&self) -> Result<ReceivedSharesList, ReceivedShareStoreError>;
+}
+
+/// Why a received-shares store operation failed.
+///
+/// The split that matters is [`Seam`](Self::Seam) — the backing could not be
+/// reached, so retry — against [`Unreadable`](Self::Unreadable), a fail-closed
+/// verdict on bytes that *are* there. Retrying that one never converges, and a
+/// host that treats it as an outage hides an attack signal. The owner-local
+/// stores all classify on this shape so one of them cannot drift into reporting
+/// a trust violation as availability (ADR 0006).
+#[derive(Debug)]
+pub enum ReceivedShareStoreError {
+    /// Stored bytes this build cannot read as a received-shares list. Never
+    /// reported as an empty list: the next persist would overwrite bookmarks it
+    /// never saw, and the mailbox items that delivered them are acked and gone.
+    Unreadable(ReceivedSharesCodecError),
+    /// The list to persist holds more than [`MAX_RECEIVED_SHARES`]. The stored
+    /// bytes are fine — the offered list is the one past the bound.
+    Full,
+    /// The offered list is not one this build may store: two bookmarks for one
+    /// scope root, or a field past its bound. A write-path refusal, so never
+    /// [`Unreadable`](Self::Unreadable) — nothing was read.
+    Encode(ReceivedSharesCodecError),
+    /// Entropy acquisition failed, so no list is sealed and none is written.
+    Entropy(EntropyError),
+    /// Sealing the list for storage failed.
+    Seal(CodecError),
+    /// The durable backing failed.
+    Seam(SeamError),
+}
+
+impl fmt::Display for ReceivedShareStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReceivedShareStoreError::Unreadable(e) => {
+                write!(f, "the stored list is unreadable: {e}")
+            }
+            ReceivedShareStoreError::Full => write!(
+                f,
+                "the received-shares list already holds {MAX_RECEIVED_SHARES} bookmarks"
+            ),
+            ReceivedShareStoreError::Encode(e) => write!(f, "the list cannot be stored: {e}"),
+            ReceivedShareStoreError::Entropy(e) => write!(f, "received-shares: {e}"),
+            ReceivedShareStoreError::Seal(e) => {
+                write!(f, "received-shares seal failed: {}", e.check())
+            }
+            ReceivedShareStoreError::Seam(e) => write!(f, "received-shares: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ReceivedShareStoreError {}
+
+impl From<SeamError> for ReceivedShareStoreError {
+    fn from(e: SeamError) -> Self {
+        ReceivedShareStoreError::Seam(e)
+    }
 }
 
 /// One owner-side sent-share record — the denormalized index the owner keeps.
@@ -609,8 +677,9 @@ pub enum AcceptError {
     Gate(GateError),
     /// Durably persisting the updated received-shares list failed — the item is
     /// left un-acked (never acked before durable), so it redelivers and
-    /// re-accepts idempotently. Nothing was lost.
-    Persist(SeamError),
+    /// re-accepts idempotently. Nothing was lost; whether a redelivery can ever
+    /// land is the [`ReceivedShareStoreError`] variant's answer.
+    Persist(ReceivedShareStoreError),
     /// Acking the item failed after the durable persist (the share IS recorded;
     /// the item will redeliver and re-accept idempotently).
     Ack(SeamError),

--- a/crates/engine/src/grants/contact_store.rs
+++ b/crates/engine/src/grants/contact_store.rs
@@ -417,7 +417,7 @@ mod tests {
     use super::super::contact::import_contact;
     use super::*;
     use crate::testkit::fakes::InMemoryStagingStore;
-    use crate::testkit::{SeededEntropy, block_on, conformance};
+    use crate::testkit::{FailingEntropy, SeededEntropy, SilentEntropy, block_on, conformance};
 
     fn enc(byte: u8) -> X25519Secret {
         X25519Secret::from_scalar([byte; 32])
@@ -425,24 +425,6 @@ mod tests {
 
     fn seeded(seed: u64) -> RefCell<SeededEntropy> {
         RefCell::new(SeededEntropy::new(seed))
-    }
-
-    /// Reports success while writing nothing, so the caller's ephemeral stays
-    /// all-zero — a seam that would silently reuse one HPKE ephemeral forever.
-    struct SilentEntropy;
-
-    impl Entropy for SilentEntropy {
-        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-            Ok(())
-        }
-    }
-
-    struct FailingEntropy;
-
-    impl Entropy for FailingEntropy {
-        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-            Err(EntropyError::new("no entropy"))
-        }
     }
 
     /// A book body sealed as this build seals one, so a test can put bytes the

--- a/crates/engine/src/grants/contact_store.rs
+++ b/crates/engine/src/grants/contact_store.rs
@@ -76,6 +76,10 @@ pub enum ContactStoreError {
     /// set this import would make is the one past the bound — so a host can
     /// offer [`ContactStore::forget`] rather than report corruption.
     Full,
+    /// The book to store is not one this build may write: two codes for one
+    /// identity, or a field past its bound. A write-path refusal, so never
+    /// [`Unreadable`](Self::Unreadable) — nothing was read.
+    Encode(BookCodecError),
     /// Entropy acquisition failed, so no book is sealed and none is written.
     Entropy(EntropyError),
     /// Sealing the book for storage failed. A write-path failure, so never
@@ -97,6 +101,7 @@ impl fmt::Display for ContactStoreError {
             ContactStoreError::Full => {
                 write!(f, "the contact book already holds {MAX_CONTACTS} contacts")
             }
+            ContactStoreError::Encode(e) => write!(f, "the contact book to store {e}"),
             ContactStoreError::Entropy(e) => write!(f, "contact book: {e}"),
             ContactStoreError::Seal(e) => write!(f, "contact book seal failed: {}", e.check()),
             ContactStoreError::Seam(e) => write!(f, "contact book: {e}"),
@@ -109,12 +114,6 @@ impl std::error::Error for ContactStoreError {}
 impl From<SeamError> for ContactStoreError {
     fn from(e: SeamError) -> Self {
         ContactStoreError::Seam(e)
-    }
-}
-
-impl From<BookCodecError> for ContactStoreError {
-    fn from(e: BookCodecError) -> Self {
-        ContactStoreError::Unreadable(e)
     }
 }
 
@@ -274,16 +273,14 @@ impl<'a, St: StagingStore, E: Entropy> StagingContactStore<'a, St, E> {
         let Some(blob) = self.staging.staged_bytes(self.staging_key()).await? else {
             return Ok(Vec::new());
         };
-        // A stored book this session cannot open is state, never an empty book:
-        // the next import would overwrite contacts it never saw.
         let body = open_owner_local(self.enc_secret, OwnerLocalKind::ContactBook, &blob)
-            .map_err(BookCodecError::DidNotOpen)?;
-        Ok(decode_book(&body)?)
+            .map_err(|e| ContactStoreError::Unreadable(BookCodecError::DidNotOpen(e)))?;
+        decode_book(&body).map_err(ContactStoreError::Unreadable)
     }
 
     /// Replace the whole book.
     async fn put(&self, book: &[Recorded]) -> Result<(), ContactStoreError> {
-        let body = encode_book(book)?;
+        let body = encode_book(book).map_err(ContactStoreError::Encode)?;
         let ephemeral =
             fresh_ephemeral(&mut *self.entropy.borrow_mut()).map_err(ContactStoreError::Entropy)?;
         let blob = seal_owner_local(
@@ -600,6 +597,33 @@ mod tests {
             Err(ContactStoreError::Unreadable(
                 BookCodecError::UnverifiableCode(_)
             ))
+        ));
+    }
+
+    /// The write path's own refusals are not a verdict on stored bytes: a book
+    /// this build declines to encode leaves the stored book unimpeached, so a
+    /// host must not be told the owner's contacts are corrupt.
+    #[test]
+    fn a_book_this_build_refuses_to_encode_is_not_reported_as_unreadable() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x62);
+        let entropy = seeded(62);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
+        let (contact, encoded) = import_recorded(&code(0x33)).expect("import");
+        let clash = [
+            Recorded {
+                contact,
+                code: encoded.clone(),
+            },
+            Recorded {
+                contact,
+                code: encoded,
+            },
+        ];
+
+        assert!(matches!(
+            block_on(store.put(&clash)),
+            Err(ContactStoreError::Encode(BookCodecError::DuplicateIdentity))
         ));
     }
 

--- a/crates/engine/src/grants/contact_store.rs
+++ b/crates/engine/src/grants/contact_store.rs
@@ -13,25 +13,29 @@
 //! [`Contact`], so a tampered backing can never re-point an identity key at a
 //! subkey its holder did not sign.
 //!
-//! What that does *not* cover, because the book carries no owner attestation
-//! and a contact code carries no counter: a tamperer can insert any validly
-//! signed third-party code, roll an identity back to a subkey its holder signed
-//! **once** but has since rotated away from, or delete an entry and turn a
-//! later revoke into [`ContactStoreError::RecipientNotImported`]. The book is
-//! also plaintext at rest, so it discloses the owner's contact graph to a local
-//! reader; the grant ledger that would otherwise carry those identity keys is
-//! sealed under the scope's write key, so this is a new disclosure rather than
-//! a restatement of a published one. Sealing the book under the `owner-local`
-//! structure closes the disclosure and the third-party insertion; the rollback
-//! and the deletion need a monotone counter that structure does not carry.
+//! The book is sealed HPKE-to-self under the session's `enc-subkey` before it
+//! reaches the host (`owner-local`, kind `contact-book`), so the contact graph
+//! is ciphertext at rest and only the owner can author an entry.
+//!
+//! What that does *not* cover, because a contact code carries no counter and
+//! the structure carries no generation: a host replaying an earlier sealed book
+//! rolls an identity back to a subkey its holder signed **once** but has since
+//! rotated away from, and dropping the stored key entirely reads as an empty
+//! book, turning a later revoke into
+//! [`ContactStoreError::RecipientNotImported`]. Both need a monotone counter
+//! held where the host cannot roll it back.
+
+use core::cell::RefCell;
 
 use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
 use cipherbox_core::error::CodecError;
+use cipherbox_core::seal::{OwnerLocalKind, open_owner_local, seal_owner_local};
 use cipherbox_core::suite::contact::import_contact_code;
 use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 use cipherbox_core::suite::x25519::X25519Secret;
 use core::fmt;
 
+use crate::entropy::{Entropy, EntropyError, fresh_ephemeral};
 use crate::seams::{SeamError, StagingStore};
 use crate::sync::owner_scoped_key;
 
@@ -72,6 +76,12 @@ pub enum ContactStoreError {
     /// set this import would make is the one past the bound — so a host can
     /// offer [`ContactStore::forget`] rather than report corruption.
     Full,
+    /// Entropy acquisition failed, so no book is sealed and none is written.
+    Entropy(EntropyError),
+    /// Sealing the book for storage failed. A write-path failure, so never
+    /// [`Unreadable`](Self::Unreadable) — nothing was read and nothing stored
+    /// is in doubt.
+    Seal(CodecError),
     /// The durable backing failed.
     Seam(SeamError),
 }
@@ -87,6 +97,8 @@ impl fmt::Display for ContactStoreError {
             ContactStoreError::Full => {
                 write!(f, "the contact book already holds {MAX_CONTACTS} contacts")
             }
+            ContactStoreError::Entropy(e) => write!(f, "contact book: {e}"),
+            ContactStoreError::Seal(e) => write!(f, "contact book seal failed: {}", e.check()),
             ContactStoreError::Seam(e) => write!(f, "contact book: {e}"),
         }
     }
@@ -115,6 +127,11 @@ impl From<BookCodecError> for ContactStoreError {
 pub enum BookCodecError {
     /// The det-CBOR framing was malformed.
     Codec(CodecError),
+    /// The stored blob did not open under this session's `enc-subkey` as a
+    /// `contact-book` blob — tampered, another identity's, another store's, or
+    /// written at a format version this build refuses. Never an empty book: the
+    /// contacts are there and this build cannot reach them.
+    DidNotOpen(CodecError),
     /// A stored code no longer imports — a tampered or truncated book, never a
     /// contact to skip past.
     UnverifiableCode(CodecError),
@@ -139,6 +156,7 @@ impl fmt::Display for BookCodecError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             BookCodecError::Codec(e) => write!(f, "codec: {e}"),
+            BookCodecError::DidNotOpen(e) => write!(f, "did not open: {}", e.check()),
             BookCodecError::UnverifiableCode(e) => {
                 write!(f, "holds a code that no longer imports: {}", e.check())
             }
@@ -225,16 +243,24 @@ fn import_recorded(bytes: &[u8]) -> Result<(Contact, Vec<u8>), CodecError> {
 
 /// The contact book the engine ships over a host's [`StagingStore`], under one
 /// staging key.
-pub struct StagingContactStore<'a, St> {
+///
+/// The book is sealed HPKE-to-self under the session's `enc-subkey` before it
+/// reaches the host, so no contact's identity key or encryption subkey sits in
+/// host storage in the clear.
+pub struct StagingContactStore<'a, St, E> {
     staging: &'a St,
+    enc_secret: &'a X25519Secret,
+    entropy: &'a RefCell<E>,
     staging_key: Vec<u8>,
 }
 
-impl<'a, St: StagingStore> StagingContactStore<'a, St> {
+impl<'a, St: StagingStore, E: Entropy> StagingContactStore<'a, St, E> {
     /// Wraps a staging store as the contact book for one session.
-    pub fn new(staging: &'a St, enc_secret: &'a X25519Secret) -> Self {
+    pub fn new(staging: &'a St, enc_secret: &'a X25519Secret, entropy: &'a RefCell<E>) -> Self {
         Self {
             staging,
+            enc_secret,
+            entropy,
             staging_key: owner_scoped_key(CONTACTS_PREFIX, enc_secret),
         }
     }
@@ -245,23 +271,36 @@ impl<'a, St: StagingStore> StagingContactStore<'a, St> {
     }
 
     async fn recorded(&self) -> Result<Vec<Recorded>, ContactStoreError> {
-        match self.staging.staged_bytes(self.staging_key()).await? {
-            None => Ok(Vec::new()),
-            Some(bytes) => Ok(decode_book(&bytes)?),
-        }
+        let Some(blob) = self.staging.staged_bytes(self.staging_key()).await? else {
+            return Ok(Vec::new());
+        };
+        // A stored book this session cannot open is state, never an empty book:
+        // the next import would overwrite contacts it never saw.
+        let body = open_owner_local(self.enc_secret, OwnerLocalKind::ContactBook, &blob)
+            .map_err(BookCodecError::DidNotOpen)?;
+        Ok(decode_book(&body)?)
     }
 
     /// Replace the whole book.
     async fn put(&self, book: &[Recorded]) -> Result<(), ContactStoreError> {
         let body = encode_book(book)?;
+        let ephemeral =
+            fresh_ephemeral(&mut *self.entropy.borrow_mut()).map_err(ContactStoreError::Entropy)?;
+        let blob = seal_owner_local(
+            self.enc_secret,
+            OwnerLocalKind::ContactBook,
+            &ephemeral,
+            &body,
+        )
+        .map_err(ContactStoreError::Seal)?;
         self.staging
-            .put_staged_bytes(self.staging_key(), &body)
+            .put_staged_bytes(self.staging_key(), &blob)
             .await?;
         Ok(())
     }
 }
 
-impl<St: StagingStore> ContactStore for StagingContactStore<'_, St> {
+impl<St: StagingStore, E: Entropy> ContactStore for StagingContactStore<'_, St, E> {
     async fn record(&self, contact_code: &[u8]) -> Result<Contact, ContactStoreError> {
         // Import re-encodes canonically, so what lands is the ~130 frozen bytes
         // of the three keys — never the caller's spelling, which tolerates
@@ -381,10 +420,43 @@ mod tests {
     use super::super::contact::import_contact;
     use super::*;
     use crate::testkit::fakes::InMemoryStagingStore;
-    use crate::testkit::{block_on, conformance};
+    use crate::testkit::{SeededEntropy, block_on, conformance};
 
     fn enc(byte: u8) -> X25519Secret {
         X25519Secret::from_scalar([byte; 32])
+    }
+
+    fn seeded(seed: u64) -> RefCell<SeededEntropy> {
+        RefCell::new(SeededEntropy::new(seed))
+    }
+
+    /// Reports success while writing nothing, so the caller's ephemeral stays
+    /// all-zero — a seam that would silently reuse one HPKE ephemeral forever.
+    struct SilentEntropy;
+
+    impl Entropy for SilentEntropy {
+        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+            Ok(())
+        }
+    }
+
+    struct FailingEntropy;
+
+    impl Entropy for FailingEntropy {
+        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+            Err(EntropyError::new("no entropy"))
+        }
+    }
+
+    /// A book body sealed as this build seals one, so a test can put bytes the
+    /// loader will actually open back under the store's key.
+    fn sealed(secret: &X25519Secret, seed: u64, body: &[u8]) -> Vec<u8> {
+        sealed_as(secret, OwnerLocalKind::ContactBook, seed, body)
+    }
+
+    fn sealed_as(secret: &X25519Secret, kind: OwnerLocalKind, seed: u64, body: &[u8]) -> Vec<u8> {
+        let ephemeral = fresh_ephemeral(&mut SeededEntropy::new(seed)).expect("ephemeral");
+        seal_owner_local(secret, kind, &ephemeral, body).expect("seal")
     }
 
     /// A contact code the peer signed itself, as one arrives out of band.
@@ -436,8 +508,9 @@ mod tests {
     fn the_staging_store_passes_the_contact_store_kit() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x11);
+        let entropy = seeded(17);
         block_on(conformance::contact_store::check(async || {
-            StagingContactStore::new(&staging, &secret)
+            StagingContactStore::new(&staging, &secret, &entropy)
         }));
     }
 
@@ -447,10 +520,12 @@ mod tests {
     fn a_recorded_contact_resolves_by_identity_key_after_a_restart() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x21);
-        let imported = block_on(StagingContactStore::new(&staging, &secret).record(&code(0x33)))
-            .expect("import");
+        let entropy = seeded(33);
+        let imported =
+            block_on(StagingContactStore::new(&staging, &secret, &entropy).record(&code(0x33)))
+                .expect("import");
 
-        let restarted = StagingContactStore::new(&staging, &secret);
+        let restarted = StagingContactStore::new(&staging, &secret, &entropy);
         let resolved =
             block_on(resolve_recipient(&restarted, &identity_of(0x33))).expect("resolves");
         assert_eq!(resolved.identity_pk(), imported.identity_pk());
@@ -465,9 +540,11 @@ mod tests {
     fn an_identity_key_no_import_verified_fails_closed() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x31);
-        block_on(StagingContactStore::new(&staging, &secret).record(&code(0x33))).expect("import");
+        let entropy = seeded(49);
+        block_on(StagingContactStore::new(&staging, &secret, &entropy).record(&code(0x33)))
+            .expect("import");
 
-        let store = StagingContactStore::new(&staging, &secret);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         assert!(
             matches!(
                 block_on(resolve_recipient(&store, &identity_of(0x44))),
@@ -483,7 +560,8 @@ mod tests {
     fn a_code_whose_binding_fails_is_never_recorded() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x41);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(65);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         assert!(matches!(
             block_on(store.record(&substituted_code(0x33, 0x44))),
             Err(ContactStoreError::Import(_))
@@ -500,18 +578,20 @@ mod tests {
         );
     }
 
-    /// Why the code is stored rather than the pair: host bytes are re-verified
-    /// on every load, so re-pointing an identity key at a subkey its holder
-    /// never signed is refused rather than served to a grant.
+    /// Why the code is stored rather than the pair: the seal is not the only
+    /// check, so even a body that opens is re-verified before it reaches a
+    /// grant. Sealed under the store's own key so the tamper reaches the
+    /// decoder rather than stopping at the AEAD.
     #[test]
     fn a_tampered_book_never_yields_a_contact() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x51);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(81);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         block_on(store.record(&code(0x33))).expect("import");
         block_on(staging.put_staged_bytes(
             store.staging_key(),
-            &framed(&[substituted_code(0x33, 0x44)]),
+            &sealed(&secret, 51, &framed(&[substituted_code(0x33, 0x44)])),
         ))
         .expect("clobber");
 
@@ -527,15 +607,128 @@ mod tests {
     fn a_book_this_build_cannot_read_fails_closed_rather_than_reading_empty() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x61);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(97);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         block_on(store.record(&code(0x33))).expect("import");
         block_on(staging.put_staged_bytes(store.staging_key(), b"not a contact book"))
             .expect("clobber");
 
         assert!(matches!(
             block_on(store.contacts()),
-            Err(ContactStoreError::Unreadable(_))
+            Err(ContactStoreError::Unreadable(BookCodecError::DidNotOpen(_)))
         ));
+    }
+
+    /// The other arm of the same rule: bytes that open under this session's key
+    /// but carry a body this build does not read are still state, not an empty
+    /// book.
+    #[test]
+    fn a_body_this_build_cannot_decode_fails_closed_rather_than_reading_empty() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x62);
+        let entropy = seeded(98);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
+        block_on(store.record(&code(0x33))).expect("import");
+        block_on(staging.put_staged_bytes(
+            store.staging_key(),
+            &sealed(&secret, 62, b"opens, but is not a contact book"),
+        ))
+        .expect("clobber");
+
+        assert!(matches!(
+            block_on(store.contacts()),
+            Err(ContactStoreError::Unreadable(BookCodecError::Codec(_)))
+        ));
+    }
+
+    /// The store names its owner-local kind, so a sibling store's blob is
+    /// unreadable state even when its body is a book this build decodes
+    /// perfectly — separation is the kind, not the body grammar.
+    #[test]
+    fn a_blob_from_another_owner_local_store_fails_closed() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x63);
+        let entropy = seeded(99);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
+        block_on(staging.put_staged_bytes(
+            store.staging_key(),
+            &sealed_as(
+                &secret,
+                OwnerLocalKind::ReceivedShares,
+                63,
+                &framed(&[code(0x33)]),
+            ),
+        ))
+        .expect("stage");
+
+        assert!(
+            matches!(
+                block_on(store.contacts()),
+                Err(ContactStoreError::Unreadable(BookCodecError::DidNotOpen(_)))
+            ),
+            "another store's blob is an error, never a book to adopt"
+        );
+    }
+
+    /// The disclosure this store's seal closes: a local reader of host storage
+    /// must not learn who the owner has imported.
+    #[test]
+    fn the_persisted_book_never_holds_a_contact_key_in_the_clear() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x64);
+        let entropy = seeded(100);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
+        let imported = block_on(store.record(&code(0x33))).expect("import");
+
+        let stored = block_on(staging.staged_bytes(store.staging_key()))
+            .expect("staged")
+            .expect("the book is stored");
+        let identity = imported.identity_pk().to_sec1();
+        let subkey = imported.enc_subkey().to_bytes();
+        assert!(
+            !stored.windows(identity.len()).any(|w| w == identity),
+            "a contact's identity key must never sit in host storage in the clear"
+        );
+        assert!(
+            !stored.windows(subkey.len()).any(|w| w == subkey),
+            "a contact's encryption subkey is sealed too"
+        );
+    }
+
+    #[test]
+    fn an_all_zero_ephemeral_fails_closed_before_the_seal() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x65);
+        let entropy = RefCell::new(SilentEntropy);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
+        assert!(matches!(
+            block_on(store.record(&code(0x33))),
+            Err(ContactStoreError::Entropy(_))
+        ));
+        assert!(
+            block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged")
+                .is_none(),
+            "a refused seal writes nothing"
+        );
+    }
+
+    #[test]
+    fn an_entropy_failure_leaves_the_recorded_book_untouched() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x66);
+        let good = seeded(102);
+        block_on(StagingContactStore::new(&staging, &secret, &good).record(&code(0x33)))
+            .expect("import");
+
+        let broken = RefCell::new(FailingEntropy);
+        let store = StagingContactStore::new(&staging, &secret, &broken);
+        assert!(block_on(store.record(&code(0x44))).is_err());
+        assert_eq!(
+            block_on(store.contacts()).expect("load").len(),
+            1,
+            "a failed import never clears the book it could not replace"
+        );
     }
 
     #[test]
@@ -543,10 +736,12 @@ mod tests {
         let staging = InMemoryStagingStore::default();
         let alice = enc(0x71);
         let bob = enc(0x72);
-        block_on(StagingContactStore::new(&staging, &alice).record(&code(0x33))).expect("import");
+        let entropy = seeded(0x71);
+        block_on(StagingContactStore::new(&staging, &alice, &entropy).record(&code(0x33)))
+            .expect("import");
 
         assert!(
-            block_on(StagingContactStore::new(&staging, &bob).contacts())
+            block_on(StagingContactStore::new(&staging, &bob, &entropy).contacts())
                 .expect("load")
                 .is_empty(),
             "one store is shared across accounts; a contact must not cross identities"
@@ -601,7 +796,8 @@ mod tests {
     fn re_importing_an_identity_replaces_the_subkey_it_resolves_to() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x81);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(129);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         block_on(store.record(&code(0x33))).expect("first import");
         block_on(store.record(&bound_code(0x33, 0x99))).expect("rotated import");
 
@@ -628,7 +824,8 @@ mod tests {
 
         let staging = InMemoryStagingStore::default();
         let secret = enc(0xB1);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(177);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         let book: Vec<Recorded> = (0..MAX_CONTACTS)
             .map(|i| {
                 let (contact, code) =
@@ -659,7 +856,8 @@ mod tests {
 
         let staging = InMemoryStagingStore::default();
         let secret = enc(0xC1);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(193);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         let padded = {
             let mut map = cbor_decode(&code(0x33)).unwrap().as_map().unwrap().clone();
             map.insert("padding", Value::Bytes(vec![0x5A; 512]));
@@ -670,8 +868,11 @@ mod tests {
         let stored = block_on(staging.staged_bytes(store.staging_key()))
             .expect("staged")
             .expect("the book is stored");
+        // Read past the seal: the claim is about the body this store authored,
+        // and asserting on ciphertext would hold however the code was spelled.
+        let body = open_owner_local(&secret, OwnerLocalKind::ContactBook, &stored).expect("opens");
         assert!(
-            !stored.windows(16).any(|w| w == [0x5A; 16]),
+            !body.windows(16).any(|w| w == [0x5A; 16]),
             "the offered padding never reached the durable book"
         );
         assert_eq!(block_on(store.contacts()).expect("load").len(), 1);
@@ -681,7 +882,8 @@ mod tests {
     fn a_lost_write_never_destroys_the_recorded_book() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0x91);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(145);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         block_on(store.record(&code(0x33))).expect("import");
 
         staging.interrupt_staged_write_after(store.staging_key(), 0);
@@ -699,7 +901,8 @@ mod tests {
     fn the_books_staging_key_sits_under_the_swept_prefix() {
         let staging = InMemoryStagingStore::default();
         let secret = enc(0xA1);
-        let store = StagingContactStore::new(&staging, &secret);
+        let entropy = seeded(161);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
         block_on(store.record(&code(0x33))).expect("import");
 
         assert!(
@@ -708,6 +911,47 @@ mod tests {
                 .iter()
                 .all(|key| key.starts_with(CONTACTS_PREFIX)),
             "the book writes nothing outside the prefix orphan GC spares"
+        );
+    }
+
+    /// The freshness invariant the seal rests on: two persists must not share an
+    /// HPKE ephemeral. `fresh_ephemeral` only rejects an all-zero draw, so a seam
+    /// stuck on any other constant is caught here or nowhere.
+    #[test]
+    fn two_persists_never_share_an_hpke_ephemeral() {
+        fn enc_of(blob: &[u8]) -> Vec<u8> {
+            decode(blob)
+                .expect("frame")
+                .as_map()
+                .expect("map")
+                .get("enc")
+                .expect("enc")
+                .as_bytes()
+                .expect("bytes")
+                .to_vec()
+        }
+
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0xD1);
+        let entropy = seeded(209);
+        let store = StagingContactStore::new(&staging, &secret, &entropy);
+
+        block_on(store.record(&code(0x33))).expect("first import");
+        let first = enc_of(
+            &block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged")
+                .expect("stored"),
+        );
+        block_on(store.record(&code(0x44))).expect("second import");
+        let second = enc_of(
+            &block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged")
+                .expect("stored"),
+        );
+
+        assert_ne!(
+            first, second,
+            "an ephemeral reused across two seals under one key and info is a confidentiality break"
         );
     }
 }

--- a/crates/engine/src/grants/invite_store.rs
+++ b/crates/engine/src/grants/invite_store.rs
@@ -347,10 +347,9 @@ fn decode_records(bytes: &[u8]) -> Result<Vec<RecordedInvite>, InviteRecordsCode
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::entropy::EntropyError;
     use crate::sync::orphan_staging_keys;
     use crate::testkit::fakes::InMemoryStagingStore;
-    use crate::testkit::{SeededEntropy, block_on, conformance};
+    use crate::testkit::{FailingEntropy, SeededEntropy, SilentEntropy, block_on, conformance};
 
     fn enc(byte: u8) -> X25519Secret {
         X25519Secret::from_scalar([byte; 32])
@@ -372,24 +371,6 @@ mod tests {
     fn sealed_as(secret: &X25519Secret, kind: OwnerLocalKind, seed: u64, body: &[u8]) -> Vec<u8> {
         let ephemeral = fresh_ephemeral(&mut SeededEntropy::new(seed)).expect("ephemeral");
         seal_owner_local(secret, kind, &ephemeral, body).expect("seal")
-    }
-
-    /// Reports success while writing nothing, so the caller's ephemeral stays
-    /// all-zero — a seam that would silently reuse one HPKE ephemeral forever.
-    struct SilentEntropy;
-
-    impl Entropy for SilentEntropy {
-        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-            Ok(())
-        }
-    }
-
-    struct FailingEntropy;
-
-    impl Entropy for FailingEntropy {
-        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-            Err(EntropyError::new("no entropy"))
-        }
     }
 
     /// The HPKE ephemeral public half a stored blob carries.
@@ -740,6 +721,27 @@ mod tests {
         let mut body = Map::new();
         body.insert("extra", Value::Unsigned(1));
         body.insert("links", Value::Array(vec![]));
+        body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
+        assert!(matches!(
+            decode_records(&encode_fixed_depth(&Value::Map(body))),
+            Err(InviteRecordsCodecError::Codec(_))
+        ));
+    }
+
+    /// The set rejects an unknown key at the record too, not only at the top
+    /// level — a record is the authority for one link's permission.
+    #[test]
+    fn a_record_with_an_unknown_key_is_refused() {
+        let mut m = Map::new();
+        m.insert("ephemeralEncPk", Value::Bytes(vec![0x01; SECRET_LEN]));
+        m.insert(
+            "ephemeralIdentityPk",
+            Value::Bytes(vec![0x02; IDENTITY_PUBLIC_LEN]),
+        );
+        m.insert("extra", Value::Unsigned(1));
+        m.insert("tag", Value::Bytes(vec![0x03; 32]));
+        let mut body = Map::new();
+        body.insert("links", Value::Array(vec![Value::Map(m)]));
         body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
         assert!(matches!(
             decode_records(&encode_fixed_depth(&Value::Map(body))),

--- a/crates/engine/src/grants/invite_store.rs
+++ b/crates/engine/src/grants/invite_store.rs
@@ -40,8 +40,8 @@ use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 use cipherbox_core::suite::secret::SECRET_LEN;
 use cipherbox_core::suite::x25519::X25519Secret;
 
-use crate::entropy::{Entropy, fresh_ephemeral};
-use crate::seams::{SeamError, SeamResult, StagingStore, UnixMillis};
+use crate::entropy::{Entropy, EntropyError, fresh_ephemeral};
+use crate::seams::{SeamError, StagingStore, UnixMillis};
 use crate::sync::owner_scoped_key;
 
 use super::accept::{TooLong, fixed, reject_unknown, req, within};
@@ -61,7 +61,7 @@ const INVITE_RECORDS_V: u64 = 1;
 /// The frozen bound on recorded links, enforced release-active in both codec
 /// directions (AGENTS.md rule 8). One record per live link across every scope
 /// the owner has invited to; it bounds reader CPU and the staging budget alike.
-pub(crate) const MAX_INVITE_RECORDS: usize = 1024;
+pub const MAX_INVITE_RECORDS: usize = 1024;
 
 /// Why encoding or decoding a stored record set failed.
 ///
@@ -69,9 +69,13 @@ pub(crate) const MAX_INVITE_RECORDS: usize = 1024;
 /// does not extend core's frozen `Malformed` registry, whose names the KAT
 /// manifest pins.
 #[derive(Debug)]
-enum InviteRecordsCodecError {
+pub enum InviteRecordsCodecError {
     /// The det-CBOR framing was malformed.
     Codec(CodecError),
+    /// The stored blob did not open under this session's `enc-subkey` as an
+    /// `invite-records` blob — tampered, another identity's, or another
+    /// owner-local store's.
+    DidNotOpen(CodecError),
     /// Two records under one tag: no defined authority for that link's
     /// permission or deadline, refused in both directions (AGENTS.md rule 8).
     DuplicateTag,
@@ -81,7 +85,10 @@ enum InviteRecordsCodecError {
     ZeroDeadline,
     /// A set written at a grammar version this build does not read. Never
     /// treated as empty: the links are there, this build cannot read them.
-    UnsupportedVersion { version: u64 },
+    UnsupportedVersion {
+        /// The version the stored body declared.
+        version: u64,
+    },
     /// A collection or field past its frozen bound.
     TooLong(TooLong),
 }
@@ -90,6 +97,7 @@ impl fmt::Display for InviteRecordsCodecError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InviteRecordsCodecError::Codec(e) => write!(f, "codec: {e}"),
+            InviteRecordsCodecError::DidNotOpen(e) => write!(f, "did not open: {}", e.check()),
             InviteRecordsCodecError::DuplicateTag => f.write_str("names one tag twice"),
             InviteRecordsCodecError::ZeroDeadline => f.write_str("records a zero deadline"),
             InviteRecordsCodecError::UnsupportedVersion { version } => {
@@ -119,7 +127,7 @@ impl<E: Into<CodecError>> From<E> for InviteRecordsCodecError {
 /// it.
 pub trait InviteStore {
     /// Durably persist the whole set of recorded links.
-    async fn persist(&self, links: &[RecordedInvite]) -> SeamResult<()>;
+    async fn persist(&self, links: &[RecordedInvite]) -> Result<(), InviteStoreError>;
 
     /// The persisted records, or an empty set when the backing holds no entry
     /// at all — the module header states what a dropped entry costs.
@@ -128,7 +136,61 @@ pub trait InviteStore {
     /// a holder's hands, so a stored set this build cannot open is
     /// unrecoverable authority, and reporting it as empty would let the next
     /// [`persist`](Self::persist) overwrite every link behind it.
-    async fn load(&self) -> SeamResult<Vec<RecordedInvite>>;
+    async fn load(&self) -> Result<Vec<RecordedInvite>, InviteStoreError>;
+}
+
+/// Why an invite-store operation failed.
+///
+/// Classified on the shape the owner-local stores share
+/// ([`ReceivedShareStoreError`](super::ReceivedShareStoreError) carries the
+/// rationale). The records are an authorization input — `convert_invite_claim`
+/// decides what may be claimed from them — so "the stored set did not open" is
+/// a report that the owner's own authority was tampered with, and must never
+/// reach a host as a retryable outage.
+#[derive(Debug)]
+pub enum InviteStoreError {
+    /// Stored bytes this build cannot read as an invite record set. Never
+    /// reported as an empty set: the next persist would overwrite links whose
+    /// fragments are already in holders' hands.
+    Unreadable(InviteRecordsCodecError),
+    /// The set to persist holds more than [`MAX_INVITE_RECORDS`]. The stored
+    /// bytes are fine — the offered set is the one past the bound — so a host
+    /// can revoke a live link rather than report corruption.
+    Full,
+    /// The offered set is not one this build may store: two records under one
+    /// tag, or a zero deadline. A write-path refusal, so never
+    /// [`Unreadable`](Self::Unreadable) — nothing was read.
+    Encode(InviteRecordsCodecError),
+    /// Entropy acquisition failed, so no set is sealed and none is written.
+    Entropy(EntropyError),
+    /// Sealing the set for storage failed.
+    Seal(CodecError),
+    /// The durable backing failed.
+    Seam(SeamError),
+}
+
+impl fmt::Display for InviteStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InviteStoreError::Unreadable(e) => write!(f, "the stored invite record set {e}"),
+            InviteStoreError::Full => write!(
+                f,
+                "the invite records already hold {MAX_INVITE_RECORDS} links"
+            ),
+            InviteStoreError::Encode(e) => write!(f, "the invite record set to store {e}"),
+            InviteStoreError::Entropy(e) => write!(f, "invite records: {e}"),
+            InviteStoreError::Seal(e) => write!(f, "invite records seal failed: {}", e.check()),
+            InviteStoreError::Seam(e) => write!(f, "invite records: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for InviteStoreError {}
+
+impl From<SeamError> for InviteStoreError {
+    fn from(e: SeamError) -> Self {
+        InviteStoreError::Seam(e)
+    }
 }
 
 /// The invite store the engine ships over a host's [`StagingStore`].
@@ -161,34 +223,33 @@ impl<'a, St: StagingStore, E: Entropy> StagingInviteStore<'a, St, E> {
 }
 
 impl<St: StagingStore, E: Entropy> InviteStore for StagingInviteStore<'_, St, E> {
-    async fn persist(&self, links: &[RecordedInvite]) -> SeamResult<()> {
-        let body = encode_records(links)
-            .map_err(|e| SeamError::new(format!("invite records encode failed: {e}")))?;
-        let ephemeral = fresh_ephemeral(&mut *self.entropy.borrow_mut())
-            .map_err(|e| SeamError::new(format!("invite records: {}", e.message())))?;
+    async fn persist(&self, links: &[RecordedInvite]) -> Result<(), InviteStoreError> {
+        if links.len() > MAX_INVITE_RECORDS {
+            return Err(InviteStoreError::Full);
+        }
+        let body = encode_records(links).map_err(InviteStoreError::Encode)?;
+        let ephemeral =
+            fresh_ephemeral(&mut *self.entropy.borrow_mut()).map_err(InviteStoreError::Entropy)?;
         let blob = seal_owner_local(
             self.enc_secret,
             OwnerLocalKind::InviteRecords,
             &ephemeral,
             &body,
         )
-        .map_err(|e| SeamError::new(format!("invite records seal failed: {e}")))?;
+        .map_err(InviteStoreError::Seal)?;
         self.staging
             .put_staged_bytes(self.staging_key(), &blob)
-            .await
+            .await?;
+        Ok(())
     }
 
-    async fn load(&self) -> SeamResult<Vec<RecordedInvite>> {
+    async fn load(&self) -> Result<Vec<RecordedInvite>, InviteStoreError> {
         let Some(blob) = self.staging.staged_bytes(self.staging_key()).await? else {
             return Ok(Vec::new());
         };
         let body = open_owner_local(self.enc_secret, OwnerLocalKind::InviteRecords, &blob)
-            .map_err(|_| SeamError::new("invite records: the stored set did not open"))?;
-        decode_records(&body).map_err(|e| {
-            SeamError::new(format!(
-                "invite records: the stored set did not decode: {e}"
-            ))
-        })
+            .map_err(|e| InviteStoreError::Unreadable(InviteRecordsCodecError::DidNotOpen(e)))?;
+        decode_records(&body).map_err(InviteStoreError::Unreadable)
     }
 }
 
@@ -412,8 +473,13 @@ mod tests {
         block_on(staging.put_staged_bytes(store.staging_key(), b"not a sealed set"))
             .expect("clobber");
         assert!(
-            block_on(store.load()).is_err(),
-            "an unreadable stored set is an error, never an empty set"
+            matches!(
+                block_on(store.load()),
+                Err(InviteStoreError::Unreadable(
+                    InviteRecordsCodecError::DidNotOpen(_)
+                ))
+            ),
+            "an unreadable stored set is a trust verdict, never a retryable seam failure"
         );
     }
 
@@ -439,8 +505,8 @@ mod tests {
         ))
         .expect("clobber");
         assert!(
-            block_on(store.load()).is_err(),
-            "a body this build cannot decode is an error, never an empty set"
+            matches!(block_on(store.load()), Err(InviteStoreError::Unreadable(_))),
+            "a body this build cannot decode is a trust verdict, never an empty set"
         );
     }
 
@@ -461,8 +527,13 @@ mod tests {
         .expect("stage");
 
         assert!(
-            block_on(store.load()).is_err(),
-            "another store's blob is an error, never a set to adopt"
+            matches!(
+                block_on(store.load()),
+                Err(InviteStoreError::Unreadable(
+                    InviteRecordsCodecError::DidNotOpen(_)
+                ))
+            ),
+            "another store's blob is a trust verdict, never a set to adopt"
         );
     }
 
@@ -490,8 +561,13 @@ mod tests {
         .expect("clobber");
 
         assert!(
-            block_on(store.load()).is_err(),
-            "a record the owner did not seal never loads"
+            matches!(
+                block_on(store.load()),
+                Err(InviteStoreError::Unreadable(
+                    InviteRecordsCodecError::DidNotOpen(_)
+                ))
+            ),
+            "a record the owner did not seal is a trust verdict, never a link to convert"
         );
     }
 
@@ -520,7 +596,10 @@ mod tests {
         let secret = enc(0x51);
         let entropy = RefCell::new(SilentEntropy);
         let store = StagingInviteStore::new(&staging, &secret, &entropy);
-        assert!(block_on(store.persist(&[record(0x33, None)])).is_err());
+        assert!(matches!(
+            block_on(store.persist(&[record(0x33, None)])),
+            Err(InviteStoreError::Entropy(_))
+        ));
         assert!(
             block_on(staging.staged_bytes(store.staging_key()))
                 .expect("staged bytes")

--- a/crates/engine/src/grants/invite_store.rs
+++ b/crates/engine/src/grants/invite_store.rs
@@ -486,7 +486,12 @@ mod tests {
         ))
         .expect("clobber");
         assert!(
-            matches!(block_on(store.load()), Err(InviteStoreError::Unreadable(_))),
+            matches!(
+                block_on(store.load()),
+                Err(InviteStoreError::Unreadable(
+                    InviteRecordsCodecError::Codec(_)
+                ))
+            ),
             "a body this build cannot decode is a trust verdict, never an empty set"
         );
     }

--- a/crates/engine/src/grants/invite_store.rs
+++ b/crates/engine/src/grants/invite_store.rs
@@ -1,0 +1,756 @@
+//! The owner's durable record of the invite links it minted — what lets a link
+//! minted in one session be converted or revoked in the next.
+//!
+//! [`convert_invite_claim`](super::convert_invite_claim) and
+//! [`revoke_invite_link`](super::revoke_invite_link) both take a
+//! [`RecordedInvite`] back as input, and nothing in a resolved record marks a
+//! row as an invite, so this store is the owner's authority over its own links
+//! rather than a cache of published state.
+//!
+//! It is therefore sealed HPKE-to-self under the session's `enc-subkey`
+//! (`owner-local`, kind `invite-records`; ADR 0006) rather than written in the
+//! clear. Conversion matches a claim's sender against the recorded
+//! `ephemeralIdentityPk` and the tag binds only the **encryption** half, so a
+//! party who could author a record would pair a real link's `ephemeralEncPk`
+//! with an identity key it holds and drive the owner into minting a genuine
+//! grant at that link's committed permission. The recorded deadline is the
+//! authority for expiry on the same rule.
+//!
+//! What the seal does *not* buy, because the structure carries no monotone
+//! generation: a host replaying an earlier sealed set restores a deadline the
+//! owner has since shortened, and dropping the stored key entirely reads as an
+//! owner who minted nothing — leaving a live commitment entry no
+//! [`revoke_invite_link`](super::revoke_invite_link) call can name, since the
+//! cut is derived from the record rather than looked up by tag. The
+//! owner-signed commitment caps both: conversion reads the permission there and
+//! treats absence as revocation, and honours the published deadline as a
+//! further restriction. Closing them needs a monotone generation held where the
+//! host cannot roll it back.
+//!
+//! Like its siblings it rides the staging store's opaque key space, on the
+//! [`RetireLedger`](crate::seams::RetireLedger) shape.
+
+use core::cell::RefCell;
+use core::fmt;
+
+use cipherbox_core::codec::{Map, Value, decode, encode_fixed_depth};
+use cipherbox_core::error::CodecError;
+use cipherbox_core::seal::{OwnerLocalKind, open_owner_local, seal_owner_local};
+use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
+use cipherbox_core::suite::secret::SECRET_LEN;
+use cipherbox_core::suite::x25519::X25519Secret;
+
+use crate::entropy::{Entropy, fresh_ephemeral};
+use crate::seams::{SeamError, SeamResult, StagingStore, UnixMillis};
+use crate::sync::owner_scoped_key;
+
+use super::accept::{TooLong, fixed, reject_unknown, req, within};
+use super::invite::RecordedInvite;
+
+/// The staging-key prefix the invite records are stored under, scoped per
+/// identity by [`owner_scoped_key`]. `is_bookkeeping` treats the whole prefix as
+/// referenced.
+///
+/// Kept short: the desktop store spells a staging key as a hex filename, twice
+/// its byte length, inside Windows' whole-path budget.
+pub const INVITE_RECORDS_PREFIX: &[u8] = b"cbx/iv/";
+
+/// The stored-body grammar version this build writes and can read.
+const INVITE_RECORDS_V: u64 = 1;
+
+/// The frozen bound on recorded links, enforced release-active in both codec
+/// directions (AGENTS.md rule 8). One record per live link across every scope
+/// the owner has invited to; it bounds reader CPU and the staging budget alike.
+pub(crate) const MAX_INVITE_RECORDS: usize = 1024;
+
+/// Why encoding or decoding a stored record set failed.
+///
+/// Engine-owned rather than a bare [`CodecError`] so a check this format needs
+/// does not extend core's frozen `Malformed` registry, whose names the KAT
+/// manifest pins.
+#[derive(Debug)]
+enum InviteRecordsCodecError {
+    /// The det-CBOR framing was malformed.
+    Codec(CodecError),
+    /// Two records under one tag: no defined authority for that link's
+    /// permission or deadline, refused in both directions (AGENTS.md rule 8).
+    DuplicateTag,
+    /// A recorded deadline of `0`. `mint_invite_grant` refuses one
+    /// ([`InviteError::InvalidExpiry`](super::InviteError::InvalidExpiry)), so
+    /// reading it as "no deadline" would resurrect a link the mint never made.
+    ZeroDeadline,
+    /// A set written at a grammar version this build does not read. Never
+    /// treated as empty: the links are there, this build cannot read them.
+    UnsupportedVersion { version: u64 },
+    /// A collection or field past its frozen bound.
+    TooLong(TooLong),
+}
+
+impl fmt::Display for InviteRecordsCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InviteRecordsCodecError::Codec(e) => write!(f, "codec: {e}"),
+            InviteRecordsCodecError::DuplicateTag => f.write_str("names one tag twice"),
+            InviteRecordsCodecError::ZeroDeadline => f.write_str("records a zero deadline"),
+            InviteRecordsCodecError::UnsupportedVersion { version } => {
+                write!(f, "is at version {version}, which is not readable")
+            }
+            InviteRecordsCodecError::TooLong(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<TooLong> for InviteRecordsCodecError {
+    fn from(e: TooLong) -> Self {
+        InviteRecordsCodecError::TooLong(e)
+    }
+}
+
+impl<E: Into<CodecError>> From<E> for InviteRecordsCodecError {
+    fn from(e: E) -> Self {
+        InviteRecordsCodecError::Codec(e.into())
+    }
+}
+
+/// Durable persistence for the owner's minted invite links.
+///
+/// Whole-list replacement, like the received-shares store: the caller's list is
+/// the authority, so a revoked link is dropped by persisting the list without
+/// it.
+pub trait InviteStore {
+    /// Durably persist the whole set of recorded links.
+    async fn persist(&self, links: &[RecordedInvite]) -> SeamResult<()>;
+
+    /// The persisted records, or an empty set when the backing holds no entry
+    /// at all — the module header states what a dropped entry costs.
+    ///
+    /// Fail-closed on an entry it cannot read: a link's fragment is already in
+    /// a holder's hands, so a stored set this build cannot open is
+    /// unrecoverable authority, and reporting it as empty would let the next
+    /// [`persist`](Self::persist) overwrite every link behind it.
+    async fn load(&self) -> SeamResult<Vec<RecordedInvite>>;
+}
+
+/// The invite store the engine ships over a host's [`StagingStore`].
+///
+/// One staging key holds the whole set; the replacement is failure-atomic at
+/// the seam ([`StagingStore::put_staged_bytes`]).
+pub struct StagingInviteStore<'a, St, E> {
+    staging: &'a St,
+    enc_secret: &'a X25519Secret,
+    entropy: &'a RefCell<E>,
+    staging_key: Vec<u8>,
+}
+
+impl<'a, St: StagingStore, E: Entropy> StagingInviteStore<'a, St, E> {
+    /// Wraps a staging store as the invite store for one session.
+    pub fn new(staging: &'a St, enc_secret: &'a X25519Secret, entropy: &'a RefCell<E>) -> Self {
+        Self {
+            staging,
+            enc_secret,
+            entropy,
+            staging_key: owner_scoped_key(INVITE_RECORDS_PREFIX, enc_secret),
+        }
+    }
+
+    /// The staging key this identity's records occupy — the entry under
+    /// [`INVITE_RECORDS_PREFIX`] that orphan GC must treat as referenced.
+    pub fn staging_key(&self) -> &[u8] {
+        &self.staging_key
+    }
+}
+
+impl<St: StagingStore, E: Entropy> InviteStore for StagingInviteStore<'_, St, E> {
+    async fn persist(&self, links: &[RecordedInvite]) -> SeamResult<()> {
+        let body = encode_records(links)
+            .map_err(|e| SeamError::new(format!("invite records encode failed: {e}")))?;
+        let ephemeral = fresh_ephemeral(&mut *self.entropy.borrow_mut())
+            .map_err(|e| SeamError::new(format!("invite records: {}", e.message())))?;
+        let blob = seal_owner_local(
+            self.enc_secret,
+            OwnerLocalKind::InviteRecords,
+            &ephemeral,
+            &body,
+        )
+        .map_err(|e| SeamError::new(format!("invite records seal failed: {e}")))?;
+        self.staging
+            .put_staged_bytes(self.staging_key(), &blob)
+            .await
+    }
+
+    async fn load(&self) -> SeamResult<Vec<RecordedInvite>> {
+        let Some(blob) = self.staging.staged_bytes(self.staging_key()).await? else {
+            return Ok(Vec::new());
+        };
+        let body = open_owner_local(self.enc_secret, OwnerLocalKind::InviteRecords, &blob)
+            .map_err(|_| SeamError::new("invite records: the stored set did not open"))?;
+        decode_records(&body).map_err(|e| {
+            SeamError::new(format!(
+                "invite records: the stored set did not decode: {e}"
+            ))
+        })
+    }
+}
+
+/// Encode the durable record set to det-CBOR, records in tag order so one set
+/// has one spelling.
+///
+/// Rejects the bound, a duplicate tag and a zero deadline release-active — the
+/// three invariants [`decode_records`] hard-rejects (AGENTS.md rule 8). A zero
+/// deadline is `mint_invite_grant`'s
+/// [`InviteError::InvalidExpiry`](super::InviteError::InvalidExpiry): storing
+/// one would durably record a link the reader must refuse to distinguish from
+/// "no deadline".
+fn encode_records(links: &[RecordedInvite]) -> Result<Vec<u8>, InviteRecordsCodecError> {
+    within("links", links.len(), MAX_INVITE_RECORDS)?;
+    let mut sorted: Vec<&RecordedInvite> = links.iter().collect();
+    sorted.sort_by_key(|link| link.tag);
+    if sorted.windows(2).any(|pair| pair[0].tag == pair[1].tag) {
+        return Err(InviteRecordsCodecError::DuplicateTag);
+    }
+    let mut encoded = Vec::with_capacity(sorted.len());
+    for link in sorted {
+        let mut m = Map::new();
+        m.insert(
+            "ephemeralEncPk",
+            Value::Bytes(link.ephemeral_enc_pk.to_vec()),
+        );
+        m.insert(
+            "ephemeralIdentityPk",
+            Value::Bytes(link.ephemeral_identity_pk.to_vec()),
+        );
+        if let Some(deadline) = link.expires_at {
+            if deadline.0 == 0 {
+                return Err(InviteRecordsCodecError::ZeroDeadline);
+            }
+            m.insert("expiresAt", Value::Unsigned(deadline.0));
+        }
+        m.insert("tag", Value::Bytes(link.tag.to_vec()));
+        encoded.push(Value::Map(m));
+    }
+    let mut body = Map::new();
+    body.insert("links", Value::Array(encoded));
+    body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
+    Ok(encode_fixed_depth(&Value::Map(body)))
+}
+
+/// Decode a stored record set (strict det-CBOR).
+///
+/// A missing or mistyped field, an unknown key, an unreadable version, a bound
+/// breach, a duplicate tag or a zero deadline is an error — never a partial set,
+/// which would silently un-record links the owner still holds.
+fn decode_records(bytes: &[u8]) -> Result<Vec<RecordedInvite>, InviteRecordsCodecError> {
+    let tree = decode(bytes)?;
+    let map = tree.as_map()?;
+    reject_unknown(map, &["links", "v"])?;
+    let version = req(map, "v")?.as_unsigned()?;
+    if version != INVITE_RECORDS_V {
+        return Err(InviteRecordsCodecError::UnsupportedVersion { version });
+    }
+    let raw = req(map, "links")?.as_array()?;
+    within("links", raw.len(), MAX_INVITE_RECORDS)?;
+    let mut links: Vec<RecordedInvite> = Vec::with_capacity(raw.len());
+    for item in raw {
+        let record = item.as_map()?;
+        reject_unknown(
+            record,
+            &["ephemeralEncPk", "ephemeralIdentityPk", "expiresAt", "tag"],
+        )?;
+        let expires_at = match record.get("expiresAt") {
+            None => None,
+            Some(value) => match value.as_unsigned()? {
+                0 => return Err(InviteRecordsCodecError::ZeroDeadline),
+                millis => Some(UnixMillis(millis)),
+            },
+        };
+        let tag = fixed::<32>(req(record, "tag")?, "tag")?;
+        if links.iter().any(|held| held.tag == tag) {
+            return Err(InviteRecordsCodecError::DuplicateTag);
+        }
+        links.push(RecordedInvite {
+            tag,
+            ephemeral_identity_pk: fixed::<IDENTITY_PUBLIC_LEN>(
+                req(record, "ephemeralIdentityPk")?,
+                "ephemeralIdentityPk",
+            )?,
+            ephemeral_enc_pk: fixed::<SECRET_LEN>(
+                req(record, "ephemeralEncPk")?,
+                "ephemeralEncPk",
+            )?,
+            expires_at,
+        });
+    }
+    Ok(links)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entropy::EntropyError;
+    use crate::sync::orphan_staging_keys;
+    use crate::testkit::fakes::InMemoryStagingStore;
+    use crate::testkit::{SeededEntropy, block_on, conformance};
+
+    fn enc(byte: u8) -> X25519Secret {
+        X25519Secret::from_scalar([byte; 32])
+    }
+
+    fn seeded(seed: u64) -> RefCell<SeededEntropy> {
+        RefCell::new(SeededEntropy::new(seed))
+    }
+
+    fn record(byte: u8, expires_at: Option<UnixMillis>) -> RecordedInvite {
+        RecordedInvite {
+            tag: [byte; 32],
+            ephemeral_identity_pk: [byte ^ 0x0f; IDENTITY_PUBLIC_LEN],
+            ephemeral_enc_pk: [byte ^ 0xf0; SECRET_LEN],
+            expires_at,
+        }
+    }
+
+    fn sealed_as(secret: &X25519Secret, kind: OwnerLocalKind, seed: u64, body: &[u8]) -> Vec<u8> {
+        let ephemeral = fresh_ephemeral(&mut SeededEntropy::new(seed)).expect("ephemeral");
+        seal_owner_local(secret, kind, &ephemeral, body).expect("seal")
+    }
+
+    /// Reports success while writing nothing, so the caller's ephemeral stays
+    /// all-zero — a seam that would silently reuse one HPKE ephemeral forever.
+    struct SilentEntropy;
+
+    impl Entropy for SilentEntropy {
+        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+            Ok(())
+        }
+    }
+
+    struct FailingEntropy;
+
+    impl Entropy for FailingEntropy {
+        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+            Err(EntropyError::new("no entropy"))
+        }
+    }
+
+    /// The HPKE ephemeral public half a stored blob carries.
+    fn enc_of(blob: &[u8]) -> Vec<u8> {
+        decode(blob)
+            .expect("frame")
+            .as_map()
+            .expect("map")
+            .get("enc")
+            .expect("enc")
+            .as_bytes()
+            .expect("bytes")
+            .to_vec()
+    }
+
+    #[test]
+    fn the_staging_store_passes_the_invite_store_kit() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x11);
+        let entropy = seeded(9);
+        block_on(conformance::invite_store::check(async || {
+            StagingInviteStore::new(&staging, &secret, &entropy)
+        }));
+    }
+
+    /// The gap this store closes: a link minted in one session must still be
+    /// convertible and revocable in the next, and every field conversion trusts
+    /// has to survive the round trip byte-exact.
+    #[test]
+    fn a_recorded_link_survives_a_restart_field_for_field() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x21);
+        let entropy = seeded(21);
+        let links = [
+            record(0x33, Some(UnixMillis(1_700_000_000_000))),
+            record(0x44, None),
+        ];
+        block_on(StagingInviteStore::new(&staging, &secret, &entropy).persist(&links))
+            .expect("persist");
+
+        let mut restored =
+            block_on(StagingInviteStore::new(&staging, &secret, &entropy).load()).expect("load");
+        restored.sort_by_key(|link| link.tag);
+        assert_eq!(restored, links);
+    }
+
+    /// The disclosure and forgery surface the seal closes: the host must not be
+    /// able to read a record, and therefore cannot author one either.
+    #[test]
+    fn the_persisted_blob_never_holds_a_recorded_key_in_the_clear() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x22);
+        let entropy = seeded(22);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        let link = record(0x33, Some(UnixMillis(1_700_000_000_000)));
+        block_on(store.persist(&[link])).expect("persist");
+
+        let stored = block_on(staging.staged_bytes(store.staging_key()))
+            .expect("staged")
+            .expect("the set is stored");
+        for (bytes, what) in [
+            (&link.tag[..], "tag"),
+            (&link.ephemeral_identity_pk[..], "ephemeral identity key"),
+            (&link.ephemeral_enc_pk[..], "ephemeral encryption subkey"),
+        ] {
+            assert!(
+                !stored.windows(bytes.len()).any(|w| w == bytes),
+                "the {what} must never sit in host storage in the clear"
+            );
+        }
+    }
+
+    #[test]
+    fn a_set_this_session_cannot_open_fails_closed_rather_than_reading_empty() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x31);
+        let entropy = seeded(31);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        block_on(store.persist(&[record(0x33, None)])).expect("persist");
+
+        block_on(staging.put_staged_bytes(store.staging_key(), b"not a sealed set"))
+            .expect("clobber");
+        assert!(
+            block_on(store.load()).is_err(),
+            "an unreadable stored set is an error, never an empty set"
+        );
+    }
+
+    /// The other arm of the same rule: bytes that open under this session's key
+    /// but carry a body grammar this build does not read are still authority,
+    /// not an empty set.
+    #[test]
+    fn a_stored_set_this_build_cannot_decode_fails_closed_rather_than_reading_empty() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x32);
+        let entropy = seeded(32);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        block_on(store.persist(&[record(0x33, None)])).expect("persist");
+
+        block_on(staging.put_staged_bytes(
+            store.staging_key(),
+            &sealed_as(
+                &secret,
+                OwnerLocalKind::InviteRecords,
+                32,
+                b"opens, but is not a record set",
+            ),
+        ))
+        .expect("clobber");
+        assert!(
+            block_on(store.load()).is_err(),
+            "a body this build cannot decode is an error, never an empty set"
+        );
+    }
+
+    /// The store names its owner-local kind, so a sibling store's blob is
+    /// unreadable state even when its body is a record set this build decodes
+    /// perfectly — separation is the kind, not the body grammar.
+    #[test]
+    fn a_blob_from_another_owner_local_store_fails_closed() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x33);
+        let entropy = seeded(33);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        let body = encode_records(&[record(0x33, None)]).expect("encode");
+        block_on(staging.put_staged_bytes(
+            store.staging_key(),
+            &sealed_as(&secret, OwnerLocalKind::ContactBook, 33, &body),
+        ))
+        .expect("stage");
+
+        assert!(
+            block_on(store.load()).is_err(),
+            "another store's blob is an error, never a set to adopt"
+        );
+    }
+
+    /// A record the host altered never reaches conversion as altered content:
+    /// the seal binds the whole body, so a forged `ephemeralIdentityPk` is a
+    /// load failure rather than a link the owner never minted.
+    #[test]
+    fn a_host_altered_record_fails_to_load_rather_than_loading_as_altered() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x34);
+        let entropy = seeded(34);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        let honest = record(0x33, None);
+        block_on(store.persist(&[honest])).expect("persist");
+
+        let mut forged = honest;
+        forged.ephemeral_identity_pk = [0x77; IDENTITY_PUBLIC_LEN];
+        let body = encode_records(&[forged]).expect("encode");
+        // Sealed to a key the attacker holds — the closest an unprivileged
+        // writer of host storage can get to authoring a record.
+        block_on(staging.put_staged_bytes(
+            store.staging_key(),
+            &sealed_as(&enc(0x99), OwnerLocalKind::InviteRecords, 34, &body),
+        ))
+        .expect("clobber");
+
+        assert!(
+            block_on(store.load()).is_err(),
+            "a record the owner did not seal never loads"
+        );
+    }
+
+    #[test]
+    fn another_identitys_records_are_not_this_sessions_records() {
+        let staging = InMemoryStagingStore::default();
+        let entropy = seeded(41);
+        let alice = enc(0x41);
+        let bob = enc(0x42);
+        block_on(
+            StagingInviteStore::new(&staging, &alice, &entropy).persist(&[record(0x33, None)]),
+        )
+        .expect("persist");
+
+        assert!(
+            block_on(StagingInviteStore::new(&staging, &bob, &entropy).load())
+                .expect("load")
+                .is_empty(),
+            "one store is shared across accounts; a link must not cross identities"
+        );
+    }
+
+    #[test]
+    fn an_all_zero_ephemeral_fails_closed_before_the_seal() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x51);
+        let entropy = RefCell::new(SilentEntropy);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        assert!(block_on(store.persist(&[record(0x33, None)])).is_err());
+        assert!(
+            block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged bytes")
+                .is_none(),
+            "a refused seal writes nothing"
+        );
+    }
+
+    /// Rule 8: the decoder refuses two records under one tag, so the encoder
+    /// must too.
+    #[test]
+    fn two_records_under_one_tag_are_refused_in_both_directions() {
+        let mut clash = record(0x33, None);
+        clash.ephemeral_enc_pk = [0x01; SECRET_LEN];
+        assert!(matches!(
+            encode_records(&[record(0x33, None), clash]),
+            Err(InviteRecordsCodecError::DuplicateTag)
+        ));
+
+        let mut body = Map::new();
+        let one = |link: &RecordedInvite| {
+            let mut m = Map::new();
+            m.insert(
+                "ephemeralEncPk",
+                Value::Bytes(link.ephemeral_enc_pk.to_vec()),
+            );
+            m.insert(
+                "ephemeralIdentityPk",
+                Value::Bytes(link.ephemeral_identity_pk.to_vec()),
+            );
+            m.insert("tag", Value::Bytes(link.tag.to_vec()));
+            Value::Map(m)
+        };
+        body.insert(
+            "links",
+            Value::Array(vec![one(&record(0x33, None)), one(&clash)]),
+        );
+        body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
+        assert!(matches!(
+            decode_records(&encode_fixed_depth(&Value::Map(body))),
+            Err(InviteRecordsCodecError::DuplicateTag)
+        ));
+    }
+
+    /// Rule 8: `0` is not "no deadline" — the mint refuses it, the decoder
+    /// refuses it, and so must the encoder, or a release build would durably
+    /// record a link its own reader rejects.
+    #[test]
+    fn a_zero_deadline_is_refused_in_both_directions() {
+        assert!(matches!(
+            encode_records(&[record(0x33, Some(UnixMillis(0)))]),
+            Err(InviteRecordsCodecError::ZeroDeadline)
+        ));
+
+        let mut m = Map::new();
+        m.insert("ephemeralEncPk", Value::Bytes(vec![0x01; SECRET_LEN]));
+        m.insert(
+            "ephemeralIdentityPk",
+            Value::Bytes(vec![0x02; IDENTITY_PUBLIC_LEN]),
+        );
+        m.insert("expiresAt", Value::Unsigned(0));
+        m.insert("tag", Value::Bytes(vec![0x03; 32]));
+        let mut body = Map::new();
+        body.insert("links", Value::Array(vec![Value::Map(m)]));
+        body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
+        assert!(matches!(
+            decode_records(&encode_fixed_depth(&Value::Map(body))),
+            Err(InviteRecordsCodecError::ZeroDeadline)
+        ));
+    }
+
+    /// Rule 8: the bound the decoder enforces is enforced at encode too.
+    #[test]
+    fn a_set_past_its_bound_is_refused_in_both_directions() {
+        let links: Vec<RecordedInvite> = (0..=MAX_INVITE_RECORDS)
+            .map(|i| {
+                let mut link = record(0x33, None);
+                link.tag[..2].copy_from_slice(&u16::try_from(i).expect("in range").to_be_bytes());
+                link
+            })
+            .collect();
+        assert!(matches!(
+            encode_records(&links),
+            Err(InviteRecordsCodecError::TooLong(TooLong {
+                field: "links",
+                ..
+            }))
+        ));
+
+        // The decoder's own bound, on a body the encoder would never emit —
+        // otherwise this test would only ever exercise one direction.
+        let mut body = Map::new();
+        body.insert(
+            "links",
+            Value::Array(
+                links
+                    .iter()
+                    .map(|link| {
+                        let mut m = Map::new();
+                        m.insert(
+                            "ephemeralEncPk",
+                            Value::Bytes(link.ephemeral_enc_pk.to_vec()),
+                        );
+                        m.insert(
+                            "ephemeralIdentityPk",
+                            Value::Bytes(link.ephemeral_identity_pk.to_vec()),
+                        );
+                        m.insert("tag", Value::Bytes(link.tag.to_vec()));
+                        Value::Map(m)
+                    })
+                    .collect(),
+            ),
+        );
+        body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
+        assert!(matches!(
+            decode_records(&encode_fixed_depth(&Value::Map(body))),
+            Err(InviteRecordsCodecError::TooLong(TooLong {
+                field: "links",
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn a_set_at_an_unreadable_version_is_refused() {
+        let mut body = Map::new();
+        body.insert("links", Value::Array(vec![]));
+        body.insert("v", Value::Unsigned(INVITE_RECORDS_V + 1));
+        assert!(matches!(
+            decode_records(&encode_fixed_depth(&Value::Map(body))),
+            Err(InviteRecordsCodecError::UnsupportedVersion { version })
+                if version == INVITE_RECORDS_V + 1
+        ));
+    }
+
+    #[test]
+    fn a_set_with_an_unknown_key_is_refused() {
+        let mut body = Map::new();
+        body.insert("extra", Value::Unsigned(1));
+        body.insert("links", Value::Array(vec![]));
+        body.insert("v", Value::Unsigned(INVITE_RECORDS_V));
+        assert!(matches!(
+            decode_records(&encode_fixed_depth(&Value::Map(body))),
+            Err(InviteRecordsCodecError::Codec(_))
+        ));
+    }
+
+    /// The set shares a key space with staged upload blocks and is referenced by
+    /// no op, so without the prefix carve-out orphan GC would collect every live
+    /// link on the next sweep.
+    #[test]
+    fn orphan_gc_never_collects_the_persisted_records() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x71);
+        let entropy = seeded(71);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        block_on(store.persist(&[record(0x33, None)])).expect("persist");
+        block_on(staging.put_staged_bytes(b"upload-residue", b"stale")).expect("stage");
+
+        assert_eq!(
+            block_on(orphan_staging_keys(&staging, &[])).expect("sweep"),
+            vec![b"upload-residue".to_vec()],
+            "only the residue is collected, never the invite records"
+        );
+    }
+
+    /// The failure a durable whole-set record must survive: the host loses the
+    /// replacement write. `put_staged_bytes` is failure-atomic, so the set the
+    /// store already holds is what the next load must still read.
+    #[test]
+    fn a_lost_write_never_destroys_the_recorded_set() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x81);
+        let entropy = seeded(81);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+        block_on(store.persist(&[record(0x33, None)])).expect("first persist");
+
+        staging.interrupt_staged_write_after(store.staging_key(), 0);
+        assert!(block_on(store.persist(&[])).is_err());
+        assert_eq!(
+            block_on(store.load()).expect("load").len(),
+            1,
+            "the set the store already held is still the one it serves"
+        );
+    }
+
+    #[test]
+    fn an_entropy_failure_leaves_the_recorded_set_untouched() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x52);
+        let good = seeded(52);
+        block_on(StagingInviteStore::new(&staging, &secret, &good).persist(&[record(0x33, None)]))
+            .expect("persist");
+
+        let broken = RefCell::new(FailingEntropy);
+        let store = StagingInviteStore::new(&staging, &secret, &broken);
+        assert!(block_on(store.persist(&[])).is_err());
+        assert_eq!(
+            block_on(store.load()).expect("load").len(),
+            1,
+            "a failed persist never clears the set it could not replace"
+        );
+    }
+
+    /// The freshness invariant the seal rests on: two persists must not share an
+    /// HPKE ephemeral. `fresh_ephemeral` only rejects an all-zero draw, so a seam
+    /// stuck on any other constant is caught here or nowhere.
+    #[test]
+    fn two_persists_never_share_an_hpke_ephemeral() {
+        let staging = InMemoryStagingStore::default();
+        let secret = enc(0x53);
+        let entropy = seeded(53);
+        let store = StagingInviteStore::new(&staging, &secret, &entropy);
+
+        block_on(store.persist(&[record(0x33, None)])).expect("first persist");
+        let first = enc_of(
+            &block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged")
+                .expect("stored"),
+        );
+        block_on(store.persist(&[record(0x44, None)])).expect("second persist");
+        let second = enc_of(
+            &block_on(staging.staged_bytes(store.staging_key()))
+                .expect("staged")
+                .expect("stored"),
+        );
+
+        assert_ne!(
+            first, second,
+            "an ephemeral reused across two seals under one key and info is a confidentiality break"
+        );
+    }
+}

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -23,8 +23,9 @@ pub mod received_share_store;
 pub mod revocation;
 
 pub use accept::{
-    AcceptError, AcceptOutcome, ReceivedShare, ReceivedShareStore, ReceivedSharesList, SentIndex,
-    SentShare, SharePointer, TooLong, accept_share,
+    AcceptError, AcceptOutcome, MAX_RECEIVED_SHARES, ReceivedShare, ReceivedShareStore,
+    ReceivedShareStoreError, ReceivedSharesCodecError, ReceivedSharesList, SentIndex, SentShare,
+    SharePointer, TooLong, accept_share,
 };
 pub use child_index::{
     DestIndexVersion, UndoDestAdd, canonicalize, insert_child, move_child, remove_child,
@@ -44,7 +45,10 @@ pub use invite::{
     InviteRevocation, LinkCapability, MintedInvite, OwnerAuthority, RecordedInvite,
     convert_invite_claim, mint_invite_grant, post_invite_claim, revoke_invite_link,
 };
-pub use invite_store::{INVITE_RECORDS_PREFIX, InviteStore, StagingInviteStore};
+pub use invite_store::{
+    INVITE_RECORDS_PREFIX, InviteRecordsCodecError, InviteStore, InviteStoreError,
+    MAX_INVITE_RECORDS, StagingInviteStore,
+};
 pub use ledger::{
     AuthorityViolation, GrantRow, PublishedGrantBlob, enforce_committed_ledger, entry_is_live,
     entry_tag_is_bound, mint_grant_row, recipient_blinded_tag, self_locate,

--- a/crates/engine/src/grants/mod.rs
+++ b/crates/engine/src/grants/mod.rs
@@ -16,6 +16,7 @@ pub mod contact;
 pub mod contact_store;
 pub mod create;
 pub mod invite;
+pub mod invite_store;
 pub mod ledger;
 pub mod owner_entry;
 pub mod received_share_store;
@@ -43,6 +44,7 @@ pub use invite::{
     InviteRevocation, LinkCapability, MintedInvite, OwnerAuthority, RecordedInvite,
     convert_invite_claim, mint_invite_grant, post_invite_claim, revoke_invite_link,
 };
+pub use invite_store::{INVITE_RECORDS_PREFIX, InviteStore, StagingInviteStore};
 pub use ledger::{
     AuthorityViolation, GrantRow, PublishedGrantBlob, enforce_committed_ledger, entry_is_live,
     entry_tag_is_bound, mint_grant_row, recipient_blinded_tag, self_locate,

--- a/crates/engine/src/grants/received_share_store.rs
+++ b/crates/engine/src/grants/received_share_store.rs
@@ -10,13 +10,14 @@
 use core::cell::RefCell;
 
 use crate::entropy::{Entropy, fresh_ephemeral};
-use crate::seams::{SeamError, SeamResult, StagingStore};
+use crate::seams::StagingStore;
 use crate::sync::owner_scoped_key;
 use cipherbox_core::seal::{OwnerLocalKind, open_owner_local, seal_owner_local};
 use cipherbox_core::suite::x25519::X25519Secret;
 
 use super::accept::{
-    ReceivedShareStore, ReceivedSharesList, decode_stored_list, encode_stored_list,
+    MAX_RECEIVED_SHARES, ReceivedShareStore, ReceivedShareStoreError, ReceivedSharesCodecError,
+    ReceivedSharesList, decode_stored_list, encode_stored_list,
 };
 
 /// The staging-key prefix the received-shares list is stored under, scoped per
@@ -62,37 +63,35 @@ impl<'a, St: StagingStore, E: Entropy> StagingReceivedShareStore<'a, St, E> {
 }
 
 impl<St: StagingStore, E: Entropy> ReceivedShareStore for StagingReceivedShareStore<'_, St, E> {
-    async fn persist(&self, shares: &ReceivedSharesList) -> SeamResult<()> {
-        let body = encode_stored_list(shares)
-            .map_err(|e| SeamError::new(format!("received-shares encode failed: {e}")))?;
+    async fn persist(&self, shares: &ReceivedSharesList) -> Result<(), ReceivedShareStoreError> {
+        if shares.len() > MAX_RECEIVED_SHARES {
+            return Err(ReceivedShareStoreError::Full);
+        }
+        let body = encode_stored_list(shares).map_err(ReceivedShareStoreError::Encode)?;
         let ephemeral = fresh_ephemeral(&mut *self.entropy.borrow_mut())
-            .map_err(|e| SeamError::new(e.message().to_string()))?;
+            .map_err(ReceivedShareStoreError::Entropy)?;
         let blob = seal_owner_local(
             self.enc_secret,
             OwnerLocalKind::ReceivedShares,
             &ephemeral,
             &body,
         )
-        .map_err(|e| SeamError::new(format!("received-shares seal failed: {e}")))?;
+        .map_err(ReceivedShareStoreError::Seal)?;
         self.staging
             .put_staged_bytes(self.staging_key(), &blob)
-            .await
+            .await?;
+        Ok(())
     }
 
-    async fn load(&self) -> SeamResult<ReceivedSharesList> {
+    async fn load(&self) -> Result<ReceivedSharesList, ReceivedShareStoreError> {
         let Some(blob) = self.staging.staged_bytes(self.staging_key()).await? else {
             return Ok(ReceivedSharesList::new());
         };
-        // Stored bytes this session cannot read are never reported as an empty
-        // list: the next persist would overwrite bookmarks it never saw, and the
-        // mailbox items that delivered them are acked and gone.
         let body = open_owner_local(self.enc_secret, OwnerLocalKind::ReceivedShares, &blob)
-            .map_err(|_| SeamError::new("received-shares: the stored list did not open"))?;
-        decode_stored_list(&body).map_err(|e| {
-            SeamError::new(format!(
-                "received-shares: the stored list did not decode: {e}"
-            ))
-        })
+            .map_err(|e| {
+                ReceivedShareStoreError::Unreadable(ReceivedSharesCodecError::DidNotOpen(e))
+            })?;
+        decode_stored_list(&body).map_err(ReceivedShareStoreError::Unreadable)
     }
 }
 
@@ -190,8 +189,13 @@ mod tests {
         block_on(staging.put_staged_bytes(store.staging_key(), b"not a sealed list"))
             .expect("clobber");
         assert!(
-            block_on(store.load()).is_err(),
-            "an unreadable stored list is an error, never an empty list"
+            matches!(
+                block_on(store.load()),
+                Err(ReceivedShareStoreError::Unreadable(
+                    ReceivedSharesCodecError::DidNotOpen(_)
+                ))
+            ),
+            "an unreadable stored list is a trust verdict, never a retryable seam failure"
         );
     }
 
@@ -216,8 +220,11 @@ mod tests {
         .expect("seal");
         block_on(staging.put_staged_bytes(store.staging_key(), &sealed)).expect("clobber");
         assert!(
-            block_on(store.load()).is_err(),
-            "a body this build cannot decode is an error, never an empty list"
+            matches!(
+                block_on(store.load()),
+                Err(ReceivedShareStoreError::Unreadable(_))
+            ),
+            "a body this build cannot decode is a trust verdict, never an empty list"
         );
     }
 
@@ -237,8 +244,13 @@ mod tests {
             .expect("seal");
         block_on(staging.put_staged_bytes(store.staging_key(), &sealed)).expect("stage");
         assert!(
-            block_on(store.load()).is_err(),
-            "another store's blob is an error, never a list to adopt"
+            matches!(
+                block_on(store.load()),
+                Err(ReceivedShareStoreError::Unreadable(
+                    ReceivedSharesCodecError::DidNotOpen(_)
+                ))
+            ),
+            "another store's blob is a trust verdict, never a list to adopt"
         );
     }
 
@@ -307,7 +319,13 @@ mod tests {
             .expect("the list is stored");
 
         staging.interrupt_staged_write_after(store.staging_key(), 0);
-        assert!(block_on(store.persist(&ReceivedSharesList::new())).is_err());
+        assert!(
+            matches!(
+                block_on(store.persist(&ReceivedSharesList::new())),
+                Err(ReceivedShareStoreError::Seam(_))
+            ),
+            "a backing that dropped the write is the one failure a host may retry"
+        );
         assert_eq!(
             block_on(staging.staged_bytes(store.staging_key()))
                 .expect("staged")
@@ -332,7 +350,10 @@ mod tests {
 
         let broken = RefCell::new(FailingEntropy);
         let store = StagingReceivedShareStore::new(&staging, &secret, &broken);
-        assert!(block_on(store.persist(&ReceivedSharesList::new())).is_err());
+        assert!(matches!(
+            block_on(store.persist(&ReceivedSharesList::new())),
+            Err(ReceivedShareStoreError::Entropy(_))
+        ));
         assert_eq!(
             block_on(store.load()).expect("load").len(),
             1,

--- a/crates/engine/src/grants/received_share_store.rs
+++ b/crates/engine/src/grants/received_share_store.rs
@@ -203,7 +203,9 @@ mod tests {
         assert!(
             matches!(
                 block_on(store.load()),
-                Err(ReceivedShareStoreError::Unreadable(_))
+                Err(ReceivedShareStoreError::Unreadable(
+                    ReceivedSharesCodecError::Codec(_)
+                ))
             ),
             "a body this build cannot decode is a trust verdict, never an empty list"
         );

--- a/crates/engine/src/grants/received_share_store.rs
+++ b/crates/engine/src/grants/received_share_store.rs
@@ -102,11 +102,10 @@ mod tests {
     use cipherbox_core::suite::secret::SecretBytes;
 
     use super::*;
-    use crate::entropy::EntropyError;
     use crate::grants::ReceivedShare;
     use crate::sync::orphan_staging_keys;
     use crate::testkit::fakes::InMemoryStagingStore;
-    use crate::testkit::{SeededEntropy, block_on, conformance};
+    use crate::testkit::{FailingEntropy, SeededEntropy, SilentEntropy, block_on, conformance};
 
     const POINTER_KEY: [u8; 32] = [0xE7; 32];
 
@@ -124,24 +123,6 @@ mod tests {
             pointer_read_key: SecretBytes::new(POINTER_KEY),
         });
         shares
-    }
-
-    /// Reports success while writing nothing, so the caller's ephemeral stays
-    /// all-zero — a seam that would silently reuse one HPKE ephemeral forever.
-    struct SilentEntropy;
-
-    impl Entropy for SilentEntropy {
-        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-            Ok(())
-        }
-    }
-
-    struct FailingEntropy;
-
-    impl Entropy for FailingEntropy {
-        fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
-            Err(EntropyError::new("no entropy"))
-        }
     }
 
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -69,10 +69,10 @@ pub use gate::{
 };
 pub use grants::{
     AbuseEvent, AcceptError, AcceptOutcome, AuthorityViolation, Contact, OwnerEntry,
-    OwnerSeedCache, PublishedGrantBlob, ReceivedShare, ReceivedShareStore, ReceivedSharesList,
-    ResolutionClass, ResolutionFacts, SentIndex, SentShare, SharePointer,
-    StagingReceivedShareStore, accept_share, cross_check, enforce_committed_ledger, import_contact,
-    recipient_blinded_tag, self_locate,
+    OwnerSeedCache, PublishedGrantBlob, ReceivedShare, ReceivedShareStore, ReceivedShareStoreError,
+    ReceivedSharesCodecError, ReceivedSharesList, ResolutionClass, ResolutionFacts, SentIndex,
+    SentShare, SharePointer, StagingReceivedShareStore, accept_share, cross_check,
+    enforce_committed_ledger, import_contact, recipient_blinded_tag, self_locate,
 };
 pub use mailbox::{VerifiedMailboxItem, poll_verified, post_sealed};
 pub use net::{

--- a/crates/engine/src/sync/staging.rs
+++ b/crates/engine/src/sync/staging.rs
@@ -22,7 +22,7 @@ use cipherbox_core::content::verify_cid;
 
 use crate::content::decode_root;
 use crate::facade::WriteHandle;
-use crate::grants::{CONTACTS_PREFIX, RECEIVED_SHARES_PREFIX};
+use crate::grants::{CONTACTS_PREFIX, INVITE_RECORDS_PREFIX, RECEIVED_SHARES_PREFIX};
 use crate::net::RETIRE_LEDGER_PREFIX;
 use crate::seams::{OpId, SeamError, SeamResult, StagingStore};
 use crate::sync::drain::{
@@ -34,7 +34,7 @@ use crate::sync::record::{RecordSeal, encode_op_record, record_content_root_cid}
 /// Whether `key` is engine bookkeeping rather than upload residue: a
 /// per-identity op-id high-water mark
 /// ([`owner_scoped_key`](crate::sync::drain::owner_scoped_key)), a retire-ledger entry, a
-/// received-shares list, or a contact book. All are per-owner, so their whole prefixes are
+/// received-shares list, a contact book, or the owner's invite records. All are per-owner, so their whole prefixes are
 /// referenced — an entry this session cannot read belongs to the identity that
 /// still needs it.
 fn is_bookkeeping(key: &[u8]) -> bool {
@@ -43,6 +43,7 @@ fn is_bookkeeping(key: &[u8]) -> bool {
         || key.starts_with(RETIRE_LEDGER_PREFIX)
         || key.starts_with(RECEIVED_SHARES_PREFIX)
         || key.starts_with(CONTACTS_PREFIX)
+        || key.starts_with(INVITE_RECORDS_PREFIX)
 }
 
 /// Journal one op onto the durable queue, returning its id.
@@ -564,6 +565,7 @@ mod tests {
                 RETIRE_LEDGER_PREFIX,
                 RECEIVED_SHARES_PREFIX,
                 CONTACTS_PREFIX,
+                INVITE_RECORDS_PREFIX,
             ] {
                 store
                     .put_staged_bytes(&foreign(prefix), &7u64.to_be_bytes())

--- a/crates/engine/src/testkit/conformance/invite_store.rs
+++ b/crates/engine/src/testkit/conformance/invite_store.rs
@@ -120,6 +120,6 @@ where
     store.persist(&[]).await.unwrap();
     assert!(
         open().await.load().await.unwrap().is_empty(),
-        "persisting an empty set clears the backing"
+        "persisting an empty set retires every recorded link"
     );
 }

--- a/crates/engine/src/testkit/conformance/invite_store.rs
+++ b/crates/engine/src/testkit/conformance/invite_store.rs
@@ -1,0 +1,78 @@
+//! Conformance kit: [`InviteStore`] whole-set replacement, durability, and
+//! field-for-field fidelity of the record conversion trusts.
+
+use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
+use cipherbox_core::suite::secret::SECRET_LEN;
+
+use crate::grants::{InviteStore, RecordedInvite};
+use crate::seams::UnixMillis;
+
+fn record(byte: u8, expires_at: Option<UnixMillis>) -> RecordedInvite {
+    RecordedInvite {
+        tag: [byte; 32],
+        ephemeral_identity_pk: [byte ^ 0x0f; IDENTITY_PUBLIC_LEN],
+        ephemeral_enc_pk: [byte ^ 0xf0; SECRET_LEN],
+        expires_at,
+    }
+}
+
+/// The stored records in tag order, so a kit assertion never depends on an
+/// order the contract does not promise.
+async fn held<S: InviteStore>(store: &S) -> Vec<RecordedInvite> {
+    let mut held = store.load().await.unwrap();
+    held.sort_by_key(|link| link.tag);
+    held
+}
+
+/// Runs the `InviteStore` contract against an implementation.
+///
+/// `open` must return a handle over the same durable backing on every call
+/// (reopen semantics); the backing must start empty.
+///
+/// # Panics
+/// Panics on the first contract violation.
+pub async fn check<S, F>(mut open: F)
+where
+    S: InviteStore,
+    F: AsyncFnMut() -> S,
+{
+    let store = open().await;
+
+    assert!(
+        store.load().await.unwrap().is_empty(),
+        "a fresh backing holds no links"
+    );
+
+    let one = record(0x11, Some(UnixMillis(1_700_000_000_000)));
+    let two = record(0x22, None);
+
+    store.persist(&[one]).await.unwrap();
+    assert_eq!(
+        held(&store).await,
+        vec![one],
+        "a persisted record reads back field for field"
+    );
+    assert_eq!(
+        held(&open().await).await,
+        vec![one],
+        "records survive reopening the backing"
+    );
+
+    // Whole-set replacement, not a merge: the caller's set is the authority, so
+    // a re-recorded link must not read back beside its pre-image.
+    store.persist(&[one, two]).await.unwrap();
+    assert_eq!(held(&open().await).await, vec![one, two]);
+
+    store.persist(&[two]).await.unwrap();
+    assert_eq!(
+        held(&open().await).await,
+        vec![two],
+        "a link absent from the persisted set does not survive — this is how a revoke lands"
+    );
+
+    store.persist(&[]).await.unwrap();
+    assert!(
+        open().await.load().await.unwrap().is_empty(),
+        "persisting an empty set clears the backing"
+    );
+}

--- a/crates/engine/src/testkit/conformance/invite_store.rs
+++ b/crates/engine/src/testkit/conformance/invite_store.rs
@@ -89,6 +89,28 @@ where
         ),
         "a set past MAX_INVITE_RECORDS is a bound the host can act on, not an outage to retry"
     );
+
+    // The other two write-path refusals are contract, not implementation
+    // detail: both leave a link's authority undefined, so every implementation
+    // owes the same answer.
+    let mut clash = two;
+    clash.ephemeral_enc_pk = [0x01; SECRET_LEN];
+    assert!(
+        matches!(
+            store.persist(&[two, clash]).await,
+            Err(InviteStoreError::Encode(_))
+        ),
+        "two records under one tag leave that link's permission and deadline undefined"
+    );
+    assert!(
+        matches!(
+            store.persist(&[record(0x33, Some(UnixMillis(0)))]).await,
+            Err(InviteStoreError::Encode(_))
+        ),
+        "a zero deadline is not 'no deadline' — the mint refuses one, so storing it would \
+         resurrect a link the mint never made"
+    );
+
     assert_eq!(
         held(&open().await).await,
         vec![one],

--- a/crates/engine/src/testkit/conformance/invite_store.rs
+++ b/crates/engine/src/testkit/conformance/invite_store.rs
@@ -4,7 +4,7 @@
 use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 use cipherbox_core::suite::secret::SECRET_LEN;
 
-use crate::grants::{InviteStore, RecordedInvite};
+use crate::grants::{InviteStore, InviteStoreError, MAX_INVITE_RECORDS, RecordedInvite};
 use crate::seams::UnixMillis;
 
 fn record(byte: u8, expires_at: Option<UnixMillis>) -> RecordedInvite {
@@ -14,6 +14,17 @@ fn record(byte: u8, expires_at: Option<UnixMillis>) -> RecordedInvite {
         ephemeral_enc_pk: [byte ^ 0xf0; SECRET_LEN],
         expires_at,
     }
+}
+
+/// One record past the frozen bound, every tag distinct.
+fn over_bound() -> Vec<RecordedInvite> {
+    (0..=MAX_INVITE_RECORDS as u32)
+        .map(|i| {
+            let mut link = record(0x11, None);
+            link.tag[..4].copy_from_slice(&i.to_be_bytes());
+            link
+        })
+        .collect()
 }
 
 /// The stored records in tag order, so a kit assertion never depends on an
@@ -68,6 +79,20 @@ where
         held(&open().await).await,
         vec![two],
         "a link absent from the persisted set does not survive — this is how a revoke lands"
+    );
+
+    store.persist(&[one]).await.unwrap();
+    assert!(
+        matches!(
+            store.persist(&over_bound()).await,
+            Err(InviteStoreError::Full)
+        ),
+        "a set past MAX_INVITE_RECORDS is a bound the host can act on, not an outage to retry"
+    );
+    assert_eq!(
+        held(&open().await).await,
+        vec![one],
+        "a refused set leaves the recorded links untouched"
     );
 
     store.persist(&[]).await.unwrap();

--- a/crates/engine/src/testkit/conformance/mod.rs
+++ b/crates/engine/src/testkit/conformance/mod.rs
@@ -22,6 +22,7 @@
 pub mod contact_store;
 pub mod credential_store;
 pub mod floor_store;
+pub mod invite_store;
 pub mod mailbox;
 pub mod received_share_store;
 pub mod record_transport;

--- a/crates/engine/src/testkit/conformance/received_share_store.rs
+++ b/crates/engine/src/testkit/conformance/received_share_store.rs
@@ -5,7 +5,10 @@ use cipherbox_core::seal::Permission;
 use cipherbox_core::suite::ecdsa::IDENTITY_PUBLIC_LEN;
 use cipherbox_core::suite::secret::{SecretBytes, ct_eq};
 
-use crate::grants::{ReceivedShare, ReceivedShareStore, ReceivedSharesList};
+use crate::grants::{
+    MAX_RECEIVED_SHARES, ReceivedShare, ReceivedShareStore, ReceivedShareStoreError,
+    ReceivedSharesList,
+};
 
 /// A list holding one bookmark per `(scope root, pointer read key)` pair given,
 /// built through the accept flow's own reconcile so the kit never fabricates a
@@ -19,6 +22,21 @@ fn list(entries: &[(&[u8], u8, Permission)]) -> ReceivedSharesList {
             display_name: "Shared Folder".into(),
             permission: *permission,
             pointer_read_key: SecretBytes::new([*key_byte; 32]),
+        });
+    }
+    shares
+}
+
+/// One bookmark past the frozen bound, every scope root distinct.
+fn over_bound() -> ReceivedSharesList {
+    let mut shares = ReceivedSharesList::new();
+    for i in 0..=MAX_RECEIVED_SHARES {
+        shares.reconcile(ReceivedShare {
+            scope_root_name: format!("k51scoperoot-{i}").into_bytes(),
+            sharer_identity_pk: [0x02; IDENTITY_PUBLIC_LEN],
+            display_name: "Shared Folder".into(),
+            permission: Permission::Read,
+            pointer_read_key: SecretBytes::new([0x5A; 32]),
         });
     }
     shares
@@ -127,5 +145,18 @@ where
     assert!(
         ct_eq(stored.pointer_read_key(), &[0xE1; 32]),
         "the pointer read key round-trips byte-exact"
+    );
+
+    assert!(
+        matches!(
+            store.persist(&over_bound()).await,
+            Err(ReceivedShareStoreError::Full)
+        ),
+        "a list past MAX_RECEIVED_SHARES is a bound the host can act on, not an outage to retry"
+    );
+    assert_eq!(
+        held(&open().await).await,
+        vec![(one.to_vec(), [0xE1; 32], Permission::Read)],
+        "a refused list leaves the stored bookmarks untouched"
     );
 }

--- a/crates/engine/src/testkit/entropy.rs
+++ b/crates/engine/src/testkit/entropy.rs
@@ -45,6 +45,29 @@ impl Entropy for SeededEntropy {
     }
 }
 
+/// A seam that reports success and writes nothing, leaving the caller's buffer
+/// at whatever it held. **Test-only.** It stands for the stuck-entropy class:
+/// `fresh_ephemeral` rejects only an all-zero draw, so a seam stuck on any
+/// constant would reuse one HPKE ephemeral under a constant recipient key and
+/// `info` — key and nonce reuse.
+pub struct SilentEntropy;
+
+impl Entropy for SilentEntropy {
+    fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+        Ok(())
+    }
+}
+
+/// A seam that refuses every draw. **Test-only.** Nothing may be sealed or
+/// written when entropy cannot be had.
+pub struct FailingEntropy;
+
+impl Entropy for FailingEntropy {
+    fn fill(&mut self, _dest: &mut [u8]) -> Result<(), EntropyError> {
+        Err(EntropyError::new("no entropy"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/engine/src/testkit/fakes/received_share_store.rs
+++ b/crates/engine/src/testkit/fakes/received_share_store.rs
@@ -6,8 +6,10 @@ use std::sync::{Arc, Mutex};
 use zeroize::Zeroizing;
 
 use crate::grants::accept::{decode_stored_list, encode_stored_list};
-use crate::grants::{ReceivedShareStore, ReceivedSharesList};
-use crate::seams::{SeamError, SeamResult};
+use crate::grants::{
+    MAX_RECEIVED_SHARES, ReceivedShareStore, ReceivedShareStoreError, ReceivedSharesList,
+};
+use crate::seams::SeamError;
 
 #[derive(Default)]
 struct Inner {
@@ -42,24 +44,25 @@ impl InMemoryReceivedShareStore {
 }
 
 impl ReceivedShareStore for InMemoryReceivedShareStore {
-    async fn persist(&self, shares: &ReceivedSharesList) -> SeamResult<()> {
-        let encoded = encode_stored_list(shares)
-            .map_err(|e| SeamError::new(format!("received-shares encode failed: {e}")))?;
+    async fn persist(&self, shares: &ReceivedSharesList) -> Result<(), ReceivedShareStoreError> {
+        if shares.len() > MAX_RECEIVED_SHARES {
+            return Err(ReceivedShareStoreError::Full);
+        }
+        let encoded = encode_stored_list(shares).map_err(ReceivedShareStoreError::Encode)?;
         let mut inner = self.inner.lock().expect("lock");
         if inner.failing {
-            return Err(SeamError::new("received-share store offline"));
+            return Err(SeamError::new("received-share store offline").into());
         }
         inner.persists += 1;
         inner.stored = Some(encoded);
         Ok(())
     }
 
-    async fn load(&self) -> SeamResult<ReceivedSharesList> {
+    async fn load(&self) -> Result<ReceivedSharesList, ReceivedShareStoreError> {
         let stored = self.inner.lock().expect("lock").stored.clone();
         match stored {
             None => Ok(ReceivedSharesList::new()),
-            Some(bytes) => decode_stored_list(&bytes)
-                .map_err(|e| SeamError::new(format!("received-shares decode failed: {e}"))),
+            Some(bytes) => decode_stored_list(&bytes).map_err(ReceivedShareStoreError::Unreadable),
         }
     }
 }

--- a/crates/engine/src/testkit/mod.rs
+++ b/crates/engine/src/testkit/mod.rs
@@ -25,7 +25,7 @@ mod world;
 pub use content::{
     block_store, doomed_version, frame_version, frame_version_with, gateway, requested_cid, serve,
 };
-pub use entropy::SeededEntropy;
+pub use entropy::{FailingEntropy, SeededEntropy, SilentEntropy};
 pub use executor::block_on;
 pub use owner_root::{
     OWNER_ROOT_EPOCH, OWNER_ROOT_PSEUDONYM_SEED, OWNER_ROOT_SCOPE_SEED,

--- a/crates/engine/tests/facade.rs
+++ b/crates/engine/tests/facade.rs
@@ -1,6 +1,8 @@
 //! Facade skeleton surface: lifecycle law, typed unimplemented commands,
 //! and event-stream plumbing over a fully faked seam set.
 
+use core::cell::RefCell;
+
 use cipherbox_core::kdf;
 use cipherbox_core::suite::contact::ContactCode;
 use cipherbox_core::suite::ecdsa::EcdsaSigner;
@@ -230,7 +232,8 @@ fn an_imported_contact_survives_a_session_restart() {
     drop(engine);
 
     let enc_subkey = kdf::enc_subkey(&SECRET);
-    let book = StagingContactStore::new(&device.staging_store, &enc_subkey);
+    let entropy = RefCell::new(SeededEntropy::new(7));
+    let book = StagingContactStore::new(&device.staging_store, &enc_subkey, &entropy);
     let identity = EcdsaSigner::from_scalar(&scalar).expect("valid identity scalar");
     let resolved = block_on(resolve_recipient(
         &book,
@@ -255,7 +258,8 @@ fn an_import_the_book_cannot_take_is_not_reported_as_imported() {
     block_on(engine.start(secret())).unwrap();
 
     let enc_subkey = kdf::enc_subkey(&SECRET);
-    let book = StagingContactStore::new(&device.staging_store, &enc_subkey);
+    let entropy = RefCell::new(SeededEntropy::new(7));
+    let book = StagingContactStore::new(&device.staging_store, &enc_subkey, &entropy);
     device
         .staging_store
         .interrupt_staged_write_after(book.staging_key(), 0);

--- a/crates/engine/tests/invite_claims.rs
+++ b/crates/engine/tests/invite_claims.rs
@@ -14,14 +14,17 @@ use cipherbox_core::suite::ed25519::Ed25519Signer;
 use cipherbox_core::suite::x25519::X25519Secret;
 
 use cipherbox_engine::grants::{
-    ClaimOutcome, CommittedScope, EphemeralInvitee, InviteClaim, OwnerAuthority, RecordedInvite,
-    convert_invite_claim, import_contact, mint_invite_grant, post_invite_claim,
+    ClaimOutcome, CommittedScope, EphemeralInvitee, InviteClaim, InviteStore, OwnerAuthority,
+    RecordedInvite, StagingInviteStore, convert_invite_claim, import_contact, mint_invite_grant,
+    post_invite_claim, revoke_invite_link,
 };
 use cipherbox_engine::mailbox::poll_verified;
 use cipherbox_engine::rotation::derive_write_name;
-use cipherbox_engine::seams::Mailbox;
-use cipherbox_engine::testkit::block_on;
-use cipherbox_engine::testkit::fakes::InMemoryMailboxHub;
+use cipherbox_engine::seams::{Mailbox, UnixMillis};
+use cipherbox_engine::testkit::fakes::{InMemoryMailboxHub, InMemoryStagingStore};
+use cipherbox_engine::testkit::{SeededEntropy, block_on};
+
+use core::cell::RefCell;
 
 const V: u64 = 2;
 const SCOPE: [u8; 16] = [0x5c; 16];
@@ -94,6 +97,10 @@ impl Owner {
 }
 
 fn link(permission: Permission) -> Link {
+    link_until(permission, None)
+}
+
+fn link_until(permission: Permission, expires_at: Option<UnixMillis>) -> Link {
     let invitee = EphemeralInvitee::from_secret(&[0x4e; 32]).expect("valid");
     let minted = mint_invite_grant(
         &owner_enc(),
@@ -101,7 +108,7 @@ fn link(permission: Permission) -> Link {
         &SCOPE,
         &WRITE_SCOPE_SEED,
         permission,
-        None,
+        expires_at,
     )
     .expect("mints");
     let commitment = GrantSetCommitment {
@@ -266,4 +273,103 @@ fn the_transport_sees_no_claim_field_in_the_clear() {
             "the transport must carry no claim field in the clear",
         );
     }
+}
+
+/// A claim from `link`'s fragment holder, delivered over the real mailbox and
+/// handed back sender-verified — the item conversion actually consumes.
+fn delivered_claim(l: &Link, claimant_seed: u8) -> cipherbox_engine::mailbox::VerifiedMailboxItem {
+    let hub = InMemoryMailboxHub::default();
+    let claimant_identity = EcdsaSigner::from_scalar(&[claimant_seed; 32]).expect("valid scalar");
+    let claimant_enc = X25519Secret::from_scalar([claimant_seed ^ 0xff; 32]);
+    block_on(post_invite_claim(
+        &hub.mailbox_for(b"holder-outbox"),
+        &import_contact(&owner_contact_code()).expect("valid bundle"),
+        &l.invitee,
+        &EPH_MAILBOX,
+        V,
+        &InviteClaim {
+            scope_root_name: scope_name(),
+            contact_code: ContactCode::create(&claimant_identity, claimant_enc.public()).encode(),
+        },
+        "claim-1",
+    ))
+    .expect("posts");
+    let owner_box = hub.mailbox_for(&owner_identity().verifying_key().to_sec1());
+    block_on(poll_verified(&owner_box, &owner_enc(), V))
+        .expect("polls")
+        .pop()
+        .expect("the claim was delivered")
+}
+
+/// The gap the invite store closes: a link minted in one session is converted
+/// and revoked in the next, against the record the owner recovered rather than
+/// against the published row.
+#[test]
+fn a_link_minted_in_one_session_converts_and_revokes_in_the_next() {
+    let staging = InMemoryStagingStore::default();
+    let enc = owner_enc();
+    let l = link(Permission::Read);
+    {
+        let entropy = RefCell::new(SeededEntropy::new(5));
+        let minting_session = StagingInviteStore::new(&staging, &enc, &entropy);
+        block_on(minting_session.persist(&[l.recorded])).expect("the mint records its link");
+    }
+
+    // A later session: a fresh handle over the same durable backing, nothing
+    // carried over in memory.
+    let entropy = RefCell::new(SeededEntropy::new(6));
+    let recovered = block_on(StagingInviteStore::new(&staging, &enc, &entropy).load())
+        .expect("the records load");
+    assert_eq!(recovered, vec![l.recorded]);
+
+    let keys = Owner::new();
+    let converted = convert_invite_claim(
+        &keys.authority(),
+        &l.scope(),
+        &recovered,
+        &delivered_claim(&l, 0x67),
+        UnixMillis(0),
+    )
+    .expect("the recovered record converts the claim");
+    assert_eq!(converted.outcome, ClaimOutcome::Granted);
+
+    let cut = revoke_invite_link(&keys.authority(), &l.scope(), &recovered[0])
+        .expect("the recovered record revokes its link");
+    assert!(
+        !cut.commitment
+            .entries
+            .iter()
+            .any(|e| e.tag == l.recorded.tag),
+        "the link the earlier session minted is cut from the owner-signed set"
+    );
+}
+
+/// The recorded deadline is what conversion judges expiry on, so it has to
+/// survive the round trip — an expired link must stay expired after a restart.
+#[test]
+fn a_recovered_record_carries_the_deadline_conversion_judges_expiry_on() {
+    let staging = InMemoryStagingStore::default();
+    let deadline = UnixMillis(1_700_000_000_000);
+    let l = link_until(Permission::Read, Some(deadline));
+    let enc = owner_enc();
+    let entropy = RefCell::new(SeededEntropy::new(7));
+    block_on(StagingInviteStore::new(&staging, &enc, &entropy).persist(&[l.recorded]))
+        .expect("persist");
+    let recovered =
+        block_on(StagingInviteStore::new(&staging, &enc, &entropy).load()).expect("load");
+    assert_eq!(recovered[0].expires_at, Some(deadline));
+
+    let keys = Owner::new();
+    assert_eq!(
+        convert_invite_claim(
+            &keys.authority(),
+            &l.scope(),
+            &recovered,
+            &delivered_claim(&l, 0x69),
+            deadline,
+        )
+        .unwrap_err()
+        .check(),
+        "link-expired",
+    );
 }

--- a/crates/engine/tests/invite_claims.rs
+++ b/crates/engine/tests/invite_claims.rs
@@ -350,7 +350,13 @@ fn a_link_minted_in_one_session_converts_and_revokes_in_the_next() {
 fn a_recovered_record_carries_the_deadline_conversion_judges_expiry_on() {
     let staging = InMemoryStagingStore::default();
     let deadline = UnixMillis(1_700_000_000_000);
-    let l = link_until(Permission::Read, Some(deadline));
+    let mut l = link_until(Permission::Read, Some(deadline));
+    // The published deadline is the copy a write-grantee can strip
+    // (`RecordedInvite::expires_at`). Clearing it leaves the recovered record
+    // as the only thing that can still refuse the claim.
+    for entry in &mut l.ledger {
+        entry.expires_at = None;
+    }
     let enc = owner_enc();
     let entropy = RefCell::new(SeededEntropy::new(7));
     block_on(StagingInviteStore::new(&staging, &enc, &entropy).persist(&[l.recorded]))


### PR DESCRIPTION
Four issues behind ADR 0006 — the owner-local sealed store — landed as separate commits so the PR can be trimmed if one has to be abandoned.

## Commit 1 — the contact book is sealed

`StagingContactStore` wrote det-CBOR in the clear under the host's `StagingStore`, so any local reader of host storage learned the owner's whole contact graph: every contact's identity key and X25519 encryption subkey. The grant ledger that would otherwise carry those keys is sealed under the scope's write key, so this was a new disclosure rather than a restatement of a published one.

The book now seals HPKE-to-self under the session's `enc-subkey` as `OwnerLocalKind::ContactBook`, on the received-shares precedent. Sealing also puts the set under the owner's authority, closing the third-party-insertion residual; rollback by replay and deletion of the whole key still need a monotone counter the structure does not carry, and the module header now claims only that.

## Commit 2 — the invite records get a store

Nothing persisted a `RecordedInvite`, so a link minted in one session could neither be converted nor revoked in the next. `StagingInviteStore` carries the set at the grants layer over `StagingStore` on the `RetireLedger` precedent, leaving `SeamSet` at nine fields, under one staging key rather than two slots.

The set is sealed, not written in the clear, because it is an authority rather than a cache: conversion matches a claim's sender against the recorded `ephemeralIdentityPk`, and the tag binds only the encryption half. A party who could author a record would pair a real link's `ephemeralEncPk` with an identity key it holds and drive the owner into minting a genuine grant at that link's committed permission.

Conversion's trust logic is untouched. `CreateInviteLink` is still `EngineError::Unimplemented`, so the facade wiring of the mint is out of scope here; the cross-session path is covered end to end in `crates/engine/tests/invite_claims.rs` — persist, reopen over the same durable backing, convert a mailbox-delivered claim against the recovered record, and revoke the link with it.

## Commit 3 — one doc line

`settings_record.rs` said HPKE ephemeral reuse "under one recipient key" is a break, dropping the `info` qualifier `suite/hpke.rs` carries. Read literally it condemned the KAT vector that seals an op record and a content-key blob under one enc subkey and one ephemeral, differing only in `info` and AAD.

## Commit 4 — the load verdict is typed

`ReceivedShareStore` and `InviteStore` returned `SeamResult`, so every verdict their `load` could reach — the blob did not open under this session's `enc-subkey`, it was sealed under a sibling store's owner-local kind, its body is a grammar this build does not read — arrived as one `SeamError`. `EngineError::Seam` is documented as availability and never a trust decision, so the shape handed a host a fail-closed trust violation dressed as a retryable outage: the retry never converges and an attack signal renders as a storage blip. The frozen bounds inverted the same way — a set past `MAX_RECEIVED_SHARES` or `MAX_INVITE_RECORDS` read as an outage with no remedy a host could offer.

Both stores now carry typed errors on the shape `ContactStoreError` already used: `Unreadable` for a verdict on bytes that are there, `Full` for an offered set past its bound, plus `Encode`, `Entropy`, `Seal` and `Seam` — the one variant a retry can fix. `AcceptError::Persist` carries the store error through rather than flattening it.

The contact book gets the same split. Its blanket `From<BookCodecError>` mapped a write-path encode refusal onto `Unreadable`, contradicting that variant's own doc that it is a verdict on stored bytes; encode failures now land on `Encode`, which the facade maps to a malformed input rather than a trust violation. Taking the three together is the drift ADR 0006 asks not to allow.

Both conformance kits now assert the bound refusal is `Full` and leaves the stored set byte-untouched, so every implementation of the seam agrees rather than only the one the engine ships.

## The rule that must not decay

Both new load paths surface a stored blob this build cannot read as an error and never as an empty list, so the next persist cannot overwrite entries it never saw — including the subtle case of a sibling store's blob whose body decodes as a valid list, which the kind discriminator in the HPKE `info` refuses at the AEAD.

Each of those tests was verified as a true negative control: with the load path changed to fall back to an empty list, four contact-book tests and four invite-store tests fail; restored, all pass. The rule-8 encode-side checks were verified the same way (dropping them fails the both-directions tests) and the whole grants module passes in a release build, so none of them is a stripped assertion.

## Gates

`cargo fmt --all --check` 0 · `cargo clippy --workspace --all-targets -- -D warnings` 0 · `cargo test --workspace` 0 · `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` 0 · `pnpm lint:tracker-refs` 0. `cargo run -p cipherbox-core --example kat_gen` leaves `crates/core/kat/` byte-identical — no new core format, both kinds were registered by #1215.

The contract suite is not covered by `cargo test --workspace` and skips when `CONTRACT_API_URL` is unset; nothing here touches the API surface, so it should be unaffected.

Closes #1207
Closes #1239
Advances #1165 — this lands the durable store its gap named, but two of its four checkable
conditions need a facade mint path that does not exist yet, so the issue stays open. The
missing wiring is #1240.
Closes #1233

## Review gates

`/simplify`, a security pass and a crypto-privacy pass were run on `git diff main...HEAD`. What they found and what changed:

- **The invite store is an authorization input under a structure with no freshness, and its header did not say so.** Both passes raised it independently. A host replaying an earlier sealed set restores a deadline the owner has shortened, and dropping the key entirely reads as an owner who minted nothing — leaving a live commitment entry no `revoke_invite_link` call can name, since the cut is derived from the record rather than looked up by tag. The owner-signed commitment caps both. The module header now states this with the same candour the contact book's does; closing it needs a monotone generation against a high-water mark, which is a mechanism this slice does not have.
- **A seal failure was reported as a trust verdict on stored bytes.** `seal_owner_local`'s error funnelled into `BookCodecError` and out as `EngineError::TrustViolation` — a write-path failure presented to the host as tampering. Split into `ContactStoreError::Seal`, mapped to `EngineError::Seam`.
- **`a_set_past_its_bound_is_refused_in_both_directions` only exercised the encode direction.** The decode-side vector is now there — the test's name was writing a cheque the body did not cash.
- **Nothing guarded the stuck-entropy class behaviourally.** `fresh_ephemeral` only rejects an all-zero draw, so a seam stuck on any other constant would reuse one HPKE ephemeral under a constant recipient key and `info` — key and nonce reuse. Both new stores now assert two persists carry different `enc`.
- The invite store also gained the missing `FailingEntropy` test, and its entropy failure now names the store.
- **`ReceivedShareStore` and `InviteStore` reported a trust verdict as a retryable seam failure.** Deferred to #1239 when first raised, because it is a trait-shape change across sibling stores; commit 4 above now lands it across all three.
- Declined: adding an encode-side reject for two records sharing an `ephemeralIdentityPk`. Conversion refuses that ambiguity already and fails closed; rejecting it at encode would refuse to record the second link at all, turning a soft failure into a live unrevokable link.

Each new fail-closed test was verified as a true negative control the same way as the others.




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal the contact book with HPKE and introduce a durable invite-records store
> - `StagingContactStore` now seals persisted contact books HPKE-to-self using `seal_owner_local`; reads fail closed if the blob does not open under the session enc-subkey, replacing the previous plaintext write path.
> - Introduces `InviteStore` / `StagingInviteStore` in [`invite_store.rs`](https://github.com/FSM1/cipher-box/pull/1234/files#diff-8ad721d229aeeef56c5b1f270fa87725bbf0771afefe35d150f319d354b4bebb), backed by owner-sealed staging blobs, enforcing `MAX_INVITE_RECORDS`, rejecting duplicate tags and zero deadlines, and returning empty only when no blob exists.
> - `ReceivedShareStore` trait methods now return `ReceivedShareStoreError` instead of `SeamResult`, with granular variants (`Full`, `Encode`, `Entropy`, `Seal`, `Seam`, `Unreadable`) covering both read and write paths.
> - `INVITE_RECORDS_PREFIX` keys are now treated as bookkeeping in [`staging.rs`](https://github.com/FSM1/cipher-box/pull/1234/files#diff-40d92937ab5dcfb6a6be4837083a632d350cc60efcb3c6444ddc3b6085780719), excluding them from orphan GC.
> - Adds `SilentEntropy` and `FailingEntropy` test helpers to the testkit for entropy failure simulation.
> - Risk: `StagingContactStore::new` now requires an entropy argument, and `ContactStoreError` surfaces new variants (`Encode`, `Entropy`, `Seal`) that callers must handle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 898cefd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable invite-record storage with persistence, revocation, expiration, validation, and owner isolation.
  * Added configurable capacity limits for invites and received shares.
  * Strengthened encrypted storage for contacts, invites, and received shares.
* **Bug Fixes**
  * Improved reporting for corrupted, invalid, incompatible, encryption, entropy, and storage failures.
  * Preserved existing data when storage updates fail.
* **Documentation**
  * Clarified confidentiality risks when reusing ephemeral values across seals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->