### PR TITLE
docs: make CipherBox the identity-token issuer in the blueprint

### DIFF
--- a/blueprint/api.md
+++ b/blueprint/api.md
@@ -38,7 +38,7 @@ What left the API relative to v1 — with the design that removed it:
 
 - Account = the Web3Auth-derived secp256k1 **identity key**; challenge-signature
   login. **CipherBox issues the identity token the Core Kit consumes** (FSM1/cipher-box-next#5 as
-  amended by ADR 0008): each verified method mints a CipherBox JWT, and the Core Kit
+  amended by [ADR 0008](https://github.com/FSM1/cipher-box-next/blob/main/decisions/0008-cipherbox-issues-the-identity-token.md)): each verified method mints a CipherBox JWT, and the Core Kit
   logs in against a CipherBox custom verifier over the API's own JWKS. The account
   model is unchanged by this — the Core Kit yields the same key whichever provider
   vouched.

--- a/blueprint/api.md
+++ b/blueprint/api.md
@@ -37,7 +37,19 @@ What left the API relative to v1 — with the design that removed it:
 ## Identity and auth
 
 - Account = the Web3Auth-derived secp256k1 **identity key**; challenge-signature
-  login; SIWE wallet login stays as a secondary auth method (feature-set decision FSM1/cipher-box-next#5).
+  login. **CipherBox issues the identity token the Core Kit consumes** (FSM1/cipher-box-next#5 as
+  amended by ADR 0008): each verified method mints a CipherBox JWT, and the Core Kit
+  logs in against a CipherBox custom verifier over the API's own JWKS. The account
+  model is unchanged by this — the Core Kit yields the same key whichever provider
+  vouched.
+- **Method set**: Google, passwordless email, and wallet. Passwordless email is
+  CipherBox's own — the API issues and verifies the code and owns its delivery.
+  Wallet is a **first-class first login on web only**: a SIWE signature the API
+  verifies mints the same JWT as any other method, so it reaches the same derived
+  key. It is absent on desktop because that webview reaches no wallet, which is a
+  platform property rather than a deferred feature (ADR 0008).
+- Google's OAuth client ID is the **provider's**, distinct from the Web3Auth project
+  client ID. The two are not interchangeable.
 - Short-lived access JWT + rotating refresh token (HTTP-only cookie on web,
   OS keychain on desktop). Staging-gated test-login endpoint for e2e.
 - Tables: `users` (keyed by `publicKey`; carries quota-limit override and BYO flag),

--- a/blueprint/desktop.md
+++ b/blueprint/desktop.md
@@ -250,6 +250,18 @@ navigation (FSM1/cipher-box-next#33 D2):
   the shell's only credential duty is hosting the keychain seam. Dev-key mode
   survives: a debug flag feeds the staging test-login path through the same
   facade, keychain bypassed — the headless agent/e2e seam.
+- **The orchestration is the web client's** (ADR 0008 D3): the shell imports the
+  same host-agnostic login package and supplies its own credential collector. It
+  does **not** take `packages/client` — the worker, leadership and Service Worker
+  machinery has no place here.
+- **Google collection is native, not in-webview.** Google Identity Services does
+  not run in this webview, and the manual OAuth2 flow it falls back to needs a
+  `redirect_uri` a packaged Tauri origin cannot satisfy — `tauri://localhost` is
+  refused as a non-`http(s)` scheme. The shell therefore serves the callback from
+  a loopback listener on a pre-registered port. This is the one login step that
+  is genuinely native (ADR 0008).
+- **No wallet method here.** The webview reaches no wallet, so the method is
+  absent rather than offered and unable to complete (ADR 0008 D2).
 - **Tray** renders the event stream: the staleness ladder maps to
   `Synced / Reconciling / Stale / Offline`, dead-letters to the parked-writes
   state (edge-triggered notifications, v1's anti-spam watermark kept), trust

--- a/blueprint/desktop.md
+++ b/blueprint/desktop.md
@@ -250,7 +250,7 @@ navigation (FSM1/cipher-box-next#33 D2):
   the shell's only credential duty is hosting the keychain seam. Dev-key mode
   survives: a debug flag feeds the staging test-login path through the same
   facade, keychain bypassed — the headless agent/e2e seam.
-- **The orchestration is the web client's** (ADR 0008 D3): the shell imports the
+- **The orchestration is the web client's** ([ADR 0008](https://github.com/FSM1/cipher-box-next/blob/main/decisions/0008-cipherbox-issues-the-identity-token.md) D3): the shell imports the
   same host-agnostic login package and supplies its own credential collector. It
   does **not** take `packages/client` — the worker, leadership and Service Worker
   machinery has no place here.

--- a/blueprint/web-client.md
+++ b/blueprint/web-client.md
@@ -198,7 +198,7 @@ all living in `packages/client` and running inside the engine worker realm:
 - **The engine owns the token lifecycle** (FSM1/cipher-box-next#28 D5): challenge-signature login
   through its API client; access JWT in engine memory; refresh cookie rides
   the Http seam. This is a distinct authentication from unlocking the Core Kit,
-  and only the latter involves an identity provider (ADR 0008).
+  and only the latter involves an identity provider ([ADR 0008](https://github.com/FSM1/cipher-box-next/blob/main/decisions/0008-cipherbox-issues-the-identity-token.md)).
 - **The login orchestration is shared, the credential collection is not**
   (ADR 0008 D3). One host-agnostic package sequences provider credential → API
   exchange → Core Kit login → secret export → `start(secret)`; both hosts import

--- a/blueprint/web-client.md
+++ b/blueprint/web-client.md
@@ -197,8 +197,18 @@ all living in `packages/client` and running inside the engine worker realm:
   entry.
 - **The engine owns the token lifecycle** (FSM1/cipher-box-next#28 D5): challenge-signature login
   through its API client; access JWT in engine memory; refresh cookie rides
-  the Http seam. SIWE stays secondary — wagmi collects the wallet signature
-  on the UI thread and the facade forwards it (engine.md).
+  the Http seam. This is a distinct authentication from unlocking the Core Kit,
+  and only the latter involves an identity provider (ADR 0008).
+- **The login orchestration is shared, the credential collection is not**
+  (ADR 0008 D3). One host-agnostic package sequences provider credential → API
+  exchange → Core Kit login → secret export → `start(secret)`; both hosts import
+  it and inject their own collector. On web that collector is the Google popup
+  and wagmi; desktop's is its own (desktop.md). The boundary is credential
+  collection, not the bearer token — v1 drew it at the token and the two hosts
+  drifted.
+- **Wallet is a first login here** (ADR 0008 D2): wagmi collects the signature on
+  the UI thread, the API verifies it and mints the identity token, and the Core
+  Kit login proceeds as for any other method. Web only.
 - **Cold start**: facade `start(secret)` → vault-pointer resolve, floor
   cold-seed, root adoption (the engine's non-circular cold-start sequence) →
   first snapshot event. The UI shows exactly two cold-start states: an


### PR DESCRIPTION
Records ADR 0008 (FSM1/cipher-box-next#64) in the blueprint. Documentation only, no code surface.

**Draft until FSM1/cipher-box-next#64 is accepted** — the decision corpus is normative and this repo carries the as-built statement of it, so this should not land ahead of the decision.

## What changed and why

The blueprint conflated two authentications:

1. **Unlocking the Core Kit** — an identity provider vouches for the person; the Core Kit returns the TSS key.
2. **Authenticating to the API** — the engine signs a challenge with the derived identity key.

FSM1/cipher-box-next#28 D5 decided (2), correctly. (1) was never decided, and v2 built it as Web3Auth's hosted OAuth in the client wiring. That is what makes a wallet unable to start a session and leaves passwordless email delegated.

The account model is untouched, and that is the point: the Core Kit yields the same secp256k1 key whichever provider vouched, so `api.md`'s "Account = the Web3Auth-derived identity key" holds either way.

### `blueprint/api.md`

CipherBox becomes the identity-token issuer over its own JWKS. The method set is stated explicitly, with passwordless email as the API's own and wallet as a first-class first login on **web only**. The "SIWE stays a secondary auth method" clause goes — that is the clause ADR 0008 amends. Adds the note that Google's OAuth client ID is the provider's and is not the Web3Auth project client ID.

### `blueprint/web-client.md`

Names the two authentications as distinct. States the shared-orchestration package and that credential collection is injected per host, with the boundary at credential collection rather than at the bearer token — v1 drew it at the token and its two hosts drifted. States that wallet is a first login here.

### `blueprint/desktop.md`

States that the shell imports the same login package but **not** `packages/client`, whose worker, leadership and Service Worker machinery has no place there. Records that Google collection is genuinely native: GIS does not run in that webview, and a packaged Tauri origin cannot satisfy the `redirect_uri` the fallback flow needs, so the callback comes from a loopback listener. States that the wallet method is absent rather than offered and unable to complete.

## Checks

`markdownlint-cli2` and `prettier --check` both clean on all three files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document CipherBox as the identity-token issuer in the authentication blueprint
> - Updates [api.md](https://github.com/FSM1/cipher-box/pull/1255/files#diff-837f9da74fb8b2f204eb39809210c38c9d235041a65fcf0e6bc79151c6a9eece) to reflect ADR 0008: CipherBox issues the identity JWT consumed by Core Kit, with each verified method (Google, passwordless email, wallet) minting the same CipherBox JWT rather than treating SIWE as secondary.
> - Updates [web-client.md](https://github.com/FSM1/cipher-box/pull/1255/files#diff-8e61a233f5585dd57ed151b4a8942f15e3113549c64a08a7620e3745c56c1ff1) to describe shared login orchestration via a host-agnostic package, and declares wallet (via wagmi) as a first-class login method on web.
> - Updates [desktop.md](https://github.com/FSM1/cipher-box/pull/1255/files#diff-1b715591e11d0d0c1bddcaa72f65442dc1b245cf78ca3079738c52b17aad3e63) to document that Google OAuth uses a native loopback listener instead of an in-webview flow, and explicitly excludes wallet as a login method on desktop due to platform constraints.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2de3c3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication flows across web and desktop experiences.
  * Documented Google, passwordless email, and wallet sign-in behavior.
  * Wallet sign-in is now described as a supported web login option using SIWE.
  * Desktop authentication uses native Google OAuth handling and does not include wallet login.
  * Clarified that passwordless email codes are issued, verified, and delivered by the API.
  * Documented shared login orchestration while preserving host-specific credential collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->