### PR TITLE
fix: carry the Google and Web3Auth client IDs separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ the same backend, or the republisher re-PUTs into a store the client never reads
 The API's write path is live end to end: authenticate and `POST /content/upload`
 returns 201 with bytes pinned in the local Kubo.
 
-Interactive login through the web UI needs `VITE_WEB3AUTH_CLIENT_ID` and
-`VITE_WEB3AUTH_VERIFIER`, which a clean checkout does not carry — the UI boots and
-renders without them, but a Core Kit session cannot be created. The suites that need an
+Interactive login through the web UI needs `VITE_WEB3AUTH_CLIENT_ID`,
+`VITE_WEB3AUTH_VERIFIER` and `VITE_GOOGLE_CLIENT_ID`, which a clean checkout does not
+carry — the UI boots and renders without them, but a Core Kit session cannot be created. The suites that need an
 authenticated session use the build-time introspection hook instead; see
 [`tests/web-e2e/README.md`](tests/web-e2e/README.md).
 

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ returns 201 with bytes pinned in the local Kubo.
 
 Interactive login through the web UI needs `VITE_WEB3AUTH_CLIENT_ID`,
 `VITE_WEB3AUTH_VERIFIER` and `VITE_GOOGLE_CLIENT_ID`, which a clean checkout does not
-carry — the UI boots and renders without them, but a Core Kit session cannot be created. The suites that need an
-authenticated session use the build-time introspection hook instead; see
-[`tests/web-e2e/README.md`](tests/web-e2e/README.md).
+carry — the UI boots and renders without them, but a Core Kit session cannot be created.
+The suites that need an authenticated session use the build-time introspection hook
+instead; see [`tests/web-e2e/README.md`](tests/web-e2e/README.md).
 
 A first folder create does not yet publish, because nothing provisions a fresh account's
 first vault pointer, so its writes are accepted, rendered pending, and reach no endpoint.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,7 +22,14 @@ VITE_ROUTING_ENDPOINTS=http://localhost:3001
 # Optional comma-separated public gateways the engine may read from.
 # VITE_PUBLIC_GATEWAYS=
 
-# Web3Auth Core Kit. Interactive login needs both. A clean checkout carries
-# neither, so the UI renders but cannot create a session until they are set.
+# Web3Auth Core Kit. Interactive login needs all three, and a clean checkout
+# carries none — the UI renders but cannot create a session until they are set.
+#
+# The two client IDs are separate registrations and are NOT interchangeable:
+#   VITE_WEB3AUTH_CLIENT_ID — the Web3Auth project, from the Web3Auth dashboard
+#   VITE_GOOGLE_CLIENT_ID   — the Google Cloud OAuth 2.0 client the verifier's
+#                             Google sub-verifier is registered against
+# Sending the Web3Auth one to Google is a 401 invalid_client on every account.
 # VITE_WEB3AUTH_CLIENT_ID=
 # VITE_WEB3AUTH_VERIFIER=
+# VITE_GOOGLE_CLIENT_ID=

--- a/apps/web/src/auth/CoreKitProvider.test.tsx
+++ b/apps/web/src/auth/CoreKitProvider.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
 const ENV = {
   VITE_WEB3AUTH_CLIENT_ID: 'client-id',
   VITE_WEB3AUTH_VERIFIER: 'verifier',
+  VITE_GOOGLE_CLIENT_ID: 'google-client-id',
 } satisfies Partial<ImportMetaEnv>;
 
 describe('CoreKitProvider', () => {

--- a/apps/web/src/auth/coreKit.test.ts
+++ b/apps/web/src/auth/coreKit.test.ts
@@ -14,6 +14,7 @@ const SESSION = '{"sessionId":"not-a-real-session-id"}';
 // login and logout outcomes a device can actually land in.
 const sdk = vi.hoisted(() => ({
   options: undefined as Record<string, unknown> | undefined,
+  subVerifier: undefined as Record<string, unknown> | undefined,
   status: 'LOGGED_IN',
   statusAfterLogin: 'LOGGED_IN',
   logoutError: undefined as Error | undefined,
@@ -35,7 +36,8 @@ vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
       init(): Promise<void> {
         return sdk.initFailure ? Promise.reject(sdk.initFailure) : Promise.resolve();
       }
-      async loginWithOAuth(): Promise<void> {
+      async loginWithOAuth(params: { subVerifierDetails: Record<string, unknown> }): Promise<void> {
+        sdk.subVerifier = params.subVerifierDetails;
         sdk.status = sdk.statusAfterLogin;
       }
       commitChanges(): Promise<void> {
@@ -50,31 +52,33 @@ vi.mock('@web3auth/mpc-core-kit', async (importOriginal) => {
 });
 
 const ENV = {
-  VITE_WEB3AUTH_CLIENT_ID: 'client-id',
+  VITE_WEB3AUTH_CLIENT_ID: 'web3auth-client-id',
   VITE_WEB3AUTH_VERIFIER: 'verifier',
+  VITE_GOOGLE_CLIENT_ID: 'google-client-id',
 } satisfies Partial<ImportMetaEnv>;
 
 const REFUSED = new Error('the session server is unreachable');
 
+let keys: MemoryKeys;
+let store: SealedStore;
+
+/** A session over a store this test can seed and read back. */
+const session = () => createCoreKitSession(ENV, store);
+
+beforeEach(() => {
+  sdk.options = undefined;
+  sdk.subVerifier = undefined;
+  sdk.status = COREKIT_STATUS.LOGGED_IN;
+  sdk.statusAfterLogin = COREKIT_STATUS.LOGGED_IN;
+  sdk.logoutError = undefined;
+  sdk.logoutCalls = 0;
+  sdk.initFailure = undefined;
+  window.localStorage.clear();
+  keys = new MemoryKeys();
+  store = sealedTestStore(keys);
+});
+
 describe('the Core Kit store', () => {
-  let keys: MemoryKeys;
-  let store: SealedStore;
-
-  /** A session over a store this test can seed and read back. */
-  const session = () => createCoreKitSession(ENV, store);
-
-  beforeEach(() => {
-    sdk.options = undefined;
-    sdk.status = COREKIT_STATUS.LOGGED_IN;
-    sdk.statusAfterLogin = COREKIT_STATUS.LOGGED_IN;
-    sdk.logoutError = undefined;
-    sdk.logoutCalls = 0;
-    sdk.initFailure = undefined;
-    window.localStorage.clear();
-    keys = new MemoryKeys();
-    store = sealedTestStore(keys);
-  });
-
   it('hands the SDK the sealed store, so nothing it writes lands in the clear', async () => {
     session();
     await store.setItem(STORE_KEY, SESSION);
@@ -156,5 +160,34 @@ describe('the Core Kit store', () => {
 
     expect(sdk.logoutCalls).toBe(1);
     expect(window.localStorage.getItem(STORE_KEY)).toBeNull();
+  });
+});
+
+describe('a Core Kit login', () => {
+  it('names the Web3Auth project to the SDK itself', () => {
+    session();
+
+    expect(sdk.options?.web3AuthClientId).toBe('web3auth-client-id');
+  });
+
+  it('sends the Google sub-verifier the Google OAuth client ID', async () => {
+    await session().login('google');
+
+    expect(sdk.subVerifier).toMatchObject({
+      typeOfLogin: 'google',
+      verifier: 'verifier',
+      clientId: 'google-client-id',
+    });
+  });
+
+  it('sends the Torus-hosted email sub-verifier the Web3Auth project client ID', async () => {
+    await session().login('email', 'member@example.test');
+
+    expect(sdk.subVerifier).toMatchObject({
+      typeOfLogin: 'email_passwordless',
+      verifier: 'verifier',
+      clientId: 'web3auth-client-id',
+      jwtParams: { login_hint: 'member@example.test' },
+    });
   });
 });

--- a/apps/web/src/auth/coreKit.ts
+++ b/apps/web/src/auth/coreKit.ts
@@ -15,6 +15,13 @@ import { indexedDbWrappingKeys, SealedStore } from './sealedStore';
 export type CoreKitLoginMethod = 'google' | 'email';
 
 /**
+ * The client ID each sub-verifier is registered under: a Google Cloud OAuth
+ * client ID for the Google connection, the Web3Auth project's own for the
+ * Torus-hosted email one. Google rejects the wrong one before Web3Auth sees it.
+ */
+type SubVerifierClientIds = Record<CoreKitLoginMethod, string>;
+
+/**
  * The Core Kit surface the login flow drives. Narrow by construction: the hook
  * never sees a Web3Auth parameter shape, and a test substitutes a plain object.
  */
@@ -37,7 +44,7 @@ class Web3AuthSession implements CoreKitSession {
     private readonly coreKit: Web3AuthMPCCoreKit,
     private readonly store: SealedStore,
     private readonly verifier: string,
-    private readonly clientId: string
+    private readonly clientIds: SubVerifierClientIds
   ) {}
 
   async restore(): Promise<void> {
@@ -61,7 +68,7 @@ class Web3AuthSession implements CoreKitSession {
       subVerifierDetails: {
         typeOfLogin: method === 'google' ? 'google' : 'email_passwordless',
         verifier: this.verifier,
-        clientId: this.clientId,
+        clientId: this.clientIds[method],
         ...(email ? { jwtParams: { login_hint: email } } : {}),
       },
     });
@@ -157,10 +164,10 @@ export function createCoreKitSession(
   env: Partial<ImportMetaEnv>,
   store: SealedStore
 ): CoreKitSession {
-  const { clientId, verifier } = loginEnv(env);
+  const { web3AuthClientId, googleClientId, verifier } = loginEnv(env);
 
   const coreKit = new Web3AuthMPCCoreKit({
-    web3AuthClientId: clientId,
+    web3AuthClientId,
     web3AuthNetwork:
       environment(env) === 'production' ? WEB3AUTH_NETWORK.MAINNET : WEB3AUTH_NETWORK.DEVNET,
     storage: store,
@@ -168,5 +175,8 @@ export function createCoreKitSession(
     manualSync: true,
     tssLib,
   });
-  return new Web3AuthSession(coreKit, store, verifier, clientId);
+  return new Web3AuthSession(coreKit, store, verifier, {
+    google: googleClientId,
+    email: web3AuthClientId,
+  });
 }

--- a/apps/web/src/engine/config.test.ts
+++ b/apps/web/src/engine/config.test.ts
@@ -90,6 +90,7 @@ describe('missingDeployEnv', () => {
     VITE_ENVIRONMENT: 'staging',
     VITE_WEB3AUTH_CLIENT_ID: 'client',
     VITE_WEB3AUTH_VERIFIER: 'verifier',
+    VITE_GOOGLE_CLIENT_ID: 'google-client',
     VITE_API_URL: 'https://api.example.test',
   };
 
@@ -97,6 +98,7 @@ describe('missingDeployEnv', () => {
     expect(missingDeployEnv({ VITE_ENVIRONMENT: 'staging' })).toEqual([
       'VITE_WEB3AUTH_CLIENT_ID',
       'VITE_WEB3AUTH_VERIFIER',
+      'VITE_GOOGLE_CLIENT_ID',
       'VITE_API_URL',
     ]);
     // A variable substituted as blank is as unusable as an absent one, and a
@@ -108,6 +110,9 @@ describe('missingDeployEnv', () => {
       ]);
       expect(missingDeployEnv({ ...deployed, VITE_WEB3AUTH_CLIENT_ID: blank })).toEqual([
         'VITE_WEB3AUTH_CLIENT_ID',
+      ]);
+      expect(missingDeployEnv({ ...deployed, VITE_GOOGLE_CLIENT_ID: blank })).toEqual([
+        'VITE_GOOGLE_CLIENT_ID',
       ]);
     }
   });
@@ -151,27 +156,45 @@ describe('shipsE2eHook', () => {
 });
 
 describe('loginEnv', () => {
-  it('reads the Web3Auth identifiers a session is built from', () => {
-    expect(loginEnv({ VITE_WEB3AUTH_CLIENT_ID: 'client', VITE_WEB3AUTH_VERIFIER: 'v' })).toEqual({
-      clientId: 'client',
+  const configured = {
+    VITE_WEB3AUTH_CLIENT_ID: 'client',
+    VITE_WEB3AUTH_VERIFIER: 'v',
+    VITE_GOOGLE_CLIENT_ID: 'google-client',
+  };
+
+  it('keeps the two client IDs apart, which name unrelated registrations', () => {
+    expect(loginEnv(configured)).toEqual({
+      web3AuthClientId: 'client',
+      googleClientId: 'google-client',
       verifier: 'v',
     });
   });
 
-  it('trims the identifiers, which are sent to Web3Auth verbatim', () => {
+  it('trims the identifiers, which are sent to the providers verbatim', () => {
     expect(
-      loginEnv({ VITE_WEB3AUTH_CLIENT_ID: ' client\n', VITE_WEB3AUTH_VERIFIER: 'v ' })
-    ).toEqual({ clientId: 'client', verifier: 'v' });
+      loginEnv({
+        VITE_WEB3AUTH_CLIENT_ID: ' client\n',
+        VITE_WEB3AUTH_VERIFIER: 'v ',
+        VITE_GOOGLE_CLIENT_ID: '\tgoogle-client ',
+      })
+    ).toEqual({ web3AuthClientId: 'client', googleClientId: 'google-client', verifier: 'v' });
   });
 
   it('refuses a build missing one, naming it', () => {
-    expect(() => loginEnv({ VITE_WEB3AUTH_CLIENT_ID: 'client' })).toThrow(
+    expect(() => loginEnv({ ...configured, VITE_WEB3AUTH_VERIFIER: undefined })).toThrow(
       /^VITE_WEB3AUTH_VERIFIER must be configured$/
     );
+    // Otherwise the member meets Google's own `401 invalid_client`, which names
+    // nothing they or an operator can act on.
+    expect(() => loginEnv({ ...configured, VITE_GOOGLE_CLIENT_ID: undefined })).toThrow(
+      /^VITE_GOOGLE_CLIENT_ID must be configured$/
+    );
     // Whitespace is missing, not configured.
-    expect(() =>
-      loginEnv({ VITE_WEB3AUTH_CLIENT_ID: 'client', VITE_WEB3AUTH_VERIFIER: '   ' })
-    ).toThrow(/^VITE_WEB3AUTH_VERIFIER must be configured$/);
+    for (const blank of ['', '   ', '\n']) {
+      expect(() => loginEnv({ ...configured, VITE_GOOGLE_CLIENT_ID: blank })).toThrow(
+        /^VITE_GOOGLE_CLIENT_ID must be configured$/
+      );
+    }
   });
 });
 

--- a/apps/web/src/engine/config.test.ts
+++ b/apps/web/src/engine/config.test.ts
@@ -185,13 +185,9 @@ describe('loginEnv', () => {
       /^VITE_WEB3AUTH_VERIFIER must be configured$/
     );
     // Otherwise the member meets Google's own `401 invalid_client`, which names
-    // nothing they or an operator can act on.
-    expect(() => loginEnv({ ...configured, VITE_GOOGLE_CLIENT_ID: undefined })).toThrow(
-      /^VITE_GOOGLE_CLIENT_ID must be configured$/
-    );
-    // Whitespace is missing, not configured.
-    for (const blank of ['', '   ', '\n']) {
-      expect(() => loginEnv({ ...configured, VITE_GOOGLE_CLIENT_ID: blank })).toThrow(
+    // nothing they or an operator can act on. Whitespace is missing, not configured.
+    for (const unset of [undefined, '', '   ', '\n']) {
+      expect(() => loginEnv({ ...configured, VITE_GOOGLE_CLIENT_ID: unset })).toThrow(
         /^VITE_GOOGLE_CLIENT_ID must be configured$/
       );
     }

--- a/apps/web/src/engine/config.ts
+++ b/apps/web/src/engine/config.ts
@@ -28,7 +28,11 @@ const ENVIRONMENTS: readonly Environment[] = ['local', 'ci', 'staging', 'product
 const DEPLOYED: readonly Environment[] = ['staging', 'production'];
 
 /** The one list of what a Core Kit session needs, shared with the build gate. */
-const LOGIN_ENV = ['VITE_WEB3AUTH_CLIENT_ID', 'VITE_WEB3AUTH_VERIFIER'] as const;
+const LOGIN_ENV = [
+  'VITE_WEB3AUTH_CLIENT_ID',
+  'VITE_WEB3AUTH_VERIFIER',
+  'VITE_GOOGLE_CLIENT_ID',
+] as const;
 
 /**
  * What a deployed bundle cannot work without. `VITE_API_URL` is here because an
@@ -100,14 +104,19 @@ export function missingLoginEnv(env: Partial<ImportMetaEnv>): string[] {
   return LOGIN_ENV.filter((name) => configured(env[name]) === undefined);
 }
 
-/** The Web3Auth identifiers a Core Kit session is built from; refuses a build missing any. */
-export function loginEnv(env: Partial<ImportMetaEnv>): { clientId: string; verifier: string } {
-  const clientId = configured(env.VITE_WEB3AUTH_CLIENT_ID);
+/** The identifiers a Core Kit session is built from; refuses a build missing any. */
+export function loginEnv(env: Partial<ImportMetaEnv>): {
+  web3AuthClientId: string;
+  googleClientId: string;
+  verifier: string;
+} {
+  const web3AuthClientId = configured(env.VITE_WEB3AUTH_CLIENT_ID);
+  const googleClientId = configured(env.VITE_GOOGLE_CLIENT_ID);
   const verifier = configured(env.VITE_WEB3AUTH_VERIFIER);
-  if (!clientId || !verifier) {
+  if (!web3AuthClientId || !googleClientId || !verifier) {
     throw new Error(`${missingLoginEnv(env).join(' and ')} must be configured`);
   }
-  return { clientId, verifier };
+  return { web3AuthClientId, googleClientId, verifier };
 }
 
 /**

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -13,7 +13,10 @@ interface ImportMetaEnv {
   readonly VITE_ENVIRONMENT?: string;
   /** `true` builds the e2e introspection hook in; any other value leaves it out. */
   readonly VITE_E2E_HOOK?: string;
+  /** The Web3Auth project's client ID — never a provider's. */
   readonly VITE_WEB3AUTH_CLIENT_ID?: string;
   /** The Web3Auth verifier the Core Kit login flows authenticate against. */
   readonly VITE_WEB3AUTH_VERIFIER?: string;
+  /** The Google Cloud OAuth client ID the verifier's Google sub-verifier is registered against. */
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -79,15 +79,15 @@ template carries the local stack's values and is the one this catalogue extends.
 Vite + React SPA. All configuration is injected as `VITE_*` environment variables at build time.
 Copy `apps/web/.env.example` to `apps/web/.env` before first run.
 
-| Variable                  | Required | Default                       | Description                                                                                                                                              |
-| :------------------------ | :------- | :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `VITE_API_URL`            | No       | `http://localhost:3000`       | Base URL of the CipherBox API.                                                                                                                           |
-| `VITE_WEB3AUTH_CLIENT_ID` | **Yes**  | —                             | Web3Auth project client ID for key derivation and authentication. <!-- VERIFY: obtain from Web3Auth dashboard -->                                        |
-| `VITE_WEB3AUTH_VERIFIER`  | **Yes**  | —                             | Web3Auth Core Kit verifier name. Login needs this and the client ID; missing either refuses the session. <!-- VERIFY: obtain from Web3Auth dashboard --> |
-| `VITE_GOOGLE_CLIENT_ID`   | No       | —                             | Google OAuth client ID for the Google Sign-In provider via Web3Auth. <!-- VERIFY: obtain from Google Cloud Console -->                                   |
-| `VITE_ENVIRONMENT`        | No       | `local`                       | Deployment environment label (`local`, `staging`, `production`). Used to show the staging banner in the UI.                                              |
-| `VITE_APP_VERSION`        | No       | (derived from crypto version) | Application version string injected at build time. Falls back to the internal crypto library version when absent.                                        |
-| `VITE_FARO_URL`           | No       | —                             | Grafana Faro collector endpoint. When absent, frontend observability is disabled. <!-- VERIFY: set to your Faro ingest URL -->                           |
+| Variable                  | Required | Default                       | Description                                                                                                                                                                    |
+| :------------------------ | :------- | :---------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_API_URL`            | No       | `http://localhost:3000`       | Base URL of the CipherBox API.                                                                                                                                                 |
+| `VITE_WEB3AUTH_CLIENT_ID` | **Yes**  | —                             | Web3Auth project client ID for key derivation and authentication. <!-- VERIFY: obtain from Web3Auth dashboard -->                                                              |
+| `VITE_WEB3AUTH_VERIFIER`  | **Yes**  | —                             | Web3Auth Core Kit verifier name. Login needs this and both client IDs; missing any refuses the session. <!-- VERIFY: obtain from Web3Auth dashboard -->                        |
+| `VITE_GOOGLE_CLIENT_ID`   | **Yes**  | —                             | Google OAuth client ID the verifier's Google sub-verifier is registered against — not interchangeable with the Web3Auth one. <!-- VERIFY: obtain from Google Cloud Console --> |
+| `VITE_ENVIRONMENT`        | No       | `local`                       | Deployment environment label (`local`, `staging`, `production`). Used to show the staging banner in the UI.                                                                    |
+| `VITE_APP_VERSION`        | No       | (derived from crypto version) | Application version string injected at build time. Falls back to the internal crypto library version when absent.                                                              |
+| `VITE_FARO_URL`           | No       | —                             | Grafana Faro collector endpoint. When absent, frontend observability is disabled. <!-- VERIFY: set to your Faro ingest URL -->                                                 |
 
 ---
 


### PR DESCRIPTION
Closes #1256. Part of #1253.

## What was wrong

`subVerifierDetails.clientId` is the **provider's** client ID. The app was spending one value on two unrelated things: `VITE_WEB3AUTH_CLIENT_ID` correctly named the Web3Auth project to the `Web3AuthMPCCoreKit` constructor, and then that same string was handed to the Google sub-verifier. Google has never issued it, so every Google sign-in ended at `401 invalid_client` before Web3Auth was involved.

The right value was never absent from the deployment — `VITE_GOOGLE_CLIENT_ID` is passed at every staging build site in `deploy-staging.yml` and `desktop-staging-release.yml`. It survived the rewrite; its reader did not.

## What changed

- `loginEnv` now returns `{ web3AuthClientId, googleClientId, verifier }`. The old shape returned `clientId`, a name that invited exactly this substitution — neither field can now be picked by accident.
- `VITE_GOOGLE_CLIENT_ID` joins `LOGIN_ENV`, so it is declared in `vite-env.d.ts`, named by `missingLoginEnv`, and — through `DEPLOY_ENV` — fails the `deployEnvGate` build plugin on a staging or production build that omits it. A deployed build can no longer ship a Google button that cannot work.
- The session carries a per-method map of client IDs instead of one string, so each sub-verifier is routed to its own registration at the call site.
- `apps/web/.env.example` now lists all three and states plainly that the two client IDs are separate registrations and not interchangeable — the template previously implied one client ID was the whole story, which is how this recurs.

## `email_passwordless`

It takes the **Web3Auth project** client ID, not Google's. That sub-verifier is Torus-hosted: there is no third-party OAuth client behind it, and the connection is registered under the Web3Auth project itself. Sending Google's ID there would break email sign-in in the same way this PR fixes Google. Worth a second pair of eyes against the verifier's actual dashboard configuration before merge.

## Tests

- `coreKit.test.ts` captures `subVerifierDetails` off the substituted SDK and asserts the Google connection receives the Google OAuth client ID, the email connection receives the Web3Auth one, and the constructor receives the Web3Auth one.
- `config.test.ts` asserts the two IDs stay apart through `loginEnv`, and that a build missing `VITE_GOOGLE_CLIENT_ID` throws naming it — absent, blank, and whitespace-only alike — rather than surfacing a provider error nobody can act on. `missingDeployEnv` covers the red-build half.
- Mutation-checked: restoring the old behaviour — routing Google to the Web3Auth ID — fails the Google routing test and nothing else.

Ran: `pnpm --filter @cipherbox/web test` (32 files, 295 tests, includes `tsc -b`), `pnpm lint`, `pnpm lint:md`, `pnpm lint:tracker-refs` — all green.

## Needs human verification

No dev server or configured verifier exists in this environment, so the runtime path is unverified: **a real Google sign-in against a verifier whose Google sub-verifier is registered with the Google Cloud OAuth client ID in `GOOGLE_CLIENT_ID`**, plus one email sign-in to confirm that connection still authenticates on the Web3Auth project ID.

## Scope

Only the client-ID plumbing. The Core Kit login architecture is untouched — `loginWithOAuth` is replaced wholesale by a separate PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry Google and Web3Auth client IDs separately for OAuth sub-verifiers
> - Splits the single `clientId` into two: `VITE_GOOGLE_CLIENT_ID` (used by Google OAuth sub-verifier) and `VITE_WEB3AUTH_CLIENT_ID` (used by the email passwordless sub-verifier and SDK init). Previously both sub-verifiers shared one client ID.
> - Updates [`config.ts`](https://github.com/FSM1/cipher-box/pull/1272/files#diff-4e12e157a8de69cb09afa15f6591facf5c9392fe6a014bd8f63a3804d4ecfaad) to require and return both IDs from `loginEnv()`, throwing if either is missing or blank.
> - Updates [`coreKit.ts`](https://github.com/FSM1/cipher-box/pull/1272/files#diff-ef6c9dcd7f99504fee0b68ee69636759b18751c9bbb3433d427c06efce875ec0) to accept a `SubVerifierClientIds` map and select the correct ID per login method.
> - Behavioral Change: `VITE_GOOGLE_CLIENT_ID` is now a required environment variable; deployments missing it will throw at session creation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f87e8d. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->