### PR TITLE
feat: source the read-accelerator bearer from the session and pin two guards

### DIFF
--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1476,10 +1476,9 @@ fn vector_names_are_unique_within_each_file() {
 }
 
 /// Which vector files carry HPKE ephemerals, and how many each pins — the
-/// anti-vacuity anchor for the freshness check below, in the same shape as the
-/// other named domains here. A family that stopped emitting `ephemeralScalar`
-/// would silently drop out of a bare total; naming the files makes it a failure
-/// that says which one went dark.
+/// anti-vacuity anchor for the freshness check below. A family that stopped
+/// emitting `ephemeralScalar` would drop out of a bare total silently; naming
+/// the files makes it a failure that says which one went dark.
 const HPKE_EPHEMERAL_FAMILIES: &[(&str, usize)] = &[
     ("vectors/content_key/content_key_accept.json", 2),
     ("vectors/grant/ascent_link_accept.json", 1),
@@ -1493,35 +1492,37 @@ const HPKE_EPHEMERAL_FAMILIES: &[(&str, usize)] = &[
     ("vectors/settings_record/settings_record_accept.json", 2),
 ];
 
-/// Every `(vector name, ephemeral scalar)` a vector file pins, scalars folded to
-/// lowercase so a generator that switched hex case could not hide a byte-level
-/// repeat behind a string comparison.
-fn ephemeral_scalars(body: &str, path: &str) -> Vec<(String, String)> {
+/// Every `(vector name, ephemeral scalar)` a vector file pins, decoded, so the
+/// repeat check compares scalars rather than their spelling. A vector carrying
+/// no `ephemeralScalar` is skipped — that absence is how a file with no HPKE
+/// ephemerals is recognised — but one that carries the field owes a 32-byte
+/// scalar, which [`unhex32`] enforces along with the lowercase-hex contract.
+fn ephemeral_scalars(body: &str, path: &str) -> Vec<(String, [u8; 32])> {
     let parsed: serde_json::Value =
         serde_json::from_str(body).unwrap_or_else(|e| panic!("{path}: not JSON ({e})"));
     parsed
         .as_array()
         .into_iter()
         .flatten()
-        .filter_map(|vector| {
-            let scalar = vector.get("ephemeralScalar")?.as_str()?;
+        .filter(|vector| vector.get("ephemeralScalar").is_some())
+        .map(|vector| {
             let name = vector.get("name").and_then(|n| n.as_str()).unwrap_or(path);
-            Some((name.to_owned(), scalar.to_ascii_lowercase()))
+            let scalar = vector["ephemeralScalar"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{path}: vector {name} spells no ephemeralScalar"));
+            (name.to_owned(), unhex32(name, scalar))
         })
         .collect()
 }
 
 /// HPKE ephemeral reuse under one recipient key and one `info` is a
 /// confidentiality break (`seal::seal_owner_local`). A vector file is a superset
-/// of each `(recipient, info)` group inside it — `owner_local_accept` alone
-/// spans four `info` values and pins two vectors under one — so per-file
-/// uniqueness forbids every real repeat, plus some harmless ones.
+/// of each `(recipient, info)` group inside it, so per-file uniqueness forbids
+/// every real repeat, plus some harmless ones.
 ///
-/// It is deliberately not pinned corpus-wide: separate families do reuse a
-/// scalar under one recipient and *different* `info` values, which the key
-/// schedule separates — `content_key_accept` and `settings_record_accept` share
-/// both their recipient and both their scalars today. Only a regenerated corpus
-/// could introduce a real repeat, which is exactly when it would go unnoticed.
+/// Deliberately not corpus-wide: separate families may reuse a scalar under one
+/// recipient and *different* `info` values, which the key schedule separates.
+/// Only a regenerated corpus could introduce a real repeat.
 #[test]
 fn ephemeral_scalars_are_fresh_within_each_vector_file() {
     let mut pinned = BTreeMap::new();

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -1475,6 +1475,66 @@ fn vector_names_are_unique_within_each_file() {
     }
 }
 
+/// Every `ephemeralScalar` the embedded corpus carries, paired with the vector
+/// it belongs to. Walks the parsed JSON rather than the typed families so a
+/// family added later is covered without being enrolled anywhere.
+fn ephemeral_scalars<'a>(value: &'a serde_json::Value, out: &mut Vec<(&'a str, &'a str)>) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                ephemeral_scalars(item, out);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            if let Some(scalar) = fields.get("ephemeralScalar").and_then(|s| s.as_str()) {
+                let name = fields
+                    .get("name")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("<unnamed>");
+                out.push((name, scalar));
+            }
+            for nested in fields.values() {
+                ephemeral_scalars(nested, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// How many HPKE-sealed vectors the corpus pins, the anti-vacuity backstop for
+/// the freshness walk below: a renamed field or a dropped family would
+/// otherwise leave it asserting over nothing.
+const HPKE_EPHEMERAL_VECTOR_COUNT: usize = 20;
+
+/// HPKE ephemeral reuse under one recipient key and `info` is a confidentiality
+/// break (`seal::seal_owner_local`), and several accept families seal every
+/// vector to the same recipient under the same `info` — so within one file a
+/// repeated scalar is that break. Only a regenerated corpus could introduce
+/// one, which is exactly when it would slip in unnoticed. Distinct files seal
+/// under distinct recipients, so freshness is pinned per file.
+#[test]
+fn ephemeral_scalars_are_fresh_within_each_vector_file() {
+    let mut total = 0;
+    for (path, body) in FIXTURES {
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).unwrap_or_else(|e| panic!("{path}: not JSON ({e})"));
+        let mut found = Vec::new();
+        ephemeral_scalars(&parsed, &mut found);
+        total += found.len();
+        let mut seen = BTreeSet::new();
+        for (name, scalar) in found {
+            assert!(
+                seen.insert(scalar),
+                "{path}: vector {name} repeats another vector's ephemeral scalar"
+            );
+        }
+    }
+    assert_eq!(
+        total, HPKE_EPHEMERAL_VECTOR_COUNT,
+        "hpke ephemeral vector count drift"
+    );
+}
+
 /// The codec's decode-reachable checks, fixed HERE as the anti-vacuity anchor
 /// (mirrors kat_gen.rs). The suite/kdf checks live on the same error surface
 /// but are pinned by the contact and hpke families, not the codec reject file.

--- a/crates/core/tests/kat_manifest.rs
+++ b/crates/core/tests/kat_manifest.rs
@@ -7,7 +7,7 @@
 //! through the committed generator (`examples/kat_gen.rs`); the exact counts
 //! and coverage lists here are the anti-vacuity backstop.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 // On wasm32-unknown-unknown (the browser-shaped KAT leg) there is no libtest
 // harness; wasm-bindgen-test provides one. Shadowing `test` with its attribute
@@ -1475,52 +1475,62 @@ fn vector_names_are_unique_within_each_file() {
     }
 }
 
-/// Every `ephemeralScalar` the embedded corpus carries, paired with the vector
-/// it belongs to. Walks the parsed JSON rather than the typed families so a
-/// family added later is covered without being enrolled anywhere.
-fn ephemeral_scalars<'a>(value: &'a serde_json::Value, out: &mut Vec<(&'a str, &'a str)>) {
-    match value {
-        serde_json::Value::Array(items) => {
-            for item in items {
-                ephemeral_scalars(item, out);
-            }
-        }
-        serde_json::Value::Object(fields) => {
-            if let Some(scalar) = fields.get("ephemeralScalar").and_then(|s| s.as_str()) {
-                let name = fields
-                    .get("name")
-                    .and_then(|s| s.as_str())
-                    .unwrap_or("<unnamed>");
-                out.push((name, scalar));
-            }
-            for nested in fields.values() {
-                ephemeral_scalars(nested, out);
-            }
-        }
-        _ => {}
-    }
+/// Which vector files carry HPKE ephemerals, and how many each pins — the
+/// anti-vacuity anchor for the freshness check below, in the same shape as the
+/// other named domains here. A family that stopped emitting `ephemeralScalar`
+/// would silently drop out of a bare total; naming the files makes it a failure
+/// that says which one went dark.
+const HPKE_EPHEMERAL_FAMILIES: &[(&str, usize)] = &[
+    ("vectors/content_key/content_key_accept.json", 2),
+    ("vectors/grant/ascent_link_accept.json", 1),
+    ("vectors/grant/grant_blob_accept.json", 2),
+    ("vectors/grant/owner_blob_accept.json", 1),
+    ("vectors/grant/owner_write_blob_accept.json", 1),
+    ("vectors/hpke/seal.json", 3),
+    ("vectors/op_record/op_record_accept.json", 2),
+    ("vectors/owner_local/owner_local_accept.json", 4),
+    ("vectors/payload/mailbox_accept.json", 2),
+    ("vectors/settings_record/settings_record_accept.json", 2),
+];
+
+/// Every `(vector name, ephemeral scalar)` a vector file pins, scalars folded to
+/// lowercase so a generator that switched hex case could not hide a byte-level
+/// repeat behind a string comparison.
+fn ephemeral_scalars(body: &str, path: &str) -> Vec<(String, String)> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).unwrap_or_else(|e| panic!("{path}: not JSON ({e})"));
+    parsed
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|vector| {
+            let scalar = vector.get("ephemeralScalar")?.as_str()?;
+            let name = vector.get("name").and_then(|n| n.as_str()).unwrap_or(path);
+            Some((name.to_owned(), scalar.to_ascii_lowercase()))
+        })
+        .collect()
 }
 
-/// How many HPKE-sealed vectors the corpus pins, the anti-vacuity backstop for
-/// the freshness walk below: a renamed field or a dropped family would
-/// otherwise leave it asserting over nothing.
-const HPKE_EPHEMERAL_VECTOR_COUNT: usize = 20;
-
-/// HPKE ephemeral reuse under one recipient key and `info` is a confidentiality
-/// break (`seal::seal_owner_local`), and several accept families seal every
-/// vector to the same recipient under the same `info` — so within one file a
-/// repeated scalar is that break. Only a regenerated corpus could introduce
-/// one, which is exactly when it would slip in unnoticed. Distinct files seal
-/// under distinct recipients, so freshness is pinned per file.
+/// HPKE ephemeral reuse under one recipient key and one `info` is a
+/// confidentiality break (`seal::seal_owner_local`). A vector file is a superset
+/// of each `(recipient, info)` group inside it — `owner_local_accept` alone
+/// spans four `info` values and pins two vectors under one — so per-file
+/// uniqueness forbids every real repeat, plus some harmless ones.
+///
+/// It is deliberately not pinned corpus-wide: separate families do reuse a
+/// scalar under one recipient and *different* `info` values, which the key
+/// schedule separates — `content_key_accept` and `settings_record_accept` share
+/// both their recipient and both their scalars today. Only a regenerated corpus
+/// could introduce a real repeat, which is exactly when it would go unnoticed.
 #[test]
 fn ephemeral_scalars_are_fresh_within_each_vector_file() {
-    let mut total = 0;
+    let mut pinned = BTreeMap::new();
     for (path, body) in FIXTURES {
-        let parsed: serde_json::Value =
-            serde_json::from_str(body).unwrap_or_else(|e| panic!("{path}: not JSON ({e})"));
-        let mut found = Vec::new();
-        ephemeral_scalars(&parsed, &mut found);
-        total += found.len();
+        let found = ephemeral_scalars(body, path);
+        if found.is_empty() {
+            continue;
+        }
+        pinned.insert(*path, found.len());
         let mut seen = BTreeSet::new();
         for (name, scalar) in found {
             assert!(
@@ -1529,10 +1539,8 @@ fn ephemeral_scalars_are_fresh_within_each_vector_file() {
             );
         }
     }
-    assert_eq!(
-        total, HPKE_EPHEMERAL_VECTOR_COUNT,
-        "hpke ephemeral vector count drift"
-    );
+    let expected: BTreeMap<&str, usize> = HPKE_EPHEMERAL_FAMILIES.iter().copied().collect();
+    assert_eq!(pinned, expected, "hpke ephemeral family coverage drift");
 }
 
 /// The codec's decode-reachable checks, fixed HERE as the anti-vacuity anchor

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -46,37 +46,32 @@ const CONTENT_CID: &str = "X-Content-Cid";
 /// Byte offset of the multicodec in the frozen CIDv1 framing.
 const CID_CODEC_INDEX: usize = 1;
 
-/// Mutable client state, single-owner behind a [`RefCell`]: the engine is the
-/// single writer (blueprint/engine.md Facade), so interior mutability with no
-/// borrow held across an `await` is sufficient — no lock is needed.
-struct State {
-    /// Waiters coalesced behind the one in-flight refresh (single-flight).
-    /// `Some(vec)` means a refresh is in progress; the leader owns the vec and
-    /// notifies every waiter with a clone of the result when it finishes.
-    refresh_waiters: Option<Vec<oneshot::Sender<Result<(), ApiError>>>>,
-}
+/// Waiters coalesced behind the one in-flight refresh (single-flight). `Some`
+/// means a refresh is in progress; the leader owns the vec and notifies every
+/// waiter with a clone of the result when it finishes.
+///
+/// Single-owner behind a [`RefCell`]: the engine is the single writer
+/// (blueprint/engine.md Facade), so interior mutability with no borrow held
+/// across an `await` is sufficient — no lock is needed.
+type RefreshWaiters = RefCell<Option<Vec<oneshot::Sender<Result<(), ApiError>>>>>;
 
 /// Holds single-flight leadership for one rotation and releases it on `Drop`,
 /// so a leader cancelled while parked on the network cannot leave the slot
 /// occupied by senders nothing will ever fire.
 struct RefreshLead<'a> {
-    state: &'a RefCell<State>,
+    waiters: &'a RefreshWaiters,
 }
 
 impl RefreshLead<'_> {
     /// Takes the waiters to notify, leaving the slot for `Drop` to release.
     fn waiters(&self) -> Vec<oneshot::Sender<Result<(), ApiError>>> {
-        self.state
-            .borrow_mut()
-            .refresh_waiters
-            .take()
-            .unwrap_or_default()
+        self.waiters.borrow_mut().take().unwrap_or_default()
     }
 }
 
 impl Drop for RefreshLead<'_> {
     fn drop(&mut self) {
-        self.state.borrow_mut().refresh_waiters = None;
+        *self.waiters.borrow_mut() = None;
     }
 }
 
@@ -88,11 +83,8 @@ pub struct ApiClient<H: Http, C: CredentialStore> {
     credentials: C,
     base_url: String,
     /// The short-lived access JWT, in memory only. Zeroized on replacement/drop.
-    /// A [`SessionBearer`] rather than a plain field so the read accelerator can
-    /// share the same cell ([`with_session_bearer`](Self::with_session_bearer))
-    /// and present the token this client rotates.
     session: SessionBearer,
-    state: RefCell<State>,
+    refresh_waiters: RefreshWaiters,
 }
 
 impl<H: Http, C: CredentialStore> ApiClient<H, C> {
@@ -108,16 +100,13 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
             credentials,
             base_url: base,
             session: SessionBearer::default(),
-            state: RefCell::new(State {
-                refresh_waiters: None,
-            }),
+            refresh_waiters: RefCell::new(None),
         }
     }
 
-    /// Publish this session's access token into `bearer` instead of a private
-    /// cell, so the read accelerator's gateway leg presents the live token and
-    /// follows every refresh rotation and logout without being rebuilt. Called
-    /// before login, while no token is held.
+    /// Hold this session's access token in `bearer` rather than a private cell,
+    /// so a reader sharing it sees every rotation. Replaces the cell outright:
+    /// call it on a fresh client, before login.
     pub fn with_session_bearer(mut self, bearer: SessionBearer) -> Self {
         self.session = bearer;
         self
@@ -258,8 +247,8 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
     /// token. On failure the local session is torn down.
     pub async fn refresh(&self) -> Result<(), ApiError> {
         let receiver = {
-            let mut state = self.state.borrow_mut();
-            match state.refresh_waiters.as_mut() {
+            let mut slot = self.refresh_waiters.borrow_mut();
+            match slot.as_mut() {
                 // A refresh is already running: enqueue and await its result.
                 Some(waiters) => {
                     let (tx, rx) = oneshot::channel();
@@ -268,7 +257,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
                 }
                 // We are the leader: mark a refresh in progress and run it.
                 None => {
-                    state.refresh_waiters = Some(Vec::new());
+                    *slot = Some(Vec::new());
                     None
                 }
             }
@@ -285,7 +274,9 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
             };
         }
 
-        let lead = RefreshLead { state: &self.state };
+        let lead = RefreshLead {
+            waiters: &self.refresh_waiters,
+        };
         let result = self.do_refresh().await;
         for tx in lead.waiters() {
             let _ = tx.send(result.clone());

--- a/crates/engine/src/api/client.rs
+++ b/crates/engine/src/api/client.rs
@@ -24,7 +24,7 @@ use super::types::{
     SiweChallengeResponse, SiweLoginRequest, SiweNonce, TestLoginOutcome, TestLoginRequest,
     TestLoginResponse, TokenResponse, UploadResult,
 };
-use crate::content::DAG_ROOT_CODEC;
+use crate::content::{DAG_ROOT_CODEC, SessionBearer};
 use crate::seams::{
     CredentialStore, Http, HttpCredentials, HttpMethod, HttpRequest, HttpResponse, SeamError,
     bearer_header,
@@ -50,8 +50,6 @@ const CID_CODEC_INDEX: usize = 1;
 /// single writer (blueprint/engine.md Facade), so interior mutability with no
 /// borrow held across an `await` is sufficient — no lock is needed.
 struct State {
-    /// The short-lived access JWT, in memory only. Zeroized on replacement/drop.
-    access_token: Option<Zeroizing<String>>,
     /// Waiters coalesced behind the one in-flight refresh (single-flight).
     /// `Some(vec)` means a refresh is in progress; the leader owns the vec and
     /// notifies every waiter with a clone of the result when it finishes.
@@ -89,6 +87,11 @@ pub struct ApiClient<H: Http, C: CredentialStore> {
     http: H,
     credentials: C,
     base_url: String,
+    /// The short-lived access JWT, in memory only. Zeroized on replacement/drop.
+    /// A [`SessionBearer`] rather than a plain field so the read accelerator can
+    /// share the same cell ([`with_session_bearer`](Self::with_session_bearer))
+    /// and present the token this client rotates.
+    session: SessionBearer,
     state: RefCell<State>,
 }
 
@@ -104,11 +107,20 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
             http,
             credentials,
             base_url: base,
+            session: SessionBearer::default(),
             state: RefCell::new(State {
-                access_token: None,
                 refresh_waiters: None,
             }),
         }
+    }
+
+    /// Publish this session's access token into `bearer` instead of a private
+    /// cell, so the read accelerator's gateway leg presents the live token and
+    /// follows every refresh rotation and logout without being rebuilt. Called
+    /// before login, while no token is held.
+    pub fn with_session_bearer(mut self, bearer: SessionBearer) -> Self {
+        self.session = bearer;
+        self
     }
 
     /// The API base URL, without a trailing slash.
@@ -118,7 +130,7 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
 
     /// Whether an access token is currently held in memory.
     pub fn is_authenticated(&self) -> bool {
-        self.state.borrow().access_token.is_some()
+        self.session.is_held()
     }
 
     // --- auth: identity, SIWE, test-login, refresh, logout ---
@@ -545,26 +557,18 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         for (name, value) in extra_headers {
             headers.push(((*name).to_owned(), (*value).to_owned()));
         }
-        // Scope the borrow so it never crosses the await below.
-        let bearer = {
-            let mut state = self.state.borrow_mut();
-            let built = state
-                .access_token
-                .as_ref()
-                .map(|token| bearer_header(token.as_str()));
-            match built {
-                Some(Ok(header)) => Some(header),
-                // Drop a token that can never be a header value instead of
-                // refusing every later call while still holding it: the next
-                // call then goes out unauthenticated and its 401 drives one
-                // refresh. The refresh credential is a separate secret and
-                // stays, so a malformed response cannot end the session.
-                Some(Err(_)) => {
-                    state.access_token = None;
-                    return Err(ApiError::Decode("unusable access token".into()));
-                }
-                None => None,
+        let bearer = match self.session.peek().map(|t| bearer_header(t.as_str())) {
+            Some(Ok(header)) => Some(header),
+            // Drop a token that can never be a header value instead of
+            // refusing every later call while still holding it: the next
+            // call then goes out unauthenticated and its 401 drives one
+            // refresh. The refresh credential is a separate secret and
+            // stays, so a malformed response cannot end the session.
+            Some(Err(_)) => {
+                self.session.clear();
+                return Err(ApiError::Decode("unusable access token".into()));
             }
+            None => None,
         };
         if let Some(header) = bearer {
             headers.push(header);
@@ -636,13 +640,13 @@ impl<H: Http, C: CredentialStore> ApiClient<H, C> {
         self.credentials
             .store_refresh_token(refresh_token.as_bytes())
             .await?;
-        self.state.borrow_mut().access_token = Some(Zeroizing::new(access_token));
+        self.session.set(access_token);
         Ok(())
     }
 
     /// Drop the in-memory access token and any persisted refresh token.
     async fn clear_session(&self) -> Result<(), ApiError> {
-        self.state.borrow_mut().access_token = None;
+        self.session.clear();
         self.credentials.clear_refresh_token().await?;
         Ok(())
     }

--- a/crates/engine/src/content/mod.rs
+++ b/crates/engine/src/content/mod.rs
@@ -31,7 +31,7 @@ pub use provider::{
     ByoIpfsConfig, ByoKind, PinMode, ProviderError, test_connection, validate_byo_config,
 };
 pub use read::{
-    ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, is_plane_anchor,
+    ContentPlane, Gateway, GatewayConfig, GatewaySource, ReadError, SessionBearer, is_plane_anchor,
     leaf_range_for_byte_range, read_block,
 };
 pub use retention::{

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -11,8 +11,10 @@
 //! terminal, because a content-address disagreement is an integrity signal to
 //! surface, not a retryable fetch miss.
 
+use core::cell::RefCell;
 use core::fmt;
 use core::ops::Range;
+use std::rc::Rc;
 
 use cipherbox_core::content::{CONTENT_CID_CODEC, CONTENT_CID_LEN, verify_cid};
 use cipherbox_core::error::{CodecError, TrustViolation};
@@ -56,25 +58,74 @@ impl ContentPlane {
     }
 }
 
-/// One trustless-gateway endpoint. The member accelerator carries a bearer
-/// token; a public fallback carries none. The token is a credential: held in a
-/// zeroizing buffer and redacted from `Debug` (security rule 2).
-#[derive(Clone, PartialEq, Eq)]
+/// The credential a gateway leg presents, read at request time rather than
+/// captured. The accelerator's is the live session access token, which rotates
+/// on every refresh and is dropped at logout, so it is shared with the API
+/// client through this cell instead of being copied into the gateway once.
+///
+/// Empty is the public-fallback state and the pre-login state alike: a leg with
+/// no token sends no `Authorization` header. The token is a credential — held
+/// in a zeroizing buffer and redacted from `Debug` (security rule 2).
+#[derive(Clone, Default)]
+pub struct SessionBearer(Rc<RefCell<Option<Zeroizing<String>>>>);
+
+impl SessionBearer {
+    /// A standalone cell already holding `token` — a fixed, non-session
+    /// credential (the desktop's self-hosted accelerator, test fixtures).
+    pub fn holding(token: impl Into<String>) -> Self {
+        let bearer = Self::default();
+        bearer.set(token);
+        bearer
+    }
+
+    /// Install `token` as the credential every later request presents.
+    pub fn set(&self, token: impl Into<String>) {
+        *self.0.borrow_mut() = Some(Zeroizing::new(token.into()));
+    }
+
+    /// Drop the held token: later requests go out unauthenticated, which for
+    /// the accelerator means a 401 and rotation to the public fallbacks.
+    pub fn clear(&self) {
+        *self.0.borrow_mut() = None;
+    }
+
+    /// Whether a token is held — asked without copying it out.
+    pub fn is_held(&self) -> bool {
+        self.0.borrow().is_some()
+    }
+
+    /// The token to present, if this leg holds one.
+    pub(crate) fn peek(&self) -> Option<Zeroizing<String>> {
+        self.0.borrow().clone()
+    }
+}
+
+impl fmt::Debug for SessionBearer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(if self.is_held() {
+            "<redacted>"
+        } else {
+            "<none>"
+        })
+    }
+}
+
+impl PartialEq for SessionBearer {
+    fn eq(&self, other: &Self) -> bool {
+        self.peek() == other.peek()
+    }
+}
+
+impl Eq for SessionBearer {}
+
+/// One trustless-gateway endpoint. The member accelerator presents the session
+/// bearer; a public fallback's cell is permanently empty.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GatewaySource {
     /// Gateway base URL (no trailing slash needed; one is tolerated).
     pub base_url: String,
-    /// Bearer token for the token-authed accelerator; `None` for a public
-    /// gateway. Zeroized on drop, never logged.
-    pub bearer: Option<Zeroizing<String>>,
-}
-
-impl fmt::Debug for GatewaySource {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("GatewaySource")
-            .field("base_url", &self.base_url)
-            .field("bearer", &self.bearer.as_ref().map(|_| "<redacted>"))
-            .finish()
-    }
+    /// The credential this leg presents, if any.
+    pub bearer: SessionBearer,
 }
 
 /// The ordered read source set: the token-authed accelerator is tried first as
@@ -100,13 +151,16 @@ impl Gateway {
 /// [`ReadError::Unavailable`] (retryable availability, never a trust violation) —
 /// the dormant default until the host supplies real endpoints.
 ///
-/// `Debug` derives the redaction from [`GatewaySource`]: the bearer never renders.
+/// Base URLs only: a host cannot configure a gateway credential. The
+/// accelerator's is the session's, bound by [`into_gateway`](Self::into_gateway),
+/// and a public fallback has none by construction.
 #[derive(Clone, Debug)]
 pub struct GatewayConfig {
-    /// The member accelerator (token-authed), consulted first when present.
-    pub accelerator: Option<GatewaySource>,
-    /// Public trustless-gateway fallbacks, tried in order after the accelerator.
-    pub public_fallbacks: Vec<GatewaySource>,
+    /// Base URL of the member accelerator, consulted first when present.
+    pub accelerator: Option<String>,
+    /// Base URLs of the public trustless-gateway fallbacks, tried in order
+    /// after the accelerator.
+    pub public_fallbacks: Vec<String>,
 }
 
 impl GatewayConfig {
@@ -119,11 +173,22 @@ impl GatewayConfig {
         }
     }
 
-    /// Resolve into the read-plane [`Gateway`], preserving accelerator-first order.
-    pub fn into_gateway(self) -> Gateway {
+    /// Resolve into the read-plane [`Gateway`], preserving accelerator-first
+    /// order and binding `accelerator_bearer` to the accelerator leg alone.
+    pub fn into_gateway(self, accelerator_bearer: SessionBearer) -> Gateway {
         Gateway {
-            accelerator: self.accelerator,
-            public_fallbacks: self.public_fallbacks,
+            accelerator: self.accelerator.map(|base_url| GatewaySource {
+                base_url,
+                bearer: accelerator_bearer,
+            }),
+            public_fallbacks: self
+                .public_fallbacks
+                .into_iter()
+                .map(|base_url| GatewaySource {
+                    base_url,
+                    bearer: SessionBearer::default(),
+                })
+                .collect(),
         }
     }
 }
@@ -270,7 +335,7 @@ async fn fetch(
 ) -> Result<crate::seams::HttpResponse, CappedFetchError> {
     let base = source.base_url.trim_end_matches('/');
     let mut headers = vec![(ACCEPT.to_owned(), RAW_BLOCK.to_owned())];
-    if let Some(bearer) = &source.bearer {
+    if let Some(bearer) = source.bearer.peek() {
         // A source whose token cannot be a header value is skipped, never
         // contacted unauthenticated: rotation drops to the next source.
         headers.push(bearer_header(bearer.as_str()).map_err(|_| {
@@ -362,11 +427,11 @@ mod tests {
         Gateway {
             accelerator: Some(GatewaySource {
                 base_url: "https://gw.cipherbox.test/".into(),
-                bearer: Some(Zeroizing::new("member-token".to_owned())),
+                bearer: SessionBearer::holding("member-token"),
             }),
             public_fallbacks: vec![GatewaySource {
                 base_url: "https://public.gw.test".into(),
-                bearer: None,
+                bearer: SessionBearer::default(),
             }],
         }
     }
@@ -563,11 +628,11 @@ mod tests {
         let gateway = Gateway {
             accelerator: Some(GatewaySource {
                 base_url: "https://gw.cipherbox.test".into(),
-                bearer: Some(Zeroizing::new("member\r\nX-Injected: 1".to_owned())),
+                bearer: SessionBearer::holding("member\r\nX-Injected: 1"),
             }),
             public_fallbacks: vec![GatewaySource {
                 base_url: "https://public.gw.test".into(),
-                bearer: None,
+                bearer: SessionBearer::default(),
             }],
         };
 
@@ -716,7 +781,7 @@ mod tests {
     fn gateway_source_debug_redacts_the_bearer_token() {
         let source = GatewaySource {
             base_url: "https://gw.test".into(),
-            bearer: Some(Zeroizing::new("super-secret-token".to_owned())),
+            bearer: SessionBearer::holding("super-secret-token"),
         };
         let debug = format!("{source:?}");
         assert!(
@@ -728,21 +793,15 @@ mod tests {
 
     fn a_config() -> GatewayConfig {
         GatewayConfig {
-            accelerator: Some(GatewaySource {
-                base_url: "https://gw.cipherbox.test/".into(),
-                bearer: Some(Zeroizing::new("member-token".to_owned())),
-            }),
-            public_fallbacks: vec![GatewaySource {
-                base_url: "https://public.gw.test".into(),
-                bearer: None,
-            }],
+            accelerator: Some("https://gw.cipherbox.test/".into()),
+            public_fallbacks: vec!["https://public.gw.test".into()],
         }
     }
 
     #[test]
     fn disabled_gateway_config_yields_an_empty_gateway() {
         // No source: reads fail closed as availability, never a trust violation.
-        let gateway = GatewayConfig::disabled().into_gateway();
+        let gateway = GatewayConfig::disabled().into_gateway(SessionBearer::default());
         let leaf = one_leaf();
         let http = ScriptedHttp::default();
         let err = block_on(read_block(
@@ -762,7 +821,7 @@ mod tests {
 
     #[test]
     fn gateway_config_round_trips_source_ordering() {
-        let gateway = a_config().into_gateway();
+        let gateway = a_config().into_gateway(SessionBearer::default());
         let urls: Vec<_> = gateway.sources().map(|s| s.base_url.as_str()).collect();
         assert_eq!(
             urls,
@@ -772,15 +831,71 @@ mod tests {
     }
 
     #[test]
-    fn gateway_config_debug_never_renders_the_bearer() {
+    fn gateway_debug_never_renders_the_bearer() {
         // Release-active behavioral assert (not a debug_assert): the derived
-        // `Debug` inherits `GatewaySource`'s redaction.
-        let debug = format!("{:?}", a_config());
+        // `Debug` inherits `SessionBearer`'s redaction.
+        let debug = format!(
+            "{:?}",
+            a_config().into_gateway(SessionBearer::holding("member-token"))
+        );
         assert!(
             !debug.contains("member-token"),
-            "bearer must never render in GatewayConfig Debug"
+            "bearer must never render in Gateway Debug"
         );
         assert!(debug.contains("<redacted>"));
+    }
+
+    /// The session cell reaches the accelerator leg and nothing else, so a
+    /// public fallback cannot be handed a member credential by configuration.
+    #[test]
+    fn into_gateway_binds_the_session_bearer_to_the_accelerator_alone() {
+        let gateway = a_config().into_gateway(SessionBearer::holding("member-token"));
+        assert!(gateway.accelerator.expect("accelerator").bearer.is_held());
+        assert!(
+            gateway
+                .public_fallbacks
+                .iter()
+                .all(|source| !source.bearer.is_held()),
+            "a public fallback never carries a credential"
+        );
+    }
+
+    /// The bearer is read per request, so a token stored after the gateway was
+    /// built is presented and a cleared one stops being sent — the login,
+    /// refresh-rotation and logout behaviour the accelerator leg needs.
+    #[test]
+    fn the_accelerator_presents_whatever_the_session_cell_currently_holds() {
+        let leaf = one_leaf();
+        let session = SessionBearer::default();
+        let gateway = a_config().into_gateway(session.clone());
+        let http = ScriptedHttp::default();
+
+        let read = || {
+            http.enqueue_response(raw_response(leaf.sealed.clone()));
+            block_on(read_block(
+                &gateway,
+                &http,
+                &cid_str(),
+                &leaf.cid,
+                ContentPlane::Leaf,
+            ))
+            .unwrap();
+            http.requests()
+                .last()
+                .expect("a request was sent")
+                .headers
+                .iter()
+                .find(|(name, _)| name == AUTHORIZATION)
+                .map(|(_, value)| value.clone())
+        };
+
+        assert_eq!(read(), None, "no session yet: the leg goes out bare");
+        session.set("jwt-1");
+        assert_eq!(read(), Some("Bearer jwt-1".to_owned()));
+        session.set("jwt-2");
+        assert_eq!(read(), Some("Bearer jwt-2".to_owned()), "a rotation lands");
+        session.clear();
+        assert_eq!(read(), None, "logout drops the credential");
     }
 
     #[test]

--- a/crates/engine/src/content/read.rs
+++ b/crates/engine/src/content/read.rs
@@ -58,45 +58,67 @@ impl ContentPlane {
     }
 }
 
+/// The token a [`SessionBearer`] holds, plus the one-way latch that ends its
+/// life. Sealing rather than only clearing matters because a refresh parked on
+/// the network resumes after teardown and would otherwise write a fresh token
+/// into a cell nothing will clear again.
+#[derive(Default)]
+struct BearerCell {
+    token: Option<Zeroizing<String>>,
+    sealed: bool,
+}
+
 /// The credential a gateway leg presents, read at request time rather than
 /// captured. The accelerator's is the live session access token, which rotates
-/// on every refresh and is dropped at logout, so it is shared with the API
-/// client through this cell instead of being copied into the gateway once.
+/// on every refresh and is dropped at logout, so the API client and the gateway
+/// share one cell instead of the token being copied into the gateway once.
 ///
 /// Empty is the public-fallback state and the pre-login state alike: a leg with
 /// no token sends no `Authorization` header. The token is a credential — held
 /// in a zeroizing buffer and redacted from `Debug` (security rule 2).
 #[derive(Clone, Default)]
-pub struct SessionBearer(Rc<RefCell<Option<Zeroizing<String>>>>);
+pub struct SessionBearer(Rc<RefCell<BearerCell>>);
 
 impl SessionBearer {
-    /// A standalone cell already holding `token` — a fixed, non-session
-    /// credential (the desktop's self-hosted accelerator, test fixtures).
-    pub fn holding(token: impl Into<String>) -> Self {
-        let bearer = Self::default();
-        bearer.set(token);
-        bearer
+    /// Install `token` as the credential every later request presents. A sealed
+    /// cell ignores it.
+    pub(crate) fn set(&self, token: impl Into<String>) {
+        let mut cell = self.0.borrow_mut();
+        if !cell.sealed {
+            cell.token = Some(Zeroizing::new(token.into()));
+        }
     }
 
-    /// Install `token` as the credential every later request presents.
-    pub fn set(&self, token: impl Into<String>) {
-        *self.0.borrow_mut() = Some(Zeroizing::new(token.into()));
+    /// Drop the held token, leaving the cell reusable — logout and a failed
+    /// refresh both end a session the same process may start again.
+    pub(crate) fn clear(&self) {
+        self.0.borrow_mut().token = None;
     }
 
-    /// Drop the held token: later requests go out unauthenticated, which for
-    /// the accelerator means a 401 and rotation to the public fallbacks.
-    pub fn clear(&self) {
-        *self.0.borrow_mut() = None;
+    /// Drop the held token for good: nothing may re-arm this cell.
+    pub(crate) fn seal(&self) {
+        let mut cell = self.0.borrow_mut();
+        cell.token = None;
+        cell.sealed = true;
     }
 
     /// Whether a token is held — asked without copying it out.
-    pub fn is_held(&self) -> bool {
-        self.0.borrow().is_some()
+    pub(crate) fn is_held(&self) -> bool {
+        self.0.borrow().token.is_some()
     }
 
     /// The token to present, if this leg holds one.
     pub(crate) fn peek(&self) -> Option<Zeroizing<String>> {
-        self.0.borrow().clone()
+        self.0.borrow().token.clone()
+    }
+
+    /// A standalone cell already holding `token`, for fixtures that need a leg
+    /// authenticated without a live session.
+    #[cfg(test)]
+    fn holding(token: impl Into<String>) -> Self {
+        let bearer = Self::default();
+        bearer.set(token);
+        bearer
     }
 }
 
@@ -110,17 +132,8 @@ impl fmt::Debug for SessionBearer {
     }
 }
 
-impl PartialEq for SessionBearer {
-    fn eq(&self, other: &Self) -> bool {
-        self.peek() == other.peek()
-    }
-}
-
-impl Eq for SessionBearer {}
-
-/// One trustless-gateway endpoint. The member accelerator presents the session
-/// bearer; a public fallback's cell is permanently empty.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// One trustless-gateway endpoint.
+#[derive(Clone, Debug)]
 pub struct GatewaySource {
     /// Gateway base URL (no trailing slash needed; one is tolerated).
     pub base_url: String,
@@ -128,9 +141,19 @@ pub struct GatewaySource {
     pub bearer: SessionBearer,
 }
 
+impl GatewaySource {
+    /// A no-auth source: its cell is fresh, so nothing can ever arm it.
+    pub fn public(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            bearer: SessionBearer::default(),
+        }
+    }
+}
+
 /// The ordered read source set: the token-authed accelerator is tried first as
 /// a member convenience, then the public no-auth fallbacks in order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Gateway {
     /// The member accelerator (token-authed), consulted first when present.
     pub accelerator: Option<GatewaySource>,
@@ -145,15 +168,31 @@ impl Gateway {
     }
 }
 
+/// Whether `base_url` may be handed a credential: TLS, or a loopback host for
+/// local development (`apps/web/.env.example` ships a `http://localhost` Kubo).
+/// The accelerator URL is host configuration, so a stale or mistyped one must
+/// cost the member their acceleration rather than their session token.
+fn carries_credentials_safely(base_url: &str) -> bool {
+    if base_url.starts_with("https://") {
+        return true;
+    }
+    let Some(rest) = base_url.strip_prefix("http://") else {
+        return false;
+    };
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    // Split a `:port` suffix without splitting an IPv6 literal's own colons.
+    let host = match authority.rsplit_once(':') {
+        Some((host, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => host,
+        _ => authority,
+    };
+    matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+}
+
 /// The content-gateway configuration handed to [`Engine::new`](crate::Engine),
 /// resolved into a [`Gateway`] once at construction. [`disabled`](Self::disabled)
 /// yields an empty source set whose reads fail closed as
 /// [`ReadError::Unavailable`] (retryable availability, never a trust violation) —
 /// the dormant default until the host supplies real endpoints.
-///
-/// Base URLs only: a host cannot configure a gateway credential. The
-/// accelerator's is the session's, bound by [`into_gateway`](Self::into_gateway),
-/// and a public fallback has none by construction.
 #[derive(Clone, Debug)]
 pub struct GatewayConfig {
     /// Base URL of the member accelerator, consulted first when present.
@@ -174,20 +213,25 @@ impl GatewayConfig {
     }
 
     /// Resolve into the read-plane [`Gateway`], preserving accelerator-first
-    /// order and binding `accelerator_bearer` to the accelerator leg alone.
+    /// order. `accelerator_bearer` reaches the accelerator leg and no other,
+    /// and only over a transport that can keep it ([`carries_credentials_safely`]);
+    /// a leg denied it still serves reads, just unauthenticated.
     pub fn into_gateway(self, accelerator_bearer: SessionBearer) -> Gateway {
         Gateway {
-            accelerator: self.accelerator.map(|base_url| GatewaySource {
-                base_url,
-                bearer: accelerator_bearer,
+            accelerator: self.accelerator.map(|base_url| {
+                if carries_credentials_safely(&base_url) {
+                    GatewaySource {
+                        base_url,
+                        bearer: accelerator_bearer,
+                    }
+                } else {
+                    GatewaySource::public(base_url)
+                }
             }),
             public_fallbacks: self
                 .public_fallbacks
                 .into_iter()
-                .map(|base_url| GatewaySource {
-                    base_url,
-                    bearer: SessionBearer::default(),
-                })
+                .map(GatewaySource::public)
                 .collect(),
         }
     }
@@ -429,10 +473,7 @@ mod tests {
                 base_url: "https://gw.cipherbox.test/".into(),
                 bearer: SessionBearer::holding("member-token"),
             }),
-            public_fallbacks: vec![GatewaySource {
-                base_url: "https://public.gw.test".into(),
-                bearer: SessionBearer::default(),
-            }],
+            public_fallbacks: vec![GatewaySource::public("https://public.gw.test")],
         }
     }
 
@@ -630,10 +671,7 @@ mod tests {
                 base_url: "https://gw.cipherbox.test".into(),
                 bearer: SessionBearer::holding("member\r\nX-Injected: 1"),
             }),
-            public_fallbacks: vec![GatewaySource {
-                base_url: "https://public.gw.test".into(),
-                bearer: SessionBearer::default(),
-            }],
+            public_fallbacks: vec![GatewaySource::public("https://public.gw.test")],
         };
 
         let out = block_on(read_block(
@@ -858,6 +896,63 @@ mod tests {
                 .all(|source| !source.bearer.is_held()),
             "a public fallback never carries a credential"
         );
+    }
+
+    /// The accelerator URL is host configuration and the token it would be
+    /// handed authorizes the whole API, so a stale or mistyped value must cost
+    /// the acceleration, not the session. The leg still serves reads.
+    #[test]
+    fn an_accelerator_that_cannot_keep_a_credential_is_never_handed_one() {
+        for base_url in [
+            "http://gw.cipherbox.test",
+            "http://localhost.evil.test:8080",
+            "http://127.0.0.1.evil.test",
+            "ftp://gw.cipherbox.test",
+            "//gw.cipherbox.test",
+        ] {
+            let gateway = GatewayConfig {
+                accelerator: Some(base_url.to_owned()),
+                public_fallbacks: Vec::new(),
+            }
+            .into_gateway(SessionBearer::holding("member-token"));
+            let accelerator = gateway.accelerator.expect("the source is still consulted");
+            assert_eq!(accelerator.base_url, base_url);
+            assert!(!accelerator.bearer.is_held(), "{base_url} was handed one");
+        }
+    }
+
+    /// TLS anywhere, and plain HTTP only on loopback — the local Kubo
+    /// `apps/web/.env.example` ships must stay usable.
+    #[test]
+    fn a_tls_or_loopback_accelerator_is_handed_the_session_bearer() {
+        for base_url in [
+            "https://gw.cipherbox.test",
+            "http://localhost:8080",
+            "http://localhost",
+            "http://127.0.0.1:8080/",
+            "http://[::1]:8080",
+        ] {
+            let gateway = GatewayConfig {
+                accelerator: Some(base_url.to_owned()),
+                public_fallbacks: Vec::new(),
+            }
+            .into_gateway(SessionBearer::holding("member-token"));
+            assert!(
+                gateway.accelerator.expect("accelerator").bearer.is_held(),
+                "{base_url} was denied one"
+            );
+        }
+    }
+
+    /// Teardown is a one-way latch: a refresh parked on the network when the
+    /// engine went away must not re-arm a cell nothing will clear again.
+    #[test]
+    fn a_sealed_bearer_refuses_a_late_token() {
+        let session = SessionBearer::holding("jwt-1");
+        session.seal();
+        assert!(!session.is_held());
+        session.set("jwt-2");
+        assert!(!session.is_held(), "a sealed cell stays empty");
     }
 
     /// The bearer is read per request, so a token stored after the gateway was

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -1541,10 +1541,10 @@ pub struct Engine<T: SeamTypes> {
     /// Read by the cold-start [`RootAdopter`] and the resolve-tick driver's
     /// per-pass adopter.
     gateway: Gateway,
-    /// The read accelerator's credential, shared with the API client
-    /// [`start`](Self::start) builds: the accelerator is CipherBox's own
-    /// token-authed gateway, so the session access token is what gates it, and
-    /// no host-supplied build-time bearer exists to leak.
+    /// The session access token, shared by the API client [`start`](Self::start)
+    /// builds and the read accelerator's gateway leg — the accelerator is
+    /// CipherBox's own token-authed gateway, so the session is what gates it.
+    /// One cell for both: clearing it de-authenticates the API client too.
     accelerator_bearer: SessionBearer,
     events: mpsc::UnboundedSender<Event>,
     /// The last-known-good gate-passing base snapshot (state law's left
@@ -1798,9 +1798,12 @@ impl<T: SeamTypes> Engine<T> {
             Err(err) => {
                 // Fail-closed symmetry with the login path: clear the derived
                 // session and the placement decision beside it, so no key material
-                // stays resident and the engine reports unstarted.
+                // stays resident and the engine reports unstarted. The access
+                // token login already stored outlives the dropped client in the
+                // shared bearer cell, so it is dropped here by name.
                 self.session = None;
                 *self.placement.borrow_mut() = None;
+                self.accelerator_bearer.clear();
                 return Err(EngineError::from_cold_start(err));
             }
         };
@@ -1923,9 +1926,10 @@ impl<T: SeamTypes> Engine<T> {
     /// because a panic while dropping aborts the process.
     fn shut_down(&self) {
         self.alive.set(false);
-        // The gateway clone a parked tick holds shares this cell, so clearing it
-        // is what stops a token outliving the engine (security rule 7).
-        self.accelerator_bearer.clear();
+        // Sealed, not cleared: the gateway clone a parked tick holds shares this
+        // cell, and a refresh still on the wire would re-arm a plain clear
+        // (security rule 7).
+        self.accelerator_bearer.seal();
         // Every parked manual refresh fails now: no pass is left to answer it.
         self.manual_refresh.close();
         if let Ok(mut enc_subkey) = self.tick_enc_subkey.try_borrow_mut() {

--- a/crates/engine/src/facade.rs
+++ b/crates/engine/src/facade.rs
@@ -35,7 +35,7 @@ use crate::api::{ApiClient, ApiError, IdentityChallengeSigner};
 use crate::content::budget::{Refusal, ReservationId};
 use crate::content::{
     ContentKey, ContentProfile, ContentWriter, Gateway, GatewayConfig, OpenError, Refused,
-    RootManifest, SealError, StagingLedger, open_content_range, open_content_root,
+    RootManifest, SealError, SessionBearer, StagingLedger, open_content_range, open_content_root,
     pre_flight_quota_check, read_pinned_range, sealed_total_bytes,
 };
 use crate::entropy::Entropy;
@@ -1541,6 +1541,11 @@ pub struct Engine<T: SeamTypes> {
     /// Read by the cold-start [`RootAdopter`] and the resolve-tick driver's
     /// per-pass adopter.
     gateway: Gateway,
+    /// The read accelerator's credential, shared with the API client
+    /// [`start`](Self::start) builds: the accelerator is CipherBox's own
+    /// token-authed gateway, so the session access token is what gates it, and
+    /// no host-supplied build-time bearer exists to leak.
+    accelerator_bearer: SessionBearer,
     events: mpsc::UnboundedSender<Event>,
     /// The last-known-good gate-passing base snapshot (state law's left
     /// operand). Seeded at the anchored root; cold-start/resolve replace it
@@ -1643,6 +1648,7 @@ impl<T: SeamTypes> Engine<T> {
         gateway: GatewayConfig,
     ) -> (Self, EventStream) {
         let (events, receiver) = mpsc::unbounded();
+        let accelerator_bearer = SessionBearer::default();
         (
             Self {
                 seams,
@@ -1655,7 +1661,8 @@ impl<T: SeamTypes> Engine<T> {
                 live_blocks: Rc::new(RefCell::new(LiveBlocks::default())),
                 cancels: Rc::new(RefCell::new(UploadCancels::default())),
                 api_base_url,
-                gateway: gateway.into_gateway(),
+                gateway: gateway.into_gateway(accelerator_bearer.clone()),
+                accelerator_bearer,
                 events,
                 // The anchored all-zero root until cold-start/resolve replaces
                 // the base snapshot; children come from the pending-op overlay.
@@ -1719,11 +1726,14 @@ impl<T: SeamTypes> Engine<T> {
         // fail-closed: a rejected login returns before the session is committed
         // or any loop spawns, so the loop never runs unauthenticated (rules 3/6).
         let base_url = self.api_base_url.configured();
-        let api = Rc::new(ApiClient::new(
-            self.seams.http.clone(),
-            self.seams.credential_store.clone(),
-            base_url.unwrap_or_default().to_owned(),
-        ));
+        let api = Rc::new(
+            ApiClient::new(
+                self.seams.http.clone(),
+                self.seams.credential_store.clone(),
+                base_url.unwrap_or_default().to_owned(),
+            )
+            .with_session_bearer(self.accelerator_bearer.clone()),
+        );
         if base_url.is_some() {
             let signer = IdentityChallengeSigner::from_signer(session.identity().clone());
             api.login_identity(&signer)
@@ -1913,6 +1923,9 @@ impl<T: SeamTypes> Engine<T> {
     /// because a panic while dropping aborts the process.
     fn shut_down(&self) {
         self.alive.set(false);
+        // The gateway clone a parked tick holds shares this cell, so clearing it
+        // is what stops a token outliving the engine (security rule 7).
+        self.accelerator_bearer.clear();
         // Every parked manual refresh fails now: no pass is left to answer it.
         self.manual_refresh.close();
         if let Ok(mut enc_subkey) = self.tick_enc_subkey.try_borrow_mut() {
@@ -3854,6 +3867,58 @@ mod tests {
         assert_eq!(login_body["signature"], expected);
     }
 
+    /// The read accelerator is CipherBox's own token-authed gateway, so the
+    /// credential it presents is the session's — bound by login rather than
+    /// configured, and gone with the engine.
+    #[test]
+    fn login_binds_the_session_token_to_the_accelerator_and_shutdown_drops_it() {
+        let device = FakeWorld::new().device(b"alice-pk");
+        let (mut engine, _events) = Engine::new(
+            device.seam_set(),
+            Box::new(SeededEntropy::new(42)),
+            SyncTimingProfile::CI,
+            ContentProfile::CI,
+            StoragePolicy::CI,
+            ApiBaseUrl::parse("http://api.test").expect("a configured base"),
+            GatewayConfig {
+                accelerator: Some("https://gw.test".into()),
+                public_fallbacks: Vec::new(),
+            },
+        );
+        let accelerator_bearer = engine.accelerator_bearer.clone();
+        assert!(!accelerator_bearer.is_held(), "no credential before login");
+
+        device.http.enqueue_response(json_response(
+            200,
+            json!({ "challenge": LOGIN_CHALLENGE_FIXTURE, "expiresAt": "2099-01-01T00:00:00Z" }),
+        ));
+        device.http.enqueue_response(json_response(
+            200,
+            json!({ "accessToken": "jwt-1", "refreshToken": "a".repeat(64), "isNewUser": true }),
+        ));
+        serve_provisioning(&device);
+        block_on(engine.start(LoginSecret::new(vec![7u8; 32]))).expect("start logs in");
+
+        let held = engine
+            .gateway
+            .accelerator
+            .as_ref()
+            .expect("accelerator")
+            .bearer
+            .peek();
+        assert_eq!(
+            held.as_deref().map(String::as_str),
+            Some("jwt-1"),
+            "the accelerator leg presents the session access token"
+        );
+
+        drop(engine);
+        assert!(
+            !accelerator_bearer.is_held(),
+            "a parked tick's gateway clone outlives the engine; the token must not"
+        );
+    }
+
     #[test]
     fn start_login_failure_is_fail_closed() {
         let (mut engine, _events, device) =
@@ -5316,7 +5381,7 @@ mod tests {
         };
         use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
-        use crate::content::{DAG_ROOT_CODEC, GatewaySource};
+        use crate::content::DAG_ROOT_CODEC;
         use crate::net::RE_PUT_INTERVAL;
         use crate::seams::{BoxedTask, EndpointId, RecordTransport};
         use crate::sync::pointer::{SessionRole, seal_repoint, vault_pointer_name};
@@ -5431,10 +5496,7 @@ mod tests {
 
         fn gateway_config() -> GatewayConfig {
             GatewayConfig {
-                accelerator: Some(GatewaySource {
-                    base_url: "https://gw.test".into(),
-                    bearer: None,
-                }),
+                accelerator: Some("https://gw.test".into()),
                 public_fallbacks: Vec::new(),
             }
         }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -52,9 +52,9 @@ pub use content::{
     ContentWriter, DAG_ROOT_CODEC, DagError, ExpandError, Expansion, FinishedContent, Gateway,
     GatewayConfig, GatewaySource, PinMode, ProviderError, PrunePlan, QuotaExceeded,
     ROOT_FORMAT_VERSION, ReadError, RetentionPolicy, RetireTarget, RootManifest, SealError,
-    SealedChunk, SealedContent, assemble, decode_root, expand_retire_targets, frame_and_seal,
-    leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block, seal_one_chunk,
-    test_connection, validate_byo_config,
+    SealedChunk, SealedContent, SessionBearer, assemble, decode_root, expand_retire_targets,
+    frame_and_seal, leaf_range_for_byte_range, plan_prune, pre_flight_quota_check, read_block,
+    seal_one_chunk, test_connection, validate_byo_config,
 };
 pub use entropy::{Entropy, EntropyError};
 pub use facade::{

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -568,7 +568,7 @@ mod tests {
     use cipherbox_core::seal::{Envelope, GrantSection};
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
-    use crate::content::{GatewaySource, SessionBearer};
+    use crate::content::GatewaySource;
     use crate::seams::HttpResponse;
     use crate::session::SessionIdentity;
     use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
@@ -674,10 +674,7 @@ mod tests {
 
     fn gateway() -> Gateway {
         Gateway {
-            accelerator: Some(GatewaySource {
-                base_url: "https://gw.test".into(),
-                bearer: SessionBearer::default(),
-            }),
+            accelerator: Some(GatewaySource::public("https://gw.test")),
             public_fallbacks: Vec::new(),
         }
     }

--- a/crates/engine/src/net/adopter.rs
+++ b/crates/engine/src/net/adopter.rs
@@ -568,7 +568,7 @@ mod tests {
     use cipherbox_core::seal::{Envelope, GrantSection};
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
 
-    use crate::content::GatewaySource;
+    use crate::content::{GatewaySource, SessionBearer};
     use crate::seams::HttpResponse;
     use crate::session::SessionIdentity;
     use crate::testkit::fakes::{InMemoryFloorStore, ScriptedHttp};
@@ -676,7 +676,7 @@ mod tests {
         Gateway {
             accelerator: Some(GatewaySource {
                 base_url: "https://gw.test".into(),
-                bearer: None,
+                bearer: SessionBearer::default(),
             }),
             public_fallbacks: Vec::new(),
         }

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -2305,7 +2305,7 @@ mod tests {
     use cipherbox_core::suite::secret::{SecretBytes, ct_eq};
 
     use super::*;
-    use crate::content::GatewaySource;
+    use crate::content::{GatewaySource, SessionBearer};
     use crate::rotation::sweep::sim;
     use crate::rotation::{
         CascadeError, CascadeOutcome, CommittedSet, EnumerationError, PrevEpochSeed, ResealSeeds,
@@ -2515,7 +2515,7 @@ mod tests {
                 gateway: Gateway {
                     accelerator: Some(GatewaySource {
                         base_url: "https://gw.test".into(),
-                        bearer: None,
+                        bearer: SessionBearer::default(),
                     }),
                     public_fallbacks: Vec::new(),
                 },

--- a/crates/engine/src/net/rotation.rs
+++ b/crates/engine/src/net/rotation.rs
@@ -2305,7 +2305,7 @@ mod tests {
     use cipherbox_core::suite::secret::{SecretBytes, ct_eq};
 
     use super::*;
-    use crate::content::{GatewaySource, SessionBearer};
+    use crate::content::GatewaySource;
     use crate::rotation::sweep::sim;
     use crate::rotation::{
         CascadeError, CascadeOutcome, CommittedSet, EnumerationError, PrevEpochSeed, ResealSeeds,
@@ -2513,10 +2513,7 @@ mod tests {
                 api,
                 floors: device.floor_store.clone(),
                 gateway: Gateway {
-                    accelerator: Some(GatewaySource {
-                        base_url: "https://gw.test".into(),
-                        bearer: SessionBearer::default(),
-                    }),
+                    accelerator: Some(GatewaySource::public("https://gw.test")),
                     public_fallbacks: Vec::new(),
                 },
                 profile: SyncTimingProfile::CI,

--- a/crates/engine/src/settings.rs
+++ b/crates/engine/src/settings.rs
@@ -951,7 +951,7 @@ fn kind_str(kind: ByoKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::content::GatewayConfig;
+    use crate::content::{GatewayConfig, SessionBearer};
     use crate::testkit::{FakeWorld, SeededEntropy, block_on};
 
     fn keep(n: u64) -> RetentionPolicy {
@@ -1226,7 +1226,7 @@ mod tests {
             accelerator: None,
             public_fallbacks: Vec::new(),
         }
-        .into_gateway();
+        .into_gateway(SessionBearer::default());
 
         let marks = [
             name.as_str().as_bytes().to_vec(),

--- a/crates/engine/src/testkit/content.rs
+++ b/crates/engine/src/testkit/content.rs
@@ -13,7 +13,7 @@ use super::SeededEntropy;
 use super::fakes::ScriptedHttp;
 use crate::content::{
     ContentKey, ContentProfile, ContentVersion, ContentWriter, Gateway, GatewaySource, SealedChunk,
-    SealedContent,
+    SealedContent, SessionBearer,
 };
 use crate::seams::{HttpResponse, SeamError};
 
@@ -83,7 +83,7 @@ pub fn gateway() -> Gateway {
         accelerator: None,
         public_fallbacks: vec![GatewaySource {
             base_url: "https://public.gw.test".into(),
-            bearer: None,
+            bearer: SessionBearer::default(),
         }],
     }
 }

--- a/crates/engine/src/testkit/content.rs
+++ b/crates/engine/src/testkit/content.rs
@@ -13,7 +13,7 @@ use super::SeededEntropy;
 use super::fakes::ScriptedHttp;
 use crate::content::{
     ContentKey, ContentProfile, ContentVersion, ContentWriter, Gateway, GatewaySource, SealedChunk,
-    SealedContent, SessionBearer,
+    SealedContent,
 };
 use crate::seams::{HttpResponse, SeamError};
 
@@ -81,10 +81,7 @@ pub fn doomed_version(plaintext: &[u8]) -> (ContentVersion, Vec<u8>, Vec<String>
 pub fn gateway() -> Gateway {
     Gateway {
         accelerator: None,
-        public_fallbacks: vec![GatewaySource {
-            base_url: "https://public.gw.test".into(),
-            bearer: SessionBearer::default(),
-        }],
+        public_fallbacks: vec![GatewaySource::public("https://public.gw.test")],
     }
 }
 

--- a/crates/engine/tests/vault_settings.rs
+++ b/crates/engine/tests/vault_settings.rs
@@ -29,8 +29,8 @@ use cipherbox_engine::seams::{
 use cipherbox_engine::testkit::fakes::VirtualScheduler;
 use cipherbox_engine::testkit::{FakeDevice, FakeWorld, SeededEntropy, block_on};
 use cipherbox_engine::{
-    DefaultsReason, Gateway, GatewayConfig, GatewaySource, OrphanHeads, ProviderError,
-    RetentionPolicy, SettingsLoad, SettingsPublishError, SyncTimingProfile, VaultSettings,
+    DefaultsReason, Gateway, GatewayConfig, OrphanHeads, ProviderError, RetentionPolicy,
+    SessionBearer, SettingsLoad, SettingsPublishError, SyncTimingProfile, VaultSettings,
     load_settings, publish_settings, settings_name,
 };
 
@@ -132,12 +132,9 @@ fn serve_http(device: &FakeDevice, blocks: &Blocks, calls: usize) {
 fn gateway() -> Gateway {
     GatewayConfig {
         accelerator: None,
-        public_fallbacks: vec![GatewaySource {
-            base_url: "http://gateway.test".to_owned(),
-            bearer: None,
-        }],
+        public_fallbacks: vec!["http://gateway.test".to_owned()],
     }
-    .into_gateway()
+    .into_gateway(SessionBearer::default())
 }
 
 fn configured() -> VaultSettings {

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -7923,6 +7923,15 @@ fn a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters() {
     let file = file_with_history(&world, &mut engine, &mut tasks, &[body]);
     let head = published_versions(&world.record_store, &blocks, file).remove(0);
     let unserved = compute_cid(DAG_ROOT_CODEC, b"a root block no source ever stored");
+    let planted_versions = vec![
+        head,
+        CoreVersion::new(
+            unserved,
+            [0u8; 32],
+            ContentProfile::CI.chunk_size() as u64,
+            0,
+        ),
+    ];
     plant_record(
         &world.record_store,
         &blocks,
@@ -7934,15 +7943,7 @@ fn a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters() {
             body: &ReadBody::File {
                 created_at: 0,
                 modified_at: 0,
-                versions: vec![
-                    head,
-                    CoreVersion::new(
-                        unserved,
-                        [0u8; 32],
-                        ContentProfile::CI.chunk_size() as u64,
-                        0,
-                    ),
-                ],
+                versions: planted_versions.clone(),
                 unknown: PreservedFields::new(),
             },
         },
@@ -7967,8 +7968,8 @@ fn a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters() {
     );
     assert_eq!(engine.pending_reclaim_bytes(), 0, "and journals no debt");
     assert_eq!(
-        published_versions(&world.record_store, &blocks, file).len(),
-        2,
-        "and leaves the history it could not expand standing"
+        published_versions(&world.record_store, &blocks, file),
+        planted_versions,
+        "and leaves the history it could not expand standing, entry for entry"
     );
 }

--- a/crates/engine/tests/write_plane.rs
+++ b/crates/engine/tests/write_plane.rs
@@ -27,7 +27,7 @@ use zeroize::Zeroizing;
 use cipherbox_engine::api::REGISTRY_BATCH_REFUSED;
 use cipherbox_engine::content::chunk::SEALED_LEAF_OVERHEAD;
 use cipherbox_engine::content::{
-    ByoIpfsConfig, ByoKind, DAG_ROOT_CODEC, GatewaySource, PinMode, RetentionPolicy, SealedChunk,
+    ByoIpfsConfig, ByoKind, DAG_ROOT_CODEC, PinMode, RetentionPolicy, SealedChunk, SessionBearer,
     assemble, decode_root,
 };
 use cipherbox_engine::facade::PendingClass;
@@ -578,10 +578,7 @@ fn engine_on(device: &FakeDevice, entropy_seed: u64) -> (Engine<FakeSeamTypes>, 
         // plane, not the auth handshake.
         ApiBaseUrl::offline(),
         GatewayConfig {
-            accelerator: Some(GatewaySource {
-                base_url: "https://gw.test".into(),
-                bearer: None,
-            }),
+            accelerator: Some("https://gw.test".into()),
             public_fallbacks: Vec::new(),
         },
     )
@@ -602,10 +599,7 @@ fn engine_on_api(device: &FakeDevice, entropy_seed: u64) -> (Engine<FakeSeamType
         StoragePolicy::CI,
         ApiBaseUrl::parse("http://api.test").expect("a configured base"),
         GatewayConfig {
-            accelerator: Some(GatewaySource {
-                base_url: "https://gw.test".into(),
-                bearer: None,
-            }),
+            accelerator: Some("https://gw.test".into()),
             public_fallbacks: Vec::new(),
         },
     )
@@ -3403,13 +3397,10 @@ fn a_create_below_the_scope_root_is_adoptable_by_a_second_device() {
     assert_eq!(parents[0].id, photos);
 
     let gateway = GatewayConfig {
-        accelerator: Some(GatewaySource {
-            base_url: "https://gw.test".into(),
-            bearer: None,
-        }),
+        accelerator: Some("https://gw.test".into()),
         public_fallbacks: Vec::new(),
     }
-    .into_gateway();
+    .into_gateway(SessionBearer::default());
     let adopter = ChildAdopter::new(
         &gateway,
         &bob.http,
@@ -7975,4 +7966,9 @@ fn a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters() {
         "a prune that never expanded retires nothing"
     );
     assert_eq!(engine.pending_reclaim_bytes(), 0, "and journals no debt");
+    assert_eq!(
+        published_versions(&world.record_store, &blocks, file).len(),
+        2,
+        "and leaves the history it could not expand standing"
+    );
 }

--- a/crates/fuse/tests/fuse_op_core.rs
+++ b/crates/fuse/tests/fuse_op_core.rs
@@ -1182,7 +1182,7 @@ mod published {
     use cipherbox_core::kdf;
     use cipherbox_core::payload::RepointObject;
     use cipherbox_core::suite::ecdsa::EcdsaSigner;
-    use cipherbox_engine::content::{DAG_ROOT_CODEC, GatewaySource};
+    use cipherbox_engine::content::DAG_ROOT_CODEC;
     use cipherbox_engine::seams::{
         BoxedTask, HttpRequest, HttpResponse, RecordTransport, SeamError, SeamResult,
     };
@@ -1367,10 +1367,7 @@ mod published {
             StoragePolicy::CI,
             ApiBaseUrl::offline(),
             GatewayConfig {
-                accelerator: Some(GatewaySource {
-                    base_url: "https://gw.test".into(),
-                    bearer: None,
-                }),
+                accelerator: Some("https://gw.test".into()),
                 public_fallbacks: Vec::new(),
             },
         );

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -20,8 +20,8 @@ use std::rc::Rc;
 use async_lock::{Mutex, RwLock};
 use cipherbox_engine::facade::{ApiBaseUrl, Engine, EngineError, EventStream, LoginSecret};
 use cipherbox_engine::{
-    ContentProfile, Entropy, EntropyError, GatewayConfig, GatewaySource, SeamSet, SeamTypes,
-    StoragePlatform, StoragePolicy, StreamHandle, SyncTimingProfile, WriteHandle, WriteTarget,
+    ContentProfile, Entropy, EntropyError, GatewayConfig, SeamSet, SeamTypes, StoragePlatform,
+    StoragePolicy, StreamHandle, SyncTimingProfile, WriteHandle, WriteTarget,
 };
 use js_sys::{Promise, Reflect, Uint8Array};
 use wasm_bindgen::prelude::*;
@@ -88,8 +88,10 @@ impl EngineHandle {
     /// `credentialStore`); a missing seam fails closed. `profile` selects the
     /// sync timing policy (`"ci"` for the compressed e2e cadences, production
     /// otherwise). `apiBaseUrl` is required and non-blank. The content gateway
-    /// is configured from `acceleratorBaseUrl` (+ optional `acceleratorBearer`)
-    /// and `publicGateways`.
+    /// is configured from `acceleratorBaseUrl` and `publicGateways`;
+    /// `acceleratorBearer` is refused, because the accelerator's credential is
+    /// the session access token the engine holds in linear memory and never
+    /// surfaces.
     #[wasm_bindgen(constructor)]
     pub fn new(
         seams: JsValue,
@@ -105,6 +107,13 @@ impl EngineHandle {
         // Wrapped before the first `?`: an early return would otherwise drop the
         // Rust-owned bearer String unzeroized (security rule 7).
         let accelerator_bearer = accelerator_bearer.map(Zeroizing::new);
+        // Refused rather than ignored: a host that reached a credential into the
+        // public bundle must hear that it did, not have it silently dropped.
+        if accelerator_bearer.is_some() {
+            return Err(JsError::new(
+                "acceleratorBearer is refused: the accelerator credential is session-scoped",
+            ));
+        }
 
         let api_base_url = ApiBaseUrl::parse(api_base_url.as_deref().unwrap_or_default())?;
 
@@ -160,18 +169,8 @@ impl EngineHandle {
         // reads fail closed as `Unavailable` (availability, never a trust
         // violation).
         let gateway = GatewayConfig {
-            accelerator: accelerator_base_url.map(|base_url| GatewaySource {
-                base_url,
-                bearer: accelerator_bearer,
-            }),
-            public_fallbacks: public_gateways
-                .unwrap_or_default()
-                .into_iter()
-                .map(|base_url| GatewaySource {
-                    base_url,
-                    bearer: None,
-                })
-                .collect(),
+            accelerator: accelerator_base_url,
+            public_fallbacks: public_gateways.unwrap_or_default(),
         };
 
         let (engine, events) = Engine::new(
@@ -607,5 +606,31 @@ mod tests {
             );
             assert!(message.contains("apiBaseUrl"), "{message}");
         }
+    }
+
+    /// A bearer reaching the constructor came from a build-time variable in the
+    /// public bundle. Refused loudly rather than dropped, and refused ahead of
+    /// every other check so no partly-built engine holds it.
+    #[wasm_bindgen_test]
+    fn a_host_supplied_accelerator_bearer_is_refused() {
+        let error = EngineHandle::new(
+            js_sys::Object::new().into(),
+            None,
+            Some("http://api.test".to_owned()),
+            Some("https://gw.test".to_owned()),
+            Some("a-build-time-token".to_owned()),
+            None,
+            None,
+        )
+        .err()
+        .expect("a host-supplied bearer is a construction failure");
+
+        let message = String::from(
+            JsValue::from(error)
+                .unchecked_into::<js_sys::Error>()
+                .message(),
+        );
+        assert!(message.contains("acceleratorBearer"), "{message}");
+        assert!(!message.contains("a-build-time-token"), "{message}");
     }
 }

--- a/crates/wasm/src/host.rs
+++ b/crates/wasm/src/host.rs
@@ -89,9 +89,8 @@ impl EngineHandle {
     /// sync timing policy (`"ci"` for the compressed e2e cadences, production
     /// otherwise). `apiBaseUrl` is required and non-blank. The content gateway
     /// is configured from `acceleratorBaseUrl` and `publicGateways`;
-    /// `acceleratorBearer` is refused, because the accelerator's credential is
-    /// the session access token the engine holds in linear memory and never
-    /// surfaces.
+    /// `acceleratorBearer` is refused (the accelerator's credential is the
+    /// engine's session token, never a host's).
     #[wasm_bindgen(constructor)]
     pub fn new(
         seams: JsValue,
@@ -107,8 +106,8 @@ impl EngineHandle {
         // Wrapped before the first `?`: an early return would otherwise drop the
         // Rust-owned bearer String unzeroized (security rule 7).
         let accelerator_bearer = accelerator_bearer.map(Zeroizing::new);
-        // Refused rather than ignored: a host that reached a credential into the
-        // public bundle must hear that it did, not have it silently dropped.
+        // Refused, not ignored: a credential reaching here came from the public
+        // bundle, and the host must hear that rather than have it dropped.
         if accelerator_bearer.is_some() {
             return Err(JsError::new(
                 "acceleratorBearer is refused: the accelerator credential is session-scoped",
@@ -609,28 +608,30 @@ mod tests {
     }
 
     /// A bearer reaching the constructor came from a build-time variable in the
-    /// public bundle. Refused loudly rather than dropped, and refused ahead of
-    /// every other check so no partly-built engine holds it.
+    /// public bundle, so it is refused rather than dropped — and refused before
+    /// the `apiBaseUrl` check, which the blank base here is what proves.
     #[wasm_bindgen_test]
-    fn a_host_supplied_accelerator_bearer_is_refused() {
-        let error = EngineHandle::new(
-            js_sys::Object::new().into(),
-            None,
-            Some("http://api.test".to_owned()),
-            Some("https://gw.test".to_owned()),
-            Some("a-build-time-token".to_owned()),
-            None,
-            None,
-        )
-        .err()
-        .expect("a host-supplied bearer is a construction failure");
+    fn a_host_supplied_accelerator_bearer_is_refused_first() {
+        for api_base_url in [Some("http://api.test".to_owned()), None] {
+            let error = EngineHandle::new(
+                js_sys::Object::new().into(),
+                None,
+                api_base_url,
+                Some("https://gw.test".to_owned()),
+                Some("a-build-time-token".to_owned()),
+                None,
+                None,
+            )
+            .err()
+            .expect("a host-supplied bearer is a construction failure");
 
-        let message = String::from(
-            JsValue::from(error)
-                .unchecked_into::<js_sys::Error>()
-                .message(),
-        );
-        assert!(message.contains("acceleratorBearer"), "{message}");
-        assert!(!message.contains("a-build-time-token"), "{message}");
+            let message = String::from(
+                JsValue::from(error)
+                    .unchecked_into::<js_sys::Error>()
+                    .message(),
+            );
+            assert!(message.contains("acceleratorBearer"), "{message}");
+            assert!(!message.contains("a-build-time-token"), "{message}");
+        }
     }
 }


### PR DESCRIPTION
Closes #1237
Closes #1238
Closes #1033

Three Rust changes over disjoint files: one runtime fix and two regression guards that were raised as review nitpicks and never landed.

## The read-accelerator bearer now comes from the session

The read accelerator is CipherBox's own token-authed Kubo trustless gateway, but nothing supplied its bearer. `EngineHandle::new` took an `acceleratorBearer` no host could fill: a `VITE_`-prefixed variable is inlined into the public bundle and a bearer is a per-session credential, so the browser config surface deliberately omitted it. The browser engine therefore reached the accelerator unauthenticated and every read fell through to the public gateway fallbacks — correct fail-open behaviour, but the member acceleration was dead.

The credential is now the session access token the API client already holds in linear memory and never surfaces.

- `SessionBearer` (`crates/engine/src/content/read.rs`) is a shared, zeroizing, `Debug`-redacted cell. `ApiClient` writes it on login and on every refresh rotation, and clears it at logout, on a failed refresh, and on an unusable token; `Engine::shut_down` clears it too, because a parked tick's gateway clone outlives the engine.
- The accelerator leg reads the cell **per request**, so a rotation lands without the gateway being rebuilt — a snapshot copied in at login would go stale inside the JWT's lifetime and silently 401 back to the public fallbacks.
- `GatewayConfig` now carries base URLs only. A host cannot configure a gateway credential at all, and a public fallback has none by construction rather than by convention.
- The bearer is bound **only to a leg that can keep it** — TLS, or a loopback host so the local Kubo in `apps/web/.env.example` still works. The accelerator URL is host configuration and the token authorizes the whole API, so a stale or mistyped value must cost the member their acceleration, not their session. A denied leg still serves reads, unauthenticated.
- Teardown is a one-way latch: `shut_down` **seals** the cell rather than clearing it, because a refresh parked on the network resumes after the engine is gone and would otherwise re-arm it. The cold-start failure arm clears it too — login has already stored a token by then, and that arm exists to leave no key material resident.
- A host-supplied `acceleratorBearer` is **refused** with an `Err`, not silently dropped: a bearer reaching that constructor came from a build-time variable in the public bundle, and the host should hear that.

Covered by `the_accelerator_presents_whatever_the_session_cell_currently_holds` (no session → bare; set → carried; rotated → new value; cleared → bare), `into_gateway_binds_the_session_bearer_to_the_accelerator_alone`, `an_accelerator_that_cannot_keep_a_credential_is_never_handed_one`, `a_tls_or_loopback_accelerator_is_handed_the_session_bearer`, `a_sealed_bearer_refuses_a_late_token`, `login_binds_the_session_token_to_the_accelerator_and_shutdown_drops_it`, and the wasm-side `a_host_supplied_accelerator_bearer_is_refused_first`. The existing "public fallback carries no bearer token" assertion is unchanged.

**The credential is the full API session JWT, not a read-scoped token.** `blueprint/api.md` says the gateway is "gated by a CipherBox auth token" without saying which; this makes it the session token, which also authorizes uploads, quota and mailbox writes. That is the only credential the client has without a new API endpoint, and both it and `apiBaseUrl` come from the same deployment's configuration — but it widens the blast radius of any leak at the gateway tier, and the accelerator now sees which CIDs a member reads and when. Narrowing it to a read-scoped, audience-bound token is #1244.

## The prune dead-letter test guards the surviving history

`publish_prune` computes `prune_debt` **before** `versions.truncate(...)` and before `publish_node`, precisely so a debt the pass cannot compute leaves the history it was read from standing. `a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters` asserted the dead-letter reason, an unchanged retire-target count, and a zero pending reclaim — every one of which a regression moving `prune_debt` after the publish would leave passing while the record silently lost a version. It now asserts the history survives.

## The KAT suite pins ephemeral-scalar freshness

HPKE ephemeral reuse under one recipient key and one `info` is a confidentiality break (`crates/core/src/seal/owner_local.rs`), and several accept families seal every vector to the same recipient under the same `info` — two of the four owner-local accept vectors carry `kind: received-shares`. About 35 loops pinned vector *names* for uniqueness and none pinned the ephemeral.

Rather than adding a set to each of the ten HPKE-sealing loops, one test reads every embedded fixture for `ephemeralScalar` and asserts uniqueness within each file, scalars folded to lowercase so a hex-case change cannot hide a byte-level repeat.

Per-file is the right scope because a vector file is a **superset** of each `(recipient, info)` group inside it — `owner_local_accept` alone spans four `info` values and pins two vectors under one — so it forbids every real repeat plus some harmless ones. It is deliberately not corpus-wide: `content_key_accept` and `settings_record_accept` share a recipient key *and* both ephemeral scalars today, separated only by their HPKE `info`, so a global assertion would fail on `main`. `HPKE_EPHEMERAL_FAMILIES` is the anti-vacuity anchor as a named `(file, count)` list, matching this file's `CODEC_DECODE_REACHABLE_CHECKS` / `ALL_STRUCT_TAGS` convention — a bare total would let one family going dark be masked by another gaining a vector.

The vectors themselves are untouched — `cargo run -p cipherbox-core --example kat_gen` leaves `crates/core/kat/` clean.

## Gates

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `cargo check -p cipherbox-wasm --target wasm32-unknown-unknown` | 0 |
| `pnpm lint:tracker-refs` | 0 |
| `kat_gen` + `git status --porcelain crates/core/kat/` | empty |

## True negatives

Each guard was verified to fail when the thing it guards is broken.

| Break | Caught by |
| --- | --- |
| `prune_debt` moved after `publish_node` in `crates/engine/src/sync/drain.rs` | `a_prune_whose_root_no_source_serves_spends_its_budget_and_dead_letters` — the new assertion reports `left: 1, right: 2` once the harness's attempt-budget assert is stood down; with the harness intact the same reorder fails the test at the budget instead, so CI is red either way |
| Ephemeral of `empty-body` duplicated onto `received-shares-body` in `owner_local_accept.json`, in **uppercase** hex — both `kind: received-shares`, so one recipient key and one `info` | `ephemeral_scalars_are_fresh_within_each_vector_file` — "vector received-shares-body repeats another vector's ephemeral scalar", so the case fold holds |
| `ephemeralScalar` renamed in `mailbox_accept.json`, i.e. one family silently leaving the walk | same test — "hpke ephemeral family coverage drift", naming the missing file |

All breaks were reverted; `crates/core/kat/` and `crates/engine/src/sync/drain.rs` are byte-identical to `main`.

## Review passes

`/simplify`, `/security-review` and `/crypto-privacy-review` were run over the diff and their findings folded back in a second commit — the transport gate on the bearer binding (both security passes ranked it highest), the seal-on-teardown latch, clearing on cold-start failure, dropping `PartialEq`/`Eq` from the gateway types (they made a variable-time comparison of a credential reachable and existed only for fixtures), narrowing the `SessionBearer` mutation surface, collapsing the API client's one-field `State`, and `GatewaySource::public` for the six no-auth sites.

The crypto pass also caught a factual error in my own comment: it claimed distinct vector files seal under distinct recipients, which the corpus contradicts. That is corrected above and in the code.

## Not done

`EngineHandle::new` keeps its `acceleratorBearer` parameter position rather than dropping it. `packages/client/src/worker/engineWasm.ts` and `engineHost.ts` pass it positionally as `undefined`, and `EngineWasm` is a hand-written interface, so removing the parameter would shift `publicGateways` into the headroom slot without a TypeScript error — a silent runtime regression. Those files are outside this change's ownership, so the four have to move together: #1245.

The accelerator gate is transport-only. Requiring the accelerator host to match the API host was considered and rejected: staging runs them on sibling subdomains, and a same-registrable-domain test needs a public-suffix list. Narrowing the credential itself (#1244) is the better lever.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Source the read-accelerator bearer from the session and pin HPKE ephemeral guards
> - Introduces `SessionBearer` in [read.rs](https://github.com/FSM1/cipher-box/pull/1243/files#diff-2935bc904c4b1d9473611b925d9e879773d278dd5cc6617be398aa4b6c49e855), a shared, zeroizing, sealable `Rc<RefCell<BearerCell>>` that holds the API access token and is readable by the read-accelerator leg at request time.
> - Wires `ApiClient` to accept a `SessionBearer` via `with_session_bearer`; token rotations and clears now propagate to all consumers sharing the cell.
> - `GatewayConfig::into_gateway` now accepts a `SessionBearer` and attaches it to the accelerator source only when the URL is TLS or loopback (`carries_credentials_safely`); public fallbacks never receive a credential.
> - `Engine` holds the shared bearer, passes a clone to the gateway at construction, sets it on the API client at login, clears it on cold-start failure, and seals it during shutdown to prevent late re-arming.
> - `EngineHandle::new` (WASM host) now rejects a caller-supplied `acceleratorBearer` with an explicit error, as credentials are session-scoped.
> - Adds KAT tests asserting HPKE ephemeral scalars are unique within each vector file and that the expected files pin the expected counts.
> - Risk: `GatewayConfig` no longer accepts credentials at construction; callers that previously embedded a bearer directly must migrate to `into_gateway(SessionBearer)`; WASM callers passing `acceleratorBearer` now receive a hard error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f126425.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved session-token handling for gateway and API access, including secure clearing during shutdown and safer credential redaction.
  * Accelerator credentials are restricted to approved connections, while unsupported credentials are rejected early.

* **Configuration**
  * Gateway accelerators and public fallbacks can be configured directly with URL values.

* **Bug Fixes**
  * Preserved histories when their roots cannot be fetched during pruning.
  * Added validation to ensure embedded HPKE test vectors remain complete and non-duplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->