### PR TITLE
docs: require a nitpick disposition comment in resolve-pr-reviews

### DIFF
--- a/.claude/commands/resolve-pr-reviews.md
+++ b/.claude/commands/resolve-pr-reviews.md
@@ -45,7 +45,19 @@ gh api graphql -f query="
 }"
 ```
 
-Filter to only unresolved threads. If none, report "No unresolved review threads" and stop.
+Filter to only unresolved threads.
+
+Then fetch the review **bodies** as well, because nitpicks and out-of-scope notes never
+appear as threads:
+
+```bash
+gh api repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/reviews \
+  --jq '.[] | select(.body | length > 0) | "\(.user.login) \(.submitted_at)\n\(.body)"'
+```
+
+Zero unresolved threads does not end the run — a nitpick-only review has no threads at
+all. Stop only when there are no threads **and** no nitpick or out-of-scope items;
+otherwise continue to step 8.
 
 ### 3. Triage each comment
 
@@ -121,10 +133,34 @@ mutation {
 }'
 ```
 
-### 8. Report summary
+### 8. Post a disposition comment for nitpicks and out-of-scope items
+
+Nitpicks and "outside the diff range" / "out of PR scope" notes live only inside a
+collapsible section of the review body (`🧹 Nitpick comments (N)`). They create **no
+inline threads**, so step 7 cannot reach them and GitHub records nothing about their
+fate. Without a posted comment there is no evidence they were ever read.
+
+Post one comment on the PR stating, per item, what was done:
+
+```bash
+gh pr comment $PR_NUMBER --repo $REPO_OWNER/$REPO_NAME --body-file <file>
+```
+
+Requirements:
+
+- One line per nitpick and per out-of-scope item — taken, already true, or rejected.
+- A rejection states the reason. "Rejected per the comment rules in AGENTS.md" is a
+  reason; silence is not.
+- An item deferred to an issue names that issue.
+- A blanket "addressed the feedback" is not a disposition. It records nothing.
+
+Post it even when every item was rejected, and even when the PR is already merged.
+
+### 9. Report summary
 
 Print a summary table:
 
 - Thread count resolved
 - Fixes made (with file:line references)
 - Comments marked as already addressed or not applicable
+- Nitpick and out-of-scope items, and the disposition comment URL from step 8


### PR DESCRIPTION
## Why

A CodeRabbit nitpick and an "outside the diff range" note live only inside a collapsible section of the **review body**. Neither creates an inline review thread. Two consequences follow, and the command had both:

1. Step 7 resolves *threads*, so it can never reach a nitpick. Nothing in GitHub then records whether the item was taken or rejected.
2. Step 2 said "if none, report No unresolved review threads and stop" — and a nitpick-only review produces exactly zero threads. The flow exited before it could consider them.

The result on a merged PR is an empty record. #1158 carried five nitpicks and one actionable finding; all five were in fact fixed on the branch before the merge, but that took a fresh audit to establish months later, because nothing was ever written down.

## What changed

- Step 2 also fetches the review bodies, and stops only when there are no threads **and** no nitpick or out-of-scope items.
- A new step 8 posts one comment giving a per-item disposition: taken, already true, rejected with a reason, or deferred to a named issue. A blanket "addressed the feedback" is called out as not a disposition.
- The printed summary in the renumbered step 9 carries the disposition comment URL.

Documentation only — no code surface, so the review gates in `AGENTS.md` do not apply.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require a nitpick disposition comment in the `resolve-pr-reviews` workflow
> Updates [resolve-pr-reviews.md](https://github.com/FSM1/cipher-box/pull/1235/files#diff-893a8c77eb9235300a2ac64672308bd2d095b7b33bdf48e845748ab62eb175fa) to require fetching PR review bodies in addition to unresolved threads, so nitpicks and out-of-scope notes are captured even when no threads remain open.
>
> - Adds a step to post a single disposition comment enumerating each nitpick/out-of-scope item with its outcome (taken, already true, rejected with reason, or deferred to a named issue).
> - Clarifies that zero unresolved threads does not terminate the run if review bodies contain items, and that a blanket "addressed the feedback" comment is insufficient.
> - The disposition comment must be posted even if all items are rejected or the PR is already merged.
> - Updates the summary step to include nitpick items and the disposition comment URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f29f588.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->